### PR TITLE
change logic to run filtering ahead of time before llm determination …

### DIFF
--- a/hubspot_ddhq_match/google_sheets_matcher/README.md
+++ b/hubspot_ddhq_match/google_sheets_matcher/README.md
@@ -11,7 +11,7 @@ This pipeline matches **candidate office names** from HubSpot companies to **rac
 - **Date + State + Election Type Partitioned FAISS** - Pre-built indices for efficient exact matching
 - **Semantic Similarity** - Gemini embeddings for race/office name matching
 - **LLM Validation** - Gemini Flash for intelligent match confirmation with confidence scoring
-- **High Concurrency** - ThreadPoolExecutor + asyncio for 1500 concurrent workers
+- **High Concurrency** - ThreadPoolExecutor + asyncio for 200 concurrent workers (optimized for API rate limits)
 - **Cost Efficient** - ~$0.0007 per 50 records
 
 ## Architecture
@@ -165,7 +165,7 @@ The pipeline script automatically runs all 5 steps in sequence:
 1. Progress bars for data extraction and cleaning
 2. Embedding generation progress with cost tracking
 3. FAISS partition building (75 partitions by date+state+election_type)
-4. High-speed matching with concurrent LLM validation (1500 workers)
+4. High-speed matching with concurrent LLM validation (200 workers)
 5. Final statistics: match rate, confidence distribution, cost breakdown
 
 **Output files created:**
@@ -221,10 +221,10 @@ Filters HubSpot to only dates present in Google Sheets:
 
 ```bash
 # Test mode (50 HubSpot records)
-ENVIRONMENT=test BATCH_SIZE=150 MAX_WORKERS=400 uv run generate_embeddings.py
+ENVIRONMENT=test BATCH_SIZE=150 MAX_WORKERS=200 uv run generate_embeddings.py
 
 # Production mode (all records)
-ENVIRONMENT=production BATCH_SIZE=150 MAX_WORKERS=400 uv run generate_embeddings.py
+ENVIRONMENT=production BATCH_SIZE=150 MAX_WORKERS=200 uv run generate_embeddings.py
 ```
 
 Generates semantic embeddings for race/office matching:
@@ -240,17 +240,17 @@ Generates semantic embeddings for race/office matching:
 
 ```bash
 # Test mode (50 test records)
-ENVIRONMENT=test BATCH_SIZE=1000 MAX_WORKERS=1500 uv run parallel_production_matcher.py
+ENVIRONMENT=test BATCH_SIZE=1000 MAX_WORKERS=200 uv run parallel_production_matcher.py
 
 # Production mode (all records)
-ENVIRONMENT=production BATCH_SIZE=1000 MAX_WORKERS=1500 uv run parallel_production_matcher.py
+ENVIRONMENT=production BATCH_SIZE=1000 MAX_WORKERS=200 uv run parallel_production_matcher.py
 ```
 
 Executes high-performance matching with:
 - **75 FAISS partitions** (date + state + election type)
 - **Semantic search** (top 5 candidates per HubSpot record)
 - **LLM validation** (70% confidence threshold)
-- **1500 concurrent workers** for maximum throughput
+- **200 concurrent workers** for optimal throughput (avoids rate limits)
 
 **Output**: `output/hubspot_googlesheets_race_matches_latest.parquet`, `hubspot_googlesheets_race_matches_{timestamp}.tsv`
 
@@ -303,7 +303,7 @@ These will NOT match (by design):
 ## Performance
 
 - **FAISS partition building**: ~0.1 seconds for 75 partitions
-- **Matching throughput**: ~17 records/second with 1500 workers
+- **Matching throughput**: ~10-15 records/second with 200 workers (rate-limit optimized)
 - **Total pipeline time**: ~5 minutes for 50 records (including LLM calls)
 
 ## Output Schema
@@ -387,12 +387,14 @@ If data extraction fails:
 2. Check `DATABRICKS_SERVER_HOSTNAME` format (e.g., `dbc-xxx.cloud.databricks.com`)
 3. Verify `DATABRICKS_HTTP_PATH` points to an active SQL warehouse
 
-### Out of Memory Errors
+### Out of Memory Errors or Rate Limit Errors
 
-If the pipeline crashes during production matching:
-1. Reduce `MAX_WORKERS` (default 1500): `MAX_WORKERS=800 uv run run_full_pipeline.py`
+If the pipeline crashes or hits rate limits during production matching:
+1. Reduce `MAX_WORKERS` (recommended 200): `MAX_WORKERS=100 uv run run_full_pipeline.py`
 2. Reduce `BATCH_SIZE` (default 1000): `BATCH_SIZE=500 uv run run_full_pipeline.py`
 3. Run individual steps separately instead of full pipeline
+
+**Note**: Gemini API has rate limits of 10,000 requests/min and 8M tokens/min. MAX_WORKERS=200 stays well under these limits.
 
 ### Low Match Rate
 

