### PR TITLE
QA <- Dev

### DIFF
--- a/serve/v1_pipeline/models/events.py
+++ b/serve/v1_pipeline/models/events.py
@@ -14,20 +14,10 @@ class PollIssueAnalysisData:
     responseCount: int
 
 @dataclass
-class PollIssueAnalysisEvent:
-    data: PollIssueAnalysisData
-    type: str = 'pollIssueAnalysis'
-
-    def to_json(self) -> dict:
-        return {
-            'type': self.type,
-            'data': asdict(self.data)
-        }
-
-@dataclass
 class PollAnalysisCompleteData:
     pollId: str
     totalResponses: int
+    issues: list[PollIssueAnalysisData]
 
 @dataclass
 class PollAnalysisCompleteEvent:

--- a/serve/v1_pipeline/pipeline/orchestrator.py
+++ b/serve/v1_pipeline/pipeline/orchestrator.py
@@ -342,7 +342,6 @@ class V1PipelineOrchestrator:
 
                         sqs_result = {
                             'success': True,
-                            'issue_events_sent': 0,
                             'complete_events_sent': total_complete_events
                         }
                         logger.info(f"✅ Published {total_complete_events} empty poll completion events")
@@ -504,7 +503,6 @@ class V1PipelineOrchestrator:
 
                     sqs_stats = {
                         'polls_processed': len(poll_ids),
-                        'issue_events_sent': 0,
                         'complete_events_sent': total_complete_events
                     }
                 else:
@@ -514,7 +512,6 @@ class V1PipelineOrchestrator:
                 sqs_time = time.time() - sqs_start
 
                 logger.info(f"✅ Event saving completed in {sqs_time:.2f}s")
