### PR TITLE
Enhance Voter Contact Plan Generator - ENG-5526

### DIFF
--- a/ai_generated_campaign_plan/sections/six_voter_contact_plan.py
+++ b/ai_generated_campaign_plan/sections/six_voter_contact_plan.py
@@ -22,10 +22,12 @@ class VoterContactPlanGenerator:
             phase_1_7w_date = campaign_info.primary_date - timedelta(weeks=7)
             phase_1_start_date_3d_buffer = date.today() + timedelta(days=3)
             phase_1_start_date = phase_1_start_date_3d_buffer if phase_1_7w_date < phase_1_start_date_3d_buffer else phase_1_7w_date
+            phase_1_final_task_1d_buffer = campaign_info.primary_date - timedelta(days=1)
             # Calculate Phase 2 start date:
             phase_2_7w_date = campaign_info.election_date - timedelta(weeks=7)
             phase_2_start_date_1d_buffer = campaign_info.primary_date + timedelta(days=1)
             phase_2_start_date = phase_2_start_date_1d_buffer if phase_2_7w_date < phase_2_start_date_1d_buffer else phase_2_7w_date
+            phase_2_final_task_1d_buffer = campaign_info.election_date - timedelta(days=1)
 
             prompt = f"""
 # TIMELINE CONTEXT:
@@ -47,20 +49,14 @@ General Election Date: {campaign_info.election_date}
 - NO Voter Outreach Task date can be before {phase_1_start_date}.
 ## PHASE 1 GUIDELINES:
 - ALL 7 Phase 1 Voter Outreach Tasks MUST be between {phase_1_start_date} and before {campaign_info.primary_date}.
-- ONLY include {primary_contact_strategy.p2p_texts} P2P Texts and {primary_contact_strategy.robocalls} Robocalls in Phase 1 of the Campaign Plan.
-- The number of P2P Text Voter Outreach Tasks before {campaign_info.primary_date} should NOT exceed {primary_contact_strategy.p2p_texts}.
-- The number of Robocall Voter Outreach Tasks before {campaign_info.primary_date} should NOT exceed {primary_contact_strategy.robocalls}.
 - There must be AT LEAST 1 Voter Outreach Task every 7 days (MAXIMUM 7 days between Voter Outreach Tasks).
-- The FINAL Voter Outreach Task in Phase 1 MUST be between {campaign_info.primary_date - timedelta(days=1)} and before {campaign_info.primary_date}.
+- The FINAL Voter Outreach Task in Phase 1 MUST be between {phase_1_final_task_1d_buffer} and before {campaign_info.primary_date}.
 - List Voter Outreach Tasks chronologically from {phase_1_start_date} through {campaign_info.primary_date}.
 
 ## PHASE 2 GUIDELINES:
 - ALL 7 Phase 2 Voter Outreach Tasks MUST be between {phase_2_start_date} and before {campaign_info.election_date}.
-- ONLY include {general_contact_strategy.p2p_texts} P2P Texts and {general_contact_strategy.robocalls} Robocalls in Phase 2 of the Campaign Plan.
-- The number of P2P Text Voter Outreach Tasks before {campaign_info.election_date} should NOT exceed {general_contact_strategy.p2p_texts}.
-- The number of Robocall Voter Outreach Tasks before {campaign_info.election_date} should NOT exceed {general_contact_strategy.robocalls}.
 - There must be AT LEAST 1 Voter Outreach Task every 7 days (MAXIMUM 7 days between Voter Outreach Tasks).
-- The FINAL Voter Outreach Task in Phase 2 MUST be between {campaign_info.election_date - timedelta(days=1)} and before {campaign_info.election_date}.
+- The FINAL Voter Outreach Task in Phase 2 MUST be between {phase_2_final_task_1d_buffer} and before {campaign_info.election_date}.
 - List Voter Outreach Tasks chronologically from {phase_2_start_date} through {campaign_info.election_date}.
 
 # VOTER OUTREACH TASKS: (Format: outreachType: outreachDescription)
@@ -99,6 +95,7 @@ General Election Date: {campaign_info.election_date}
             start_7w_date = campaign_info.election_date - timedelta(weeks=7)
             start_date_3d_buffer = date.today() + timedelta(days=3)
             start_date = start_date_3d_buffer if start_7w_date < start_date_3d_buffer else start_7w_date
+            final_task_1d_buffer = campaign_info.election_date - timedelta(days=1)
             
             prompt = f"""
 # TIMELINE CONTEXT:
@@ -115,13 +112,10 @@ General Election Date: {campaign_info.election_date}
 - Generate a Campaign Plan containing Voter Outreach Tasks.
 
 # GOAL COMPLETION GUIDELINES:
-- ONLY include {general_contact_strategy.p2p_texts} P2P Texts and {general_contact_strategy.robocalls} Robocalls in the Campaign Plan.
 - NO Voter Outreach Task date can be before {start_date}.
 - ALL 7 Voter Outreach Tasks MUST be between {start_date} and before {campaign_info.election_date}.
-- The number of P2P Text Voter Outreach Tasks before {campaign_info.election_date} should NOT exceed {general_contact_strategy.p2p_texts}.
-- The number of Robocall Voter Outreach Tasks before {campaign_info.election_date} should NOT exceed {general_contact_strategy.robocalls}.
 - There must be AT LEAST 1 Voter Outreach Task every 7 days (MAXIMUM 7 days between Voter Outreach Tasks).
