### PR TITLE
fix to-json

### DIFF
--- a/serve/v1_pipeline/pipeline/sqs_publisher.py
+++ b/serve/v1_pipeline/pipeline/sqs_publisher.py
@@ -102,7 +102,7 @@ class SQSEventPublisher:
 
             total_complete_events += 1
 
-        self._save_events_locally(all_events.to_json())
+        self._save_events_locally(all_events)
 
         return {
             'polls_processed': len(polls),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Passes `all_events` (list) to `_save_events_locally` instead of calling `to_json()` in `serve/v1_pipeline/pipeline/sqs_publisher.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28841af43d900c75f9ac5631e1353e0c1c84b8c7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->