-                logger.info(f"   Saved {sqs_stats['issue_events_sent']} issue events")
                 logger.info(f"   Saved {sqs_stats['complete_events_sent']} complete events")
 
                 sqs_result = {

--- a/serve/v1_pipeline/pipeline/sqs_publisher.py
+++ b/serve/v1_pipeline/pipeline/sqs_publisher.py
@@ -60,11 +60,11 @@ class SQSEventPublisher:
             if record.poll_id:
                 polls[record.poll_id].append(record)
 
-        total_issues = 0
         total_complete_events = 0
-        all_issues = []
+        all_events = []
 
         for poll_id, records in polls.items():
+            poll_issues = []
             logger.info(f"Processing poll_id: {poll_id} ({len(records)} records)")
 
             cluster_stats = self._aggregate_cluster_stats(records)
@@ -74,7 +74,7 @@ class SQSEventPublisher:
             logger.info(f"  Processing top {len(top_clusters)} clusters")
 
             for rank, cluster_data in enumerate(top_clusters, start=1):
-                all_issues.append(
+                poll_issues.append(
                     PollIssueAnalysisData(
                         pollId=poll_id,
                         rank=rank,
@@ -88,12 +88,11 @@ class SQSEventPublisher:
 
                 logger.info(f"  ✅ Rank {rank}: {cluster_data['theme']} ({cluster_data['responseCount']} respondents) - saved locally")
 
-                total_issues += 1
-
             unique_respondents = len(set(record.phone_number for record in records))
             logger.info(f"  Total unique respondents: {unique_respondents} (from {len(records)} atomic messages)")
 
-            complete_event = self._build_complete_event(poll_id, unique_respondents, all_issues)
+            complete_event = self._build_complete_event(poll_id, unique_respondents, poll_issues)
+            all_events.append(complete_event)
 
             if self.publish_to_sqs:
                 self._send_to_sqs(complete_event)
@@ -103,11 +102,10 @@ class SQSEventPublisher:
 
             total_complete_events += 1
 
-        self._save_events_locally([complete_event])
+        self._save_events_locally(all_events.to_json())
 
         return {
             'polls_processed': len(polls),
-            'issues_sent': total_issues,
             'complete_events_sent': total_complete_events
         }
 
@@ -188,7 +186,7 @@ class SQSEventPublisher:
         """
         logger.info(f"Publishing empty poll completion event for poll_id: {poll_id}")
 
-        complete_event = self._build_complete_event(poll_id, total_responses=0)
+        complete_event = self._build_complete_event(poll_id, total_responses=0, issues=[])
         events = [complete_event.to_json()]
 
         if self.publish_to_sqs:
@@ -201,7 +199,6 @@ class SQSEventPublisher:
 
         return {
             'polls_processed': 1,
-            'issue_events_sent': 0,
             'complete_events_sent': 1
         }
 

--- a/serve/v1_pipeline/pipeline/sqs_publisher.py
+++ b/serve/v1_pipeline/pipeline/sqs_publisher.py
@@ -18,7 +18,6 @@ from serve.v1_pipeline.models.events import (
     PollAnalysisCompleteData,
     PollAnalysisCompleteEvent,
     PollIssueAnalysisData,
-    PollIssueAnalysisEvent,
 )
 from serve.v1_pipeline.models.unified_record import UnifiedCampaignRecord
 from shared.logger import get_logger
@@ -61,9 +60,9 @@ class SQSEventPublisher:
             if record.poll_id:
                 polls[record.poll_id].append(record)
 
-        total_issue_events = 0
+        total_issues = 0
         total_complete_events = 0
-        all_events = []
+        all_issues = []
 
         for poll_id, records in polls.items():
             logger.info(f"Processing poll_id: {poll_id} ({len(records)} records)")
@@ -75,24 +74,26 @@ class SQSEventPublisher:
             logger.info(f"  Processing top {len(top_clusters)} clusters")
 
             for rank, cluster_data in enumerate(top_clusters, start=1):
-                event = self._build_issue_event(poll_id, rank, cluster_data)
+                all_issues.append(
+                    PollIssueAnalysisData(
+                        pollId=poll_id,
+                        rank=rank,
+                        theme=cluster_data['theme'],
+                        summary=cluster_data['summary'],
+                        analysis=cluster_data['analysis'],
+                        quotes=cluster_data['quotes'],
+                        responseCount=cluster_data['responseCount']
+                    )
+                )
 
-                all_events.append(event.to_json())
+                logger.info(f"  ✅ Rank {rank}: {cluster_data['theme']} ({cluster_data['responseCount']} respondents) - saved locally")
 
-                if self.publish_to_sqs:
-                    self._send_to_sqs(event)
-                    logger.info(f"  ✅ Rank {rank}: {cluster_data['theme']} ({cluster_data['responseCount']} respondents) - sent to SQS + saved locally")
-                else:
-                    logger.info(f"  ✅ Rank {rank}: {cluster_data['theme']} ({cluster_data['responseCount']} respondents) - saved locally")
-
-                total_issue_events += 1
+                total_issues += 1
 
             unique_respondents = len(set(record.phone_number for record in records))
             logger.info(f"  Total unique respondents: {unique_respondents} (from {len(records)} atomic messages)")
 
-            complete_event = self._build_complete_event(poll_id, unique_respondents)
-
-            all_events.append(complete_event.to_json())
+            complete_event = self._build_complete_event(poll_id, unique_respondents, all_issues)
 
             if self.publish_to_sqs:
                 self._send_to_sqs(complete_event)
@@ -102,11 +103,11 @@ class SQSEventPublisher:
 
             total_complete_events += 1
 
-        self._save_events_locally(all_events)
+        self._save_events_locally([complete_event])
 
         return {
             'polls_processed': len(polls),
-            'issue_events_sent': total_issue_events,
+            'issues_sent': total_issues,
             'complete_events_sent': total_complete_events
         }
 
@@ -170,26 +171,13 @@ class SQSEventPublisher:
 
         return ranked[:self.top_n]
 
-    def _build_issue_event(self, poll_id: str, rank: int, cluster_data: dict) -> PollIssueAnalysisEvent:
-        return PollIssueAnalysisEvent(
-            type='pollIssueAnalysis',
-            data=PollIssueAnalysisData(
-                pollId=poll_id,
-                rank=rank,
-                theme=cluster_data['theme'],
-                summary=cluster_data['summary'],
-                analysis=cluster_data['analysis'],
-                quotes=cluster_data['quotes'],
-                responseCount=cluster_data['responseCount']
-            )
-        )
-
-    def _build_complete_event(self, poll_id: str, total_responses: int) -> PollAnalysisCompleteEvent:
+    def _build_complete_event(self, poll_id: str, total_responses: int, issues: list[PollIssueAnalysisData]) -> PollAnalysisCompleteEvent:
         return PollAnalysisCompleteEvent(
             type='pollAnalysisComplete',
             data=PollAnalysisCompleteData(
                 pollId=poll_id,
-                totalResponses=total_responses
+                totalResponses=total_responses,
+                issues=issues
             )
         )
 
@@ -239,7 +227,7 @@ class SQSEventPublisher:
             logger.error(f"Failed to save events locally: {e}", exc_info=True)
             raise
 
-    def _send_to_sqs(self, event: PollIssueAnalysisEvent | PollAnalysisCompleteEvent) -> None:
+    def _send_to_sqs(self, event: PollAnalysisCompleteEvent) -> None:
         """Send event to SQS FIFO queue with proper MessageGroupId"""
         if not self.publish_to_sqs or not self.sqs_client:
             logger.warning("SQS publishing disabled but _send_to_sqs called")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Embeds top issue analyses into `pollAnalysisComplete` events, removes `pollIssueAnalysis` events, and updates orchestrator/publisher logic and metrics accordingly.
> 
> - **Events Model (`serve/v1_pipeline/models/events.py`)**:
>   - Add `issues: list[PollIssueAnalysisData]` to `PollAnalysisCompleteData` and keep `to_json` on `PollAnalysisCompleteEvent`.
>   - Remove `PollIssueAnalysisEvent` class.
> - **SQS Publisher (`serve/v1_pipeline/pipeline/sqs_publisher.py`)**:
>   - Aggregate top clusters per poll into `PollIssueAnalysisData` items and include them in a single `PollAnalysisCompleteEvent` per poll.
>   - Stop emitting per-issue events; only send/shell out completion events.
>   - Update `_build_complete_event` to accept `issues`; adjust `publish_empty_poll_event` accordingly.
>   - Restrict `_send_to_sqs` to `PollAnalysisCompleteEvent`.
>   - Persist only completion events locally.
> - **Orchestrator (`serve/v1_pipeline/pipeline/orchestrator.py`)**:
>   - Remove references to `issue_events_sent` and related logs.
>   - Preserve empty-poll completion publishing flow and stats using only `complete_events_sent`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3883d9b25699247c3d82778b08acae12fdb4552f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->