### PR TITLE
60 days lifecycle for cleaning up (delete input) and output (transiti…

### DIFF
--- a/infrastructure/modules/serve-analyze-fargate/main.tf
+++ b/infrastructure/modules/serve-analyze-fargate/main.tf
@@ -83,7 +83,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "pipeline_data_lifecycle" {
     status = "Enabled"
 
     expiration {
-      days = 30
+      days = 60
     }
 
     filter {
@@ -96,7 +96,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "pipeline_data_lifecycle" {
     status = "Enabled"
 
     transition {
-      days          = 7
+      days          = 60
       storage_class = "GLACIER"
     }
 


### PR DESCRIPTION
…on to glacier)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extend S3 lifecycle: expire `input/` objects after 60 days (from 30) and transition `output/` objects to GLACIER after 60 days (from 7).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af3a6a29dc0c697a642fa7aab2891b5eb83f9f87. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->