--- a/hubspot_ddhq_match/google_sheets_matcher/data_cleaning.py
+++ b/hubspot_ddhq_match/google_sheets_matcher/data_cleaning.py
@@ -104,6 +104,7 @@ class DataCleaner:
 
         df['office_name'] = df['properties_candidate_office'].fillna('')
         df['official_office_name'] = df['properties_official_office_name'].fillna('')
+        df['office_level'] = df['properties_office_level'].fillna('')
         df['state'] = df['properties_state'].apply(self.standardize_state_code)
         df['city'] = df['properties_city'].fillna('')
         df['district'] = df['properties_candidate_district'].fillna('')
@@ -130,6 +131,7 @@ class DataCleaner:
                 'candidate_name': row['properties_candidate_name'],
                 'office_name': row['office_name'],
                 'official_office_name': row['official_office_name'],
+                'office_level': row['office_level'],
                 'state': row['state'],
                 'city': row['city'],
                 'district': row['district'],

--- a/hubspot_ddhq_match/google_sheets_matcher/data_extraction.py
+++ b/hubspot_ddhq_match/google_sheets_matcher/data_extraction.py
@@ -40,6 +40,7 @@ class DataExtractor:
           properties_candidate_name,
           properties_candidate_office,
           properties_official_office_name,
+          properties_office_level,
           properties_state,
           properties_city,
           properties_candidate_district,
@@ -77,14 +78,27 @@ class DataExtractor:
             self.logger.debug(f"Header row: {raw_data[0]}")
 
             df = pd.DataFrame(raw_data[1:])
-            df.columns = [
-                'race_id_empty',
-                'date',
-                'state_election_type',
-                'race_name_orig',
-                'election_type_clean',
-                'race_name_with_state'
-            ]
+
+            if len(df.columns) == 4:
+                df.columns = [
+                    'race_id',
+                    'date',
+                    'state_election_type',
+                    'race_name_orig'
+                ]
+                df['election_type_clean'] = df['state_election_type']
+                df['race_name_with_state'] = df['race_name_orig']
+            elif len(df.columns) == 6:
+                df.columns = [
+                    'race_id_empty',
+                    'date',
+                    'state_election_type',
+                    'race_name_orig',
+                    'election_type_clean',
+                    'race_name_with_state'
+                ]
+            else:
+                raise ValueError(f"Unexpected number of columns: {len(df.columns)}. Expected 4 or 6.")
 
             self.logger.info(f"✅ Google Sheets races extracted: {len(df):,} records")
             self.logger.debug(f"Columns: {list(df.columns)}")

--- a/hubspot_ddhq_match/google_sheets_matcher/parallel_production_matcher.py
+++ b/hubspot_ddhq_match/google_sheets_matcher/parallel_production_matcher.py
@@ -179,7 +179,7 @@ class ProductionMatcher:
                 candidate_races_considered=""
             )
 
-        prompt = f"""Analyze this HubSpot candidate and determine if it's a federal/state race or if it matches a local race.
+        prompt = f"""Match this HubSpot candidate to a local/municipal race from the Google Sheets list.
 
 HubSpot Candidate:
 - Office: {hubspot_record['office_name']}
@@ -188,30 +188,6 @@ HubSpot Candidate:
 - District: {hubspot_record.get('district', 'N/A')}
 - Election Date: {hubspot_record['election_date']}
 - Election Type: {hubspot_record['election_type']}
-
-STEP 1: CHECK IF FEDERAL OR STATE LEVEL RACE
-First, determine if this is a federal or state level office:
-
-FEDERAL OFFICES (return "FEDERAL_RACE"):
-- President/President of the United States
-- U.S. Senate/US Senate/United States Senate
-- U.S. House of Representatives/US House/Congressional District
-
-STATE OFFICES (return "STATE_RACE"):
-- Governor/Lieutenant Governor (unless it's a school board like "Governor Mifflin School Board")
-- State Senate/State House/State Assembly/State Legislature
-- State Representative/State Senator
-- Attorney General/Secretary of State/State Treasurer/State Auditor/State Comptroller
-- State Supreme Court/State Appeals Court
-
-If this is a FEDERAL or STATE office, return:
-{{
-  "match_index": null,
-  "confidence": 95,
-  "reasoning": "Federal race: [office name]" OR "State race: [office name]"
-}}
-
-STEP 2: IF LOCAL/MUNICIPAL RACE, MATCH AGAINST GOOGLE SHEETS
 
 Google Sheets Races (top {len(candidate_races)} semantic matches):
 """
@@ -224,7 +200,7 @@ Google Sheets Races (top {len(candidate_races)} semantic matches):
         races_considered = " | ".join(races_list)
 
         prompt += """
-If this is a LOCAL/MUNICIPAL race, does it match a race in the list above?
+Does the HubSpot candidate match any of the races above?
 
 CRITICAL MATCHING RULES:
 1. Municipality/jurisdiction names MUST be identical (city, town, borough, county, school district name)
@@ -264,6 +240,8 @@ OR if match found (exact or group-level):
   "confidence": <70-100 for exact, 60-75 for group-level>,
   "reasoning": "<brief explanation, specify if group-level match>"
 }