-- The FINAL Voter Outreach Task MUST be between {campaign_info.election_date - timedelta(days=1)} and before {campaign_info.election_date}.
+- The FINAL Voter Outreach Task MUST be between {final_task_1d_buffer} and before {campaign_info.election_date}.
 - List Voter Outreach Tasks chronologically from {campaign_info.election_date - start_date} through {campaign_info.election_date}.
 
 # VOTER OUTREACH TASKS: (Format: outreachType: outreachDescription)
@@ -180,8 +174,6 @@ if __name__ == "__main__":
     campaign_info_with_primary = CampaignInfo(
         candidate_name="John Doe",
         office_and_jurisdiction="Mayor, Springfield, MA",
-        # election_date=date(2025, 11, 5),
-        # primary_date=date(2025, 8, 1),
         election_date=election_date_weeks,
         primary_date=primary_date_weeks,
         race_type="Nonpartisan",
@@ -212,8 +204,6 @@ if __name__ == "__main__":
     campaign_info_with_primary = CampaignInfo(
         candidate_name="John Doe",
         office_and_jurisdiction="Mayor, Springfield, MA",
-        # election_date=date(2025, 11, 5),
-        # primary_date=date(2025, 8, 1),
         election_date=election_date_weeks,
         primary_date=primary_date_weeks,
         race_type="Nonpartisan",
@@ -244,8 +234,6 @@ if __name__ == "__main__":
     campaign_info_with_primary = CampaignInfo(
         candidate_name="John Doe",
         office_and_jurisdiction="Mayor, Springfield, MA",
-        # election_date=date(2025, 11, 5),
-        # primary_date=date(2025, 8, 1),
         election_date=election_date_weeks,
         primary_date=primary_date_weeks,
         race_type="Nonpartisan",
@@ -276,8 +264,6 @@ if __name__ == "__main__":
     campaign_info_with_primary = CampaignInfo(
         candidate_name="John Doe",
         office_and_jurisdiction="Mayor, Springfield, MA",
-        # election_date=date(2025, 11, 5),
-        # primary_date=date(2025, 8, 1),
         election_date=election_date_weeks,
         primary_date=primary_date_weeks,
         race_type="Nonpartisan",
@@ -308,8 +294,6 @@ if __name__ == "__main__":
     campaign_info_with_primary = CampaignInfo(
         candidate_name="John Doe",
         office_and_jurisdiction="Mayor, Springfield, MA",
-        # election_date=date(2025, 11, 5),
-        # primary_date=date(2025, 8, 1),
         election_date=election_date_weeks,
         primary_date=primary_date_weeks,
         race_type="Nonpartisan",
@@ -340,8 +324,6 @@ if __name__ == "__main__":
     campaign_info_with_primary = CampaignInfo(
         candidate_name="John Doe",
         office_and_jurisdiction="Mayor, Springfield, MA",
-        # election_date=date(2025, 11, 5),
-        # primary_date=date(2025, 8, 1),
         election_date=election_date_weeks,
         primary_date=primary_date_weeks,
         race_type="Nonpartisan",
@@ -430,7 +412,6 @@ if __name__ == "__main__":
     campaign_info_no_primary = CampaignInfo(
         candidate_name="Jane Smith",
         office_and_jurisdiction="City Council, District 3, Boston, MA",
-        # election_date=date(2025, 7, 22),
         election_date=election_date_8_weeks,
         primary_date=None,
         race_type="Nonpartisan",
@@ -531,3 +512,5 @@ if __name__ == "__main__":
     print(f"Signup Date: {date.today()}")
     print(f"Election Date: {election_date_1_weeks}")
     print(result_1_weeks)
+
+    print("\n" + "="*60 + "\n")

--- a/ai_generated_campaign_plan/sections/six_voter_contact_plan.py
+++ b/ai_generated_campaign_plan/sections/six_voter_contact_plan.py
@@ -4,8 +4,6 @@ from ai_generated_campaign_plan.schema.models import CleanedCampaignInfo, Contac
 from shared.logger import get_logger
 from shared.llm_gemini import GeminiClient
 
-
-
 class VoterContactPlanGenerator:
     
     def __init__(self):
@@ -19,81 +17,128 @@ class VoterContactPlanGenerator:
         
         has_primary = campaign_info.has_primary
         
-        if has_primary:            
-            prompt = f"""
-today's date: {date.today()}
-primary date: {campaign_info.primary_date}
-general election date: {campaign_info.election_date}
+        if has_primary:    
+            # Calculate Phase 1 start date:
+            phase_1_7w_date = campaign_info.primary_date - timedelta(weeks=7)
+            phase_1_start_date_3d_buffer = date.today() + timedelta(days=3)
+            phase_1_start_date = phase_1_start_date_3d_buffer if phase_1_7w_date < phase_1_start_date_3d_buffer else phase_1_7w_date
+            # Calculate Phase 2 start date:
+            phase_2_7w_date = campaign_info.election_date - timedelta(weeks=7)
+            phase_2_start_date_1d_buffer = campaign_info.primary_date + timedelta(days=1)
+            phase_2_start_date = phase_2_start_date_1d_buffer if phase_2_7w_date < phase_2_start_date_1d_buffer else phase_2_7w_date
 
-CAMPAIGN CONTEXT:
+            prompt = f"""
+# TIMELINE CONTEXT:
+Signup Date: {date.today()}
+Voter Outreach Phase 1 Start Date = {phase_1_start_date}
+Primary Date: {campaign_info.primary_date}
+Voter Outreach Phase 2 Start Date = {phase_2_start_date}
+General Election Date: {campaign_info.election_date}
+
+# CAMPAIGN CONTEXT:
 - Candidate: {campaign_info.candidate_name}
 - Office: {campaign_info.office_and_jurisdiction}
 - Has Primary: Yes
 
-RULES:
-- the number of texts before the primary should not exceed {primary_contact_strategy.p2p_texts}
-- the number of robocalls before the primary should not exceed {primary_contact_strategy.robocalls}
-- the number of texts after the primary should not exceed {general_contact_strategy.p2p_texts}
-- the number of robocalls after the primary should not exceed {general_contact_strategy.robocalls}
-- one set of text messaging and robocalls should be schedules close to the election to remind of the polling location and to vote
-- there are two parts, one before the primary and one after the primary, 
-- These are some examples of the messages that can be used before the primary:
-    - First Text before primary: Candidate intro and vote-by-mail awareness if applicable
-    - First Robocall before primary: Ballot arrival and early voting prompt
-    - Second Text before primary: Experience and contrast message
-    - Second Robocall before primary: Vote return and community message
-    - Third Text before primary: Persuasion and vote planning
-    - Last Robocall before primary: Final GOTV push and polling info
-    - Last Text before primary: Final GOTV reminder
- - These are some examples of the messages that can be used after the primary:
-    - First Text after primary: Reintroduction and contrast message
-    - First Robocall after primary: Early voting alert
-    - Second Text after primary: Key issues and voter education
-    - Second Robocall after primary: Final persuasion
-    - Third Text after primary: Vote-by-mail deadline and GOTV push
-    - Last Text after primary: Final reminder and polling location link
-    - Last Robocall after primary: Election Day GOTV
- - If there are two texts or robocalls, take example from first and last text or robocall
+# GOAL:
+- Generate a Campaign Plan containing Voter Outreach Tasks for both Phase 1 (Primary) and Phase 2 (General Election).
 
-Generate a voter contact plan with both primary and general election phases in this format:
-[List contacts chronologically from today through primary, then general election]
+# GOAL COMPLETION GUIDELINES:
+- NO Voter Outreach Task date can be before {phase_1_start_date}.
+## PHASE 1 GUIDELINES:
+- ALL 7 Phase 1 Voter Outreach Tasks MUST be between {phase_1_start_date} and before {campaign_info.primary_date}.
+- ONLY include {primary_contact_strategy.p2p_texts} P2P Texts and {primary_contact_strategy.robocalls} Robocalls in Phase 1 of the Campaign Plan.
+- The number of P2P Text Voter Outreach Tasks before {campaign_info.primary_date} should NOT exceed {primary_contact_strategy.p2p_texts}.
+- The number of Robocall Voter Outreach Tasks before {campaign_info.primary_date} should NOT exceed {primary_contact_strategy.robocalls}.
+- There must be AT LEAST 1 Voter Outreach Task every 7 days (MAXIMUM 7 days between Voter Outreach Tasks).
+- The FINAL Voter Outreach Task in Phase 1 MUST be between {campaign_info.primary_date - timedelta(days=1)} and before {campaign_info.primary_date}.
+- List Voter Outreach Tasks chronologically from {phase_1_start_date} through {campaign_info.primary_date}.
 
-Example format:
-- [FULL MONTH DD] – P2P Text #1: [Message theme]
-- [FULL MONTH DD] – Robocall #1: [Message theme]
-- [Primary Date] – Primary Election Day
-- [FULL MONTH DD] – P2P Text #[N]: [Message theme for general]
-- [Election Date] – General Election Day
+## PHASE 2 GUIDELINES:
+- ALL 7 Phase 2 Voter Outreach Tasks MUST be between {phase_2_start_date} and before {campaign_info.election_date}.
+- ONLY include {general_contact_strategy.p2p_texts} P2P Texts and {general_contact_strategy.robocalls} Robocalls in Phase 2 of the Campaign Plan.
+- The number of P2P Text Voter Outreach Tasks before {campaign_info.election_date} should NOT exceed {general_contact_strategy.p2p_texts}.
+- The number of Robocall Voter Outreach Tasks before {campaign_info.election_date} should NOT exceed {general_contact_strategy.robocalls}.
+- There must be AT LEAST 1 Voter Outreach Task every 7 days (MAXIMUM 7 days between Voter Outreach Tasks).
+- The FINAL Voter Outreach Task in Phase 2 MUST be between {campaign_info.election_date - timedelta(days=1)} and before {campaign_info.election_date}.
+- List Voter Outreach Tasks chronologically from {phase_2_start_date} through {campaign_info.election_date}.
+
+# VOTER OUTREACH TASKS: (Format: outreachType: outreachDescription)
+## PHASE 1 TASKS:
+- P2P Text: Early Text – Candidate introduction + race message
+- Robocall: Early Robocall – Candidate introduction + race message
+- P2P Text: Mid campaign Text – Persuasion message
+- Robocall: Mid campaign Robocall – Persuasion message + polling info
+- P2P Text: Late campaign Text – Early vote push
+- Robocall: Final Robocall – GOTV call (morning)
+- P2P Text: Final Text – Primary Day reminder + poll finder
+### IMPORTANT: THERE MUST BE ALL 7 PHASE 1 VOTER OUTREACH TASKS BETWEEN {phase_1_start_date} AND BEFORE {campaign_info.primary_date}.
+
+## PHASE 2 TASKS:
+- P2P Text: Early Text – Candidate reintroduction + race message
+- Robocall: Early Robocall – Candidate reintroduction + race message
+- P2P Text: Mid campaign Text – Persuasion message
+- Robocall: Mid campaign Robocall – Persuasion message + polling info
+- P2P Text: Late campaign Text – Early vote push
+- Robocall: Final Robocall – GOTV call (morning)
+- P2P Text: Final Text – Election Day reminder + poll finder
+### IMPORTANT: THERE MUST BE ALL 7 PHASE 2 VOTER OUTREACH TASKS BETWEEN {phase_2_start_date} AND BEFORE {campaign_info.election_date}.
+---
+# OUTPUT EXAMPLE FORMAT:
+- yyyy-mm-dd – outreachType: outreachDescription
+- yyyy-mm-dd – outreachType: outreachDescription
+...
+- {campaign_info.primary_date} – Primary Election Day
+- yyyy-mm-dd – outreachType: outreachDescription
+- yyyy-mm-dd – outreachType: outreachDescription
+...
+- {campaign_info.election_date} – General Election Day
 """
         else:            
+            # Calculate start date:
+            start_7w_date = campaign_info.election_date - timedelta(weeks=7)
+            start_date_3d_buffer = date.today() + timedelta(days=3)
+            start_date = start_date_3d_buffer if start_7w_date < start_date_3d_buffer else start_7w_date
+            
             prompt = f"""
-today's date: {date.today()}
-general election date: {campaign_info.election_date}
+# TIMELINE CONTEXT:
+Signup Date: {date.today()}
+Voter Outreach Start Date = {start_date}
+General Election Date: {campaign_info.election_date}
 
-CAMPAIGN CONTEXT:
+# CAMPAIGN CONTEXT:
 - Candidate: {campaign_info.candidate_name}
 - Office: {campaign_info.office_and_jurisdiction}
 - Has Primary: No
 
-RULES:
-- Only include {general_contact_strategy.p2p_texts} texts and {general_contact_strategy.robocalls} robocalls
-- one set of text messaging and robocalls should be schedules close to the election to remind of the polling location and to vote
-- List contacts chronologically from today through general election
-- These are some examples of the messages that can be used:
-        - Early Text – Voter intro + early voting alert
-        - Early Robocall – Candidate intro + race message
-        - Mid campaign Text – Contrast/persuasion message
-        - Mid campaign Robocall – Polling info + persuasion
-        - Late campaign Text – Final early vote push
-        - Final Text – Election Day reminder + poll finder
-        - Final Robocall – Final GOTV call (morning)
+# GOAL:
+- Generate a Campaign Plan containing Voter Outreach Tasks.
 
-Generate a voter contact plan for general election only in this format:
+# GOAL COMPLETION GUIDELINES:
+- ONLY include {general_contact_strategy.p2p_texts} P2P Texts and {general_contact_strategy.robocalls} Robocalls in the Campaign Plan.
+- NO Voter Outreach Task date can be before {start_date}.
+- ALL 7 Voter Outreach Tasks MUST be between {start_date} and before {campaign_info.election_date}.
+- The number of P2P Text Voter Outreach Tasks before {campaign_info.election_date} should NOT exceed {general_contact_strategy.p2p_texts}.
+- The number of Robocall Voter Outreach Tasks before {campaign_info.election_date} should NOT exceed {general_contact_strategy.robocalls}.
+- There must be AT LEAST 1 Voter Outreach Task every 7 days (MAXIMUM 7 days between Voter Outreach Tasks).
+- The FINAL Voter Outreach Task MUST be between {campaign_info.election_date - timedelta(days=1)} and before {campaign_info.election_date}.
+- List Voter Outreach Tasks chronologically from {campaign_info.election_date - start_date} through {campaign_info.election_date}.
 
-Example format:
-- [FULL MONTH DD] – P2P Text #1: [Message theme]
-- [FULL MONTH DD] – Robocall #1: [Message theme]
-- [Election Date] – General Election Day
+# VOTER OUTREACH TASKS: (Format: outreachType: outreachDescription)
+- P2P Text: Early Text – Candidate intro
+- Robocall: Early Robocall – Candidate intro + race message
+- P2P Text: Mid campaign Text – Persuasion message
+- Robocall: Mid campaign Robocall – Persuasion message + polling info
+- P2P Text: Late campaign Text – Early vote push
+- Robocall: Final Robocall – GOTV call (morning)
+- P2P Text: Final Text – Election Day reminder + poll finder
+## IMPORTANT: THERE MUST BE ALL 7 VOTER OUTREACH TASKS BETWEEN {start_date} AND BEFORE {campaign_info.election_date}.
+---
+# OUTPUT EXAMPLE FORMAT:
+- yyyy-mm-dd – outreachType: outreachDescription
+- yyyy-mm-dd – outreachType: outreachDescription
+...
+- {campaign_info.election_date} – General Election Day
 """
         try:
             response = self.llm_client.generate_content(
@@ -123,12 +168,22 @@ if __name__ == "__main__":
     campaign_utils = CampaignUtils()
     generator = VoterContactPlanGenerator()
 
-    print("=== TEST CASE 1: CAMPAIGN WITH PRIMARY ===")
+    print("\n" + "="*60 + "\n")
+
+    print("=== CAMPAIGN WITH PRIMARY TEST CASES ===")
+
+    print("\n" + "="*60 + "\n")
+
+    print("=== TEST CASE 1: PRIMARY 16 + GENERAL ELECTION 24 WEEKS FROM SIGNUP DATE ===")
+    primary_date_weeks = date.today() + timedelta(weeks=16)
+    election_date_weeks = date.today() + timedelta(weeks=24)
     campaign_info_with_primary = CampaignInfo(
         candidate_name="John Doe",
         office_and_jurisdiction="Mayor, Springfield, MA",
-        election_date=date(2025, 11, 5),
-        primary_date=date(2025, 8, 1),
+        # election_date=date(2025, 11, 5),
+        # primary_date=date(2025, 8, 1),
+        election_date=election_date_weeks,
+        primary_date=primary_date_weeks,
         race_type="Nonpartisan",
         seats_available=1,
         number_of_opponents=2,
@@ -144,15 +199,239 @@ if __name__ == "__main__":
     primary_campaign_plan = campaign_utils.optimize_contact_strategy(date.today(), cleaned_campaign_info_with_primary.primary_date)
     general_campaign_plan = campaign_utils.optimize_contact_strategy(cleaned_campaign_info_with_primary.primary_date, cleaned_campaign_info_with_primary.election_date)
     result_with_primary = asyncio.run(generator.generate_section(cleaned_campaign_info_with_primary, primary_campaign_plan, general_campaign_plan))
+    print(f"Signup Date: {date.today()}")
+    print(f"Primary Date: {cleaned_campaign_info_with_primary.primary_date}")
+    print(f"Election Date: {cleaned_campaign_info_with_primary.election_date}")
     print(result_with_primary)
-    
+
+    print("\n" + "="*60 + "\n")
+
+    print("=== TEST CASE 2: PRIMARY 12 WEEKS + GENERAL ELECTION 16 FROM SIGNUP DATE ===")
+    primary_date_weeks = date.today() + timedelta(weeks=12)
+    election_date_weeks = date.today() + timedelta(weeks=16)
+    campaign_info_with_primary = CampaignInfo(
+        candidate_name="John Doe",
+        office_and_jurisdiction="Mayor, Springfield, MA",
+        # election_date=date(2025, 11, 5),
+        # primary_date=date(2025, 8, 1),
+        election_date=election_date_weeks,
+        primary_date=primary_date_weeks,
+        race_type="Nonpartisan",
+        seats_available=1,
+        number_of_opponents=2,
+        win_number=15000,
+        total_likely_voters=100000,
+        available_cell_phones=10000,
+        available_landlines=1000,
+        incumbent_status=IncumbentStatus.NOT_APPLICABLE,
+        additional_race_context="Focus on education funding and infrastructure improvements"
+    )
+
+    cleaned_campaign_info_with_primary = campaign_utils.clean_campaign_info(campaign_info_with_primary)
+    primary_campaign_plan = campaign_utils.optimize_contact_strategy(date.today(), cleaned_campaign_info_with_primary.primary_date)
+    general_campaign_plan = campaign_utils.optimize_contact_strategy(cleaned_campaign_info_with_primary.primary_date, cleaned_campaign_info_with_primary.election_date)
+    result_with_primary = asyncio.run(generator.generate_section(cleaned_campaign_info_with_primary, primary_campaign_plan, general_campaign_plan))
+    print(f"Signup Date: {date.today()}")
+    print(f"Primary Date: {cleaned_campaign_info_with_primary.primary_date}")
+    print(f"Election Date: {cleaned_campaign_info_with_primary.election_date}")
+    print(result_with_primary)
+
+    print("\n" + "="*60 + "\n")
+
+    print("=== TEST CASE 3: PRIMARY 6 WEEKS + GENERAL ELECTION 12 FROM SIGNUP DATE ===")
+    primary_date_weeks = date.today() + timedelta(weeks=6)
+    election_date_weeks = date.today() + timedelta(weeks=12)
+    campaign_info_with_primary = CampaignInfo(
+        candidate_name="John Doe",
+        office_and_jurisdiction="Mayor, Springfield, MA",
+        # election_date=date(2025, 11, 5),
+        # primary_date=date(2025, 8, 1),
+        election_date=election_date_weeks,
+        primary_date=primary_date_weeks,
+        race_type="Nonpartisan",
+        seats_available=1,
+        number_of_opponents=2,
+        win_number=15000,
+        total_likely_voters=100000,
+        available_cell_phones=10000,
+        available_landlines=1000,
+        incumbent_status=IncumbentStatus.NOT_APPLICABLE,
+        additional_race_context="Focus on education funding and infrastructure improvements"
+    )
+
+    cleaned_campaign_info_with_primary = campaign_utils.clean_campaign_info(campaign_info_with_primary)
+    primary_campaign_plan = campaign_utils.optimize_contact_strategy(date.today(), cleaned_campaign_info_with_primary.primary_date)
+    general_campaign_plan = campaign_utils.optimize_contact_strategy(cleaned_campaign_info_with_primary.primary_date, cleaned_campaign_info_with_primary.election_date)
+    result_with_primary = asyncio.run(generator.generate_section(cleaned_campaign_info_with_primary, primary_campaign_plan, general_campaign_plan))
+    print(f"Signup Date: {date.today()}")
+    print(f"Primary Date: {cleaned_campaign_info_with_primary.primary_date}")
+    print(f"Election Date: {cleaned_campaign_info_with_primary.election_date}")
+    print(result_with_primary)
+
+    print("\n" + "="*60 + "\n")
+
+    print("=== TEST CASE 4: PRIMARY 4 WEEKS + GENERAL ELECTION 8 FROM SIGNUP DATE ===")
+    primary_date_weeks = date.today() + timedelta(weeks=4)
+    election_date_weeks = date.today() + timedelta(weeks=8)
+    campaign_info_with_primary = CampaignInfo(
+        candidate_name="John Doe",
+        office_and_jurisdiction="Mayor, Springfield, MA",
+        # election_date=date(2025, 11, 5),
+        # primary_date=date(2025, 8, 1),
+        election_date=election_date_weeks,
+        primary_date=primary_date_weeks,
+        race_type="Nonpartisan",
+        seats_available=1,
+        number_of_opponents=2,
+        win_number=15000,
+        total_likely_voters=100000,
+        available_cell_phones=10000,
+        available_landlines=1000,
+        incumbent_status=IncumbentStatus.NOT_APPLICABLE,
+        additional_race_context="Focus on education funding and infrastructure improvements"
+    )
+
+    cleaned_campaign_info_with_primary = campaign_utils.clean_campaign_info(campaign_info_with_primary)
+    primary_campaign_plan = campaign_utils.optimize_contact_strategy(date.today(), cleaned_campaign_info_with_primary.primary_date)
+    general_campaign_plan = campaign_utils.optimize_contact_strategy(cleaned_campaign_info_with_primary.primary_date, cleaned_campaign_info_with_primary.election_date)
+    result_with_primary = asyncio.run(generator.generate_section(cleaned_campaign_info_with_primary, primary_campaign_plan, general_campaign_plan))
+    print(f"Signup Date: {date.today()}")
+    print(f"Primary Date: {cleaned_campaign_info_with_primary.primary_date}")
+    print(f"Election Date: {cleaned_campaign_info_with_primary.election_date}")
+    print(result_with_primary)
+
+    print("\n" + "="*60 + "\n")
+
+    print("=== TEST CASE 5: PRIMARY 2 WEEKS + GENERAL ELECTION 6 FROM SIGNUP DATE ===")
+    primary_date_weeks = date.today() + timedelta(weeks=2)
+    election_date_weeks = date.today() + timedelta(weeks=6)
+    campaign_info_with_primary = CampaignInfo(
+        candidate_name="John Doe",
+        office_and_jurisdiction="Mayor, Springfield, MA",
+        # election_date=date(2025, 11, 5),
+        # primary_date=date(2025, 8, 1),
+        election_date=election_date_weeks,
+        primary_date=primary_date_weeks,
+        race_type="Nonpartisan",
+        seats_available=1,
+        number_of_opponents=2,
+        win_number=15000,
+        total_likely_voters=100000,
+        available_cell_phones=10000,
+        available_landlines=1000,
+        incumbent_status=IncumbentStatus.NOT_APPLICABLE,
+        additional_race_context="Focus on education funding and infrastructure improvements"
+    )
+
+    cleaned_campaign_info_with_primary = campaign_utils.clean_campaign_info(campaign_info_with_primary)
+    primary_campaign_plan = campaign_utils.optimize_contact_strategy(date.today(), cleaned_campaign_info_with_primary.primary_date)
+    general_campaign_plan = campaign_utils.optimize_contact_strategy(cleaned_campaign_info_with_primary.primary_date, cleaned_campaign_info_with_primary.election_date)
+    result_with_primary = asyncio.run(generator.generate_section(cleaned_campaign_info_with_primary, primary_campaign_plan, general_campaign_plan))
+    print(f"Signup Date: {date.today()}")
+    print(f"Primary Date: {cleaned_campaign_info_with_primary.primary_date}")
+    print(f"Election Date: {cleaned_campaign_info_with_primary.election_date}")
+    print(result_with_primary)
+
+    print("\n" + "="*60 + "\n")
+
+    print("=== TEST CASE 6: PRIMARY 1 WEEKS + GENERAL ELECTION 4 FROM SIGNUP DATE ===")
+    primary_date_weeks = date.today() + timedelta(weeks=1)
+    election_date_weeks = date.today() + timedelta(weeks=4)
+    campaign_info_with_primary = CampaignInfo(
+        candidate_name="John Doe",
+        office_and_jurisdiction="Mayor, Springfield, MA",
+        # election_date=date(2025, 11, 5),
+        # primary_date=date(2025, 8, 1),
+        election_date=election_date_weeks,
+        primary_date=primary_date_weeks,
+        race_type="Nonpartisan",
+        seats_available=1,
+        number_of_opponents=2,
+        win_number=15000,
+        total_likely_voters=100000,
+        available_cell_phones=10000,
+        available_landlines=1000,
+        incumbent_status=IncumbentStatus.NOT_APPLICABLE,
+        additional_race_context="Focus on education funding and infrastructure improvements"
+    )
+
+    cleaned_campaign_info_with_primary = campaign_utils.clean_campaign_info(campaign_info_with_primary)
+    primary_campaign_plan = campaign_utils.optimize_contact_strategy(date.today(), cleaned_campaign_info_with_primary.primary_date)
+    general_campaign_plan = campaign_utils.optimize_contact_strategy(cleaned_campaign_info_with_primary.primary_date, cleaned_campaign_info_with_primary.election_date)
+    result_with_primary = asyncio.run(generator.generate_section(cleaned_campaign_info_with_primary, primary_campaign_plan, general_campaign_plan))
+    print(f"Signup Date: {date.today()}")
+    print(f"Primary Date: {cleaned_campaign_info_with_primary.primary_date}")
+    print(f"Election Date: {cleaned_campaign_info_with_primary.election_date}")
+    print(result_with_primary)
+
+    print("\n" + "="*60 + "\n")
+
+    print("=== CAMPAIGN WITHOUT PRIMARY TEST CASES ===")
+
     print("\n" + "="*60 + "\n")
     
-    print("=== TEST CASE 2: CAMPAIGN WITHOUT PRIMARY ===")
+    print("=== TEST CASE 1: GENERAL ELECTION 16 WEEKS FROM SIGNUP DATE ===")
+    election_date_16_weeks = date.today() + timedelta(weeks=16)
+    campaign_info_16_weeks = CampaignInfo(
+        candidate_name="Michael Chen",
+        office_and_jurisdiction="School Board, At-Large",
+        election_date=election_date_16_weeks,
+        primary_date=None,
+        race_type="Nonpartisan",
+        seats_available=2,
+        number_of_opponents=4,
+        win_number=18000,
+        total_likely_voters=90000,
+        available_cell_phones=18000,
+        available_landlines=2000,
+        incumbent_status=IncumbentStatus.NOT_APPLICABLE,
+        additional_race_context="Focus on education reform and student achievement"
+    )
+
+    cleaned_campaign_info_16_weeks = campaign_utils.clean_campaign_info(campaign_info_16_weeks)
+    general_campaign_plan = campaign_utils.optimize_contact_strategy(date.today(), cleaned_campaign_info_16_weeks.election_date)
+    result_16_weeks = asyncio.run(generator.generate_section(cleaned_campaign_info_16_weeks, general_contact_strategy=general_campaign_plan))
+    print(f"Signup Date: {date.today()}")
+    print(f"Election Date: {election_date_16_weeks}")
+    print(result_16_weeks)
+
+    print("\n" + "="*60 + "\n")
+    
+    print("=== TEST CASE 2: GENERAL ELECTION 12 WEEKS FROM SIGNUP DATE ===")
+    election_date_12_weeks = date.today() + timedelta(weeks=12)
+    campaign_info_12_weeks = CampaignInfo(
+        candidate_name="Sarah Williams",
+        office_and_jurisdiction="County Commissioner, District 2",
+        election_date=election_date_12_weeks,
+        primary_date=None,
+        race_type="Nonpartisan",
+        seats_available=1,
+        number_of_opponents=2,
+        win_number=12000,
+        total_likely_voters=60000,
+        available_cell_phones=12000,
+        available_landlines=1500,
+        incumbent_status=IncumbentStatus.NOT_APPLICABLE,
+        additional_race_context="Focus on infrastructure and public safety"
+    )
+
+    cleaned_campaign_info_12_weeks = campaign_utils.clean_campaign_info(campaign_info_12_weeks)
+    general_campaign_plan = campaign_utils.optimize_contact_strategy(date.today(), cleaned_campaign_info_12_weeks.election_date)
+    result_12_weeks = asyncio.run(generator.generate_section(cleaned_campaign_info_12_weeks, general_contact_strategy=general_campaign_plan))
+    print(f"Signup Date: {date.today()}")
+    print(f"Election Date: {election_date_12_weeks}")
+    print(result_12_weeks)
+
+    print("\n" + "="*60 + "\n")
+
+    print("=== TEST CASE 3: GENERAL ELECTION 8 WEEKS FROM SIGNUP DATE ===")
+    election_date_8_weeks = date.today() + timedelta(weeks=8)
+    outreach_start_date = election_date_8_weeks - timedelta(weeks=8)
     campaign_info_no_primary = CampaignInfo(
         candidate_name="Jane Smith",
         office_and_jurisdiction="City Council, District 3, Boston, MA",
-        election_date=date(2025, 7, 22),
+        # election_date=date(2025, 7, 22),
+        election_date=election_date_8_weeks,
         primary_date=None,
         race_type="Nonpartisan",
         seats_available=1,
@@ -167,5 +446,88 @@ if __name__ == "__main__":
 
     cleaned_campaign_info_no_primary = campaign_utils.clean_campaign_info(campaign_info_no_primary)
     general_campaign_plan = campaign_utils.optimize_contact_strategy(date.today(), cleaned_campaign_info_no_primary.election_date)
-    result_no_primary = asyncio.run(generator.generate_section(cleaned_campaign_info_no_primary, general_contact_strategy=general_campaign_plan))
-    print(result_no_primary)
+    result_8_weeks = asyncio.run(generator.generate_section(cleaned_campaign_info_no_primary, general_contact_strategy=general_campaign_plan))
+    print(f"Signup Date: {date.today()}")
+    print(f"Election Date: {election_date_8_weeks}")
+    print(result_8_weeks)
+
+    print("\n" + "="*60 + "\n")
+
+    print("=== TEST CASE 4: GENERAL ELECTION 4 WEEKS FROM SIGNUP DATE ===")
+    election_date_4_weeks = date.today() + timedelta(weeks=4)
+    campaign_info_4_weeks = CampaignInfo(
+        candidate_name="Bob Johnson",
+        office_and_jurisdiction="State Representative, District 5",
+        election_date=election_date_4_weeks,
+        primary_date=None,
+        race_type="Partisan",
+        seats_available=1,
+        number_of_opponents=1,
+        win_number=10000,
+        total_likely_voters=40000,
+        available_cell_phones=8000,
+        available_landlines=1200,
+        incumbent_status=IncumbentStatus.NOT_APPLICABLE,
+        additional_race_context="Focus on economic development and job creation"
+    )
+
+    cleaned_campaign_info_4_weeks = campaign_utils.clean_campaign_info(campaign_info_4_weeks)
+    general_campaign_plan = campaign_utils.optimize_contact_strategy(date.today(), cleaned_campaign_info_4_weeks.election_date)
+    result_4_weeks = asyncio.run(generator.generate_section(cleaned_campaign_info_4_weeks, general_contact_strategy=general_campaign_plan))
+    print(f"Signup Date: {date.today()}")
+    print(f"Election Date: {election_date_4_weeks}")
+    print(result_4_weeks)
+
+    print("\n" + "="*60 + "\n")
+
+    print("=== TEST CASE 5: GENERAL ELECTION 2 WEEKS FROM SIGNUP DATE ===")
+    election_date_2_weeks = date.today() + timedelta(weeks=2)
+    campaign_info_2_weeks = CampaignInfo(
+        candidate_name="Bob Johnson",
+        office_and_jurisdiction="State Representative, District 5",
+        election_date=election_date_2_weeks,
+        primary_date=None,
+        race_type="Partisan",
+        seats_available=1,
+        number_of_opponents=1,
+        win_number=10000,
+        total_likely_voters=40000,
+        available_cell_phones=8000,
+        available_landlines=1200,
+        incumbent_status=IncumbentStatus.NOT_APPLICABLE,
+        additional_race_context="Focus on economic development and job creation"
+    )
+
+    cleaned_campaign_info_2_weeks = campaign_utils.clean_campaign_info(campaign_info_2_weeks)
+    general_campaign_plan = campaign_utils.optimize_contact_strategy(date.today(), cleaned_campaign_info_2_weeks.election_date)
+    result_2_weeks = asyncio.run(generator.generate_section(cleaned_campaign_info_2_weeks, general_contact_strategy=general_campaign_plan))
+    print(f"Signup Date: {date.today()}")
+    print(f"Election Date: {election_date_2_weeks}")
+    print(result_2_weeks)
+
+    print("\n" + "="*60 + "\n")
+
+    print("=== TEST CASE 6: GENERAL ELECTION 1 WEEK FROM SIGNUP DATE ===")
+    election_date_1_weeks = date.today() + timedelta(weeks=1)
+    campaign_info_1_weeks = CampaignInfo(
+        candidate_name="Bob Johnson",
+        office_and_jurisdiction="State Representative, District 5",
+        election_date=election_date_1_weeks,
+        primary_date=None,
+        race_type="Partisan",
+        seats_available=1,
+        number_of_opponents=1,
+        win_number=10000,
+        total_likely_voters=40000,
+        available_cell_phones=8000,
+        available_landlines=1200,
+        incumbent_status=IncumbentStatus.NOT_APPLICABLE,
+        additional_race_context="Focus on economic development and job creation"
+    )
+
+    cleaned_campaign_info_1_weeks = campaign_utils.clean_campaign_info(campaign_info_1_weeks)
+    general_campaign_plan = campaign_utils.optimize_contact_strategy(date.today(), cleaned_campaign_info_1_weeks.election_date)
+    result_1_weeks = asyncio.run(generator.generate_section(cleaned_campaign_info_1_weeks, general_contact_strategy=general_campaign_plan))
+    print(f"Signup Date: {date.today()}")
+    print(f"Election Date: {election_date_1_weeks}")
+    print(result_1_weeks)


### PR DESCRIPTION
# Summary
Added two-phase timeline support for campaigns with primaries. Each phase (primary and general) has its own 7-week outreach window with buffer date logic.

# Changes
## Two-Phase Timeline System
Separate Phase 1 (primary) and Phase 2 (general election) handling
Phase 1 start: max of (primary date - 7 weeks) and (today + 3 days)
Phase 2 start: max of (election date - 7 weeks) and (primary date + 1 day)

## Contact Strategy Integration
Integrated ContactOptimization for both phases
Prompts enforce P2P text and robocall limits per phase

## Enhanced Prompts
Split prompts for primary vs non-primary campaigns
Phase-specific guidelines and date boundaries

## Testing
Added test cases for multiple timeline scenarios (1-16 weeks before election, with and without primaries)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements two-phase voter outreach planning with buffer-based start dates, enforced per-phase task/limit rules, and comprehensive scenario tests.
> 
> - **Voter Contact Plan Generation (`ai_generated_campaign_plan/sections/six_voter_contact_plan.py`)**:
>   - **Phased Timeline Logic**:
>     - Compute Phase 1 start (`primary_date - 7w` vs `today + 3d`) and Phase 2 start (`election_date - 7w` vs `primary_date + 1d`).
>     - Non-primary campaigns: start at max of (`election_date - 7w`, `today + 3d`).
>   - **Prompt Overhaul**:
>     - Separate prompts for primary vs non-primary; include detailed date context and output format.
>     - Enforce per-phase limits from `ContactOptimization` (P2P texts/robocalls), exactly 7 tasks per phase, ≤7 days between tasks, and final task within 1 day before milestone.
>   - **Logging**: Log generated plan content.
>   - **Testing (main)**:
>     - Add multiple timeline scenarios (1–16 weeks) for campaigns with and without primaries; print signup/primary/election dates and generated plans.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1391adbc1cf3ccc9fe8c103b3de6fe90dda023a5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->