+
+IMPORTANT: In the reasoning field, use single quotes (') instead of double quotes (") when referring to office names or races to avoid JSON parsing errors.
 """
 
         try:
@@ -279,33 +257,6 @@ OR if match found (exact or group-level):
             match_index = result.match_index
             confidence = result.confidence
             reasoning = result.reasoning
-
-            reasoning_lower = reasoning.lower()
-            is_federal = reasoning_lower.startswith('federal race:')
-            is_state = reasoning_lower.startswith('state race:')
-
-            if is_federal or is_state:
-                race_type = "FEDERAL_RACE" if is_federal else "STATE_RACE"
-                return MatchResult(
-                    hubspot_company_id=hubspot_record['company_id'],
-                    candidate_name=hubspot_record.get('candidate_name', ''),
-                    candidate_office=hubspot_record['office_name'],
-                    state=hubspot_record['state'],
-                    city=hubspot_record.get('city', ''),
-                    district=hubspot_record.get('district', ''),
-                    election_date=str(hubspot_record['election_date']),
-                    election_type=hubspot_record['election_type'],
-                    matched_race_id=None,
-                    matched_race_name=race_type,
-                    match_confidence=confidence,
-                    match_reasoning=reasoning,
-                    partition_key=self.build_partition_key(
-                        hubspot_record['election_date'],
-                        hubspot_record['state'],
-                        hubspot_record['election_type']
-                    ),
-                    candidate_races_considered=races_considered
-                )
 
             if match_index is not None and confidence >= 60:
                 matched_race = candidate_races.iloc[match_index - 1]
@@ -377,6 +328,53 @@ OR if match found (exact or group-level):
 
     async def match_single_record(self, hubspot_record: pd.Series) -> MatchResult:
         """Match a single HubSpot record"""
+
+        office_level = str(hubspot_record.get('office_level', '')).strip().upper()
+
+        if office_level == 'FEDERAL':
+            return MatchResult(
+                hubspot_company_id=hubspot_record['company_id'],
+                candidate_name=hubspot_record.get('candidate_name', ''),
+                candidate_office=hubspot_record['office_name'],
+                state=hubspot_record['state'],
+                city=hubspot_record.get('city', ''),
+                district=hubspot_record.get('district', ''),
+                election_date=str(hubspot_record['election_date']),
+                election_type=hubspot_record['election_type'],
+                matched_race_id=None,
+                matched_race_name='FEDERAL_RACE',
+                match_confidence=100.0,
+                match_reasoning='Federal race (filtered by office_level field)',
+                partition_key=self.build_partition_key(
+                    hubspot_record['election_date'],
+                    hubspot_record['state'],
+                    hubspot_record['election_type']
+                ),
+                candidate_races_considered=''
+            )
+
+        if office_level == 'STATE':
+            return MatchResult(
+                hubspot_company_id=hubspot_record['company_id'],
+                candidate_name=hubspot_record.get('candidate_name', ''),
+                candidate_office=hubspot_record['office_name'],
+                state=hubspot_record['state'],
+                city=hubspot_record.get('city', ''),
+                district=hubspot_record.get('district', ''),
+                election_date=str(hubspot_record['election_date']),
+                election_type=hubspot_record['election_type'],
+                matched_race_id=None,
+                matched_race_name='STATE_RACE',
+                match_confidence=100.0,
+                match_reasoning='State race (filtered by office_level field)',
+                partition_key=self.build_partition_key(
+                    hubspot_record['election_date'],
+                    hubspot_record['state'],
+                    hubspot_record['election_type']
+                ),
+                candidate_races_considered=''
+            )
+
         candidate_races = self.search_partition(hubspot_record, top_k=5)
         match_result = await self.validate_match_with_llm(hubspot_record, candidate_races)
         return match_result


### PR DESCRIPTION
…for office type, so we can determine with certainty federal vs state vs local races, turn down concurrency to not run into 8 million toks/min limit

small pr to make things work better for the google sheets ddhq matcher

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prefilters federal/state races using `office_level`, simplifies LLM to local matching, supports 4/6-column Google Sheets input, and drops MAX_WORKERS to 200 with updated docs and commands.
> 
> - **Matching Logic**:
>   - Prefilters records by `office_level` to label `FEDERAL_RACE`/`STATE_RACE` without LLM; LLM now only validates local/municipal matches.
>   - Simplifies LLM prompt/output and removes prior federal/state detection; adds instruction to use single quotes in reasoning to avoid JSON parsing issues.
> - **Data Extraction & Cleaning**:
>   - Adds `properties_office_level` selection and propagates `office_level` through cleaning/expanded records.
>   - Supports Google Sheets input with either 4 or 6 columns; normalizes to `race_id/date/state_election_type/race_name_orig` plus derived `election_type_clean` and `race_name_with_state`.
> - **Concurrency & Performance**:
>   - Reduces `MAX_WORKERS` from 1500 to 200 across embeddings and matching to stay within API rate limits; updates throughput notes (10–15 r/s).
> - **Documentation**:
>   - Updates README commands, troubleshooting (rate limits), and performance sections to reflect new concurrency and guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b406e84ce8c947f39fc7eaabd079cf8f6d650198. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->