### PR TITLE
[DATA-1407] add braintrust to ddhq-hubspot election matching

### DIFF
--- a/hubspot_ddhq_match/parallel_production_matcher.py
+++ b/hubspot_ddhq_match/parallel_production_matcher.py
@@ -29,6 +29,15 @@ from tqdm.asyncio import tqdm
 from concurrent.futures import ThreadPoolExecutor
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
+from shared.braintrust import (
+    init_braintrust,
+    traced_llm_call,
+    load_prompt_from_braintrust,
+    flush_logs,
+    is_enabled,
+    get_client,
+    BraintrustClient,
+)
 from shared.llm_gemini import GeminiClient, GeminiModelType
 from shared.logger import get_logger
 
@@ -367,6 +376,10 @@ class ParallelProductionMatcher:
         )
         self.logger.info(f"   Gemini Flash initialized with {target_concurrency} max connections, 9 retries (HIGH THROUGHPUT with reliability)")
 
+        environment = os.getenv("ENVIRONMENT", "local")
+        self.logger.info(f"Braintrust environment: {environment}")
+        init_braintrust(project="hubspot-ddhq-match")
+
     def _search_similar_candidates(self, hubspot_record: Dict, k: int = 5) -> tuple[List[Dict[str, Any]], str]:
         """
         Search for k most similar DDHQ candidates using date + state + election type partitioned FAISS
@@ -634,7 +647,7 @@ Match {i}:
 """
 
         # Build prompt (no runoff-specific context needed - LLM just validates matching)
-        prompt = f"""TASK: Match a HubSpot candidate to DDHQ candidates and return JSON ONLY.
+        fallback_prompt = f"""TASK: Match a HubSpot candidate to DDHQ candidates and return JSON ONLY.
 NOTE: Federal and state races are pre-filtered. Only match local/municipal races.
 
 OUTPUT FORMAT (REQUIRED):
@@ -704,6 +717,21 @@ Be extremely conservative - false positives are worse than false negatives. If u
 
 OUTPUT JSON ONLY (no explanation, no markdown):"""
 
+        # Load prompts from Braintrust (with local fallback)
+        prompt = load_prompt_from_braintrust(
+            prompt_name="hubspot-ddhq-match-validator",
+            fallback_prompt=fallback_prompt,
+            variables={
+                "hubspoot_name": hubspot_info['name'],
+                "hubspoot_full_name": hubspot_info['full_name'],
+                "hubspoot_state": hubspot_info['state'],
+                "hubspoot_city": hubspot_info['city'],
+                "hubspoot_office": hubspot_info['office'],
+                "hubspoot_embedding_text": hubspot_info['embedding_text'],
+                "candidates_text": candidates_text,
+
+            }
+        )
         llm_validation_start = time.time()
 
         try:
@@ -715,7 +743,7 @@ OUTPUT JSON ONLY (no explanation, no markdown):"""
             async def _llm_call():
                 return await asyncio.get_event_loop().run_in_executor(
                     self.thread_pool,
-                    lambda: self.llm_client.generate_content(prompt)
+                    lambda: self.llm_client.generate_content(prompt, trace_name="hubspot-ddhq-match")
                 )
 
             try:

--- a/hubspot_ddhq_match/parallel_production_matcher.py
+++ b/hubspot_ddhq_match/parallel_production_matcher.py
@@ -31,12 +31,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from shared.braintrust import (
     init_braintrust,
-    traced_llm_call,
-    load_prompt_from_braintrust,
-    flush_logs,
-    is_enabled,
-    get_client,
-    BraintrustClient,
+    cache_prompt,
+    build_cached_prompt,
 )
 from shared.llm_gemini import GeminiClient, GeminiModelType
 from shared.logger import get_logger
@@ -380,6 +376,112 @@ class ParallelProductionMatcher:
         self.logger.info(f"Braintrust environment: {environment}")
         init_braintrust(project="hubspot-ddhq-match")
 
+        self._init_prompt_cache()
+
+    def _init_prompt_cache(self):
+        self.logger.info("📝 Loading Braintrust prompt template (one-time)...")
+        self._prompt_name = "hubspot-ddhq-match-validator"
+
+        warmup_vars = {
+            "hubspot_name": "warmup",
+            "hubspot_full_name": "warmup",
+            "hubspot_state": "warmup",
+            "hubspot_city": "warmup",
+            "hubspot_office": "warmup",
+            "hubspot_embedding_text": "warmup",
+            "candidates_text": "warmup"
+        }
+
+        prompt_obj = cache_prompt(self._prompt_name, warmup_variables=warmup_vars)
+        if prompt_obj is not None:
+            self.logger.info("   ✅ Braintrust prompt cached (subsequent builds are ~0.03ms)")
+        else:
+            self.logger.warning("   ⚠️ Braintrust prompt not available, using fallback")
+
+    def _build_prompt(self, hubspot_info: Dict, candidates_text: str) -> str:
+        variables = {
+            "hubspot_name": hubspot_info['name'],
+            "hubspot_full_name": hubspot_info['full_name'],
+            "hubspot_state": hubspot_info['state'],
+            "hubspot_city": hubspot_info['city'],
+            "hubspot_office": hubspot_info['office'],
+            "hubspot_embedding_text": hubspot_info['embedding_text'],
+            "candidates_text": candidates_text
+        }
+
+        fallback = f"""TASK: Match a HubSpot candidate to DDHQ candidates and return JSON ONLY.
+NOTE: Federal and state races are pre-filtered. Only match local/municipal races.
+
+OUTPUT FORMAT (REQUIRED):
+{{"best_match": <number or null>, "confidence": <0-100>, "reasoning": "<brief explanation>"}}
+
+EXAMPLE OUTPUT:
+{{"best_match": 1, "confidence": 95, "reasoning": "Exact name, state, and office match."}}
+OR if no match:
+{{"best_match": null, "confidence": 0, "reasoning": "No valid match found."}}
+
+---
+
+HubSpot Candidate:
+- Name: {hubspot_info['name']}
+- Full Name: {hubspot_info['full_name']}
+- State: {hubspot_info['state']}
+- City: {hubspot_info['city']}
+- Office: {hubspot_info['office']}
+- Embedding: {hubspot_info['embedding_text']}
+
+DDHQ Candidates (ranked by similarity):
+{candidates_text}
+
+MATCHING RULES:
+
+1. NAME REQUIREMENTS (MANDATORY):
+   - First name: Must be exact match, clear nickname (Bob/Robert), or obvious variant (Jon/John)
+   - Last name: Must be exact match or extremely close phonetic variant
+   - Suffixes: Jr., Sr., II, III, IV, V are acceptable variations (John Smith Jr. = John Smith)
+   - REJECT: Different genders (Stanley→Susan), unrelated names (Marco→Erick), random similarities
+
+2. GEOGRAPHIC REQUIREMENTS (MANDATORY):
+   - State: DDHQ race MUST be in the same state as HubSpot candidate
+   - Jurisdiction: For local races, city/county/municipality must match
+   - REJECT: Any cross-state or cross-jurisdiction matches
+
+3. VALIDATION EXAMPLES:
+
+   VALID LOCAL MATCHES (High Confidence):
+   - "John Smith" for Berkeley City Council → "John Smith, Berkeley City Council" (exact match)
+   - "Bob Johnson" for County Commissioner → "Robert Johnson, County Commissioner" (nickname variation)
+   - "Mary O'Connor" for School Board → "Mary O'Connor, School Board" (exact match)
+   - "John Smith Jr." for Mayor → "John Smith, Mayor" (suffix variation - acceptable)
+
+   INVALID LOCAL MATCHES (Must Reject):
+   - "Stanley Pokras" → "Susan Kopras" (gender mismatch, different first name)
+   - "Test User" → "Ronald Test" (test data, unrelated)
+   - "Marco Huerta" → "Erick Huerta" (different first name entirely)
+   - "Jane Doe, Arlington City Council" → "Jane Doe, Arlington County Board" (different jurisdiction type)
+   - "Morrio Clark (NC)" → "Laura Clark (SC)" (different state, different first name)
+
+4. CONFIDENCE CALIBRATION:
+   - 95-100: Perfect name + state + office match
+   - 85-94: Very strong name similarity + state match
+   - 75-84: Good name match + state match with minor uncertainty
+   - 70-74: Reasonable match but with some concerns
+   - Below 70: MUST REJECT - return null
+
+5. AUTOMATIC REJECTIONS:
+   - Any name containing "test", "sample", "demo", "fake"
+   - Different states when HubSpot has state data
+   - No meaningful name similarity between first or last names
+   - Clear gender mismatches
+   - Completely unrelated names
+
+Be extremely conservative - false positives are worse than false negatives. If uncertain, REJECT.
+
+OUTPUT JSON ONLY (no explanation, no markdown):"""
+
+        result = build_cached_prompt(self._prompt_name, variables, fallback_prompt=fallback)
+        return result if result else fallback
+
     def _search_similar_candidates(self, hubspot_record: Dict, k: int = 5) -> tuple[List[Dict[str, Any]], str]:
         """
         Search for k most similar DDHQ candidates using date + state + election type partitioned FAISS
@@ -646,92 +748,8 @@ Match {i}:
   - Embedding: {candidate['embedding_text']}
 """
 
-        # Build prompt (no runoff-specific context needed - LLM just validates matching)
-        fallback_prompt = f"""TASK: Match a HubSpot candidate to DDHQ candidates and return JSON ONLY.
-NOTE: Federal and state races are pre-filtered. Only match local/municipal races.
-
-OUTPUT FORMAT (REQUIRED):
-{{"best_match": <number or null>, "confidence": <0-100>, "reasoning": "<brief explanation>"}}
-
-EXAMPLE OUTPUT:
-{{"best_match": 1, "confidence": 95, "reasoning": "Exact name, state, and office match."}}
-OR if no match:
-{{"best_match": null, "confidence": 0, "reasoning": "No valid match found."}}
-
----
-
-HubSpot Candidate:
-- Name: {hubspot_info['name']}
-- Full Name: {hubspot_info['full_name']}
-- State: {hubspot_info['state']}
-- City: {hubspot_info['city']}
-- Office: {hubspot_info['office']}
-- Embedding: {hubspot_info['embedding_text']}
-
-DDHQ Candidates (ranked by similarity):
-{candidates_text}
-
-MATCHING RULES:
-
-1. NAME REQUIREMENTS (MANDATORY):
-   - First name: Must be exact match, clear nickname (Bob/Robert), or obvious variant (Jon/John)
-   - Last name: Must be exact match or extremely close phonetic variant
-   - Suffixes: Jr., Sr., II, III, IV, V are acceptable variations (John Smith Jr. = John Smith)
-   - REJECT: Different genders (Stanley→Susan), unrelated names (Marco→Erick), random similarities
-
-2. GEOGRAPHIC REQUIREMENTS (MANDATORY):
-   - State: DDHQ race MUST be in the same state as HubSpot candidate
-   - Jurisdiction: For local races, city/county/municipality must match
-   - REJECT: Any cross-state or cross-jurisdiction matches
-
-3. VALIDATION EXAMPLES:
-
-   VALID LOCAL MATCHES (High Confidence):
-   - "John Smith" for Berkeley City Council → "John Smith, Berkeley City Council" (exact match)
-   - "Bob Johnson" for County Commissioner → "Robert Johnson, County Commissioner" (nickname variation)
-   - "Mary O'Connor" for School Board → "Mary O'Connor, School Board" (exact match)
-   - "John Smith Jr." for Mayor → "John Smith, Mayor" (suffix variation - acceptable)
-
-   INVALID LOCAL MATCHES (Must Reject):
-   - "Stanley Pokras" → "Susan Kopras" (gender mismatch, different first name)
-   - "Test User" → "Ronald Test" (test data, unrelated)
-   - "Marco Huerta" → "Erick Huerta" (different first name entirely)
-   - "Jane Doe, Arlington City Council" → "Jane Doe, Arlington County Board" (different jurisdiction type)
-   - "Morrio Clark (NC)" → "Laura Clark (SC)" (different state, different first name)
-
-4. CONFIDENCE CALIBRATION:
-   - 95-100: Perfect name + state + office match
-   - 85-94: Very strong name similarity + state match
-   - 75-84: Good name match + state match with minor uncertainty
-   - 70-74: Reasonable match but with some concerns
-   - Below 70: MUST REJECT - return null
-
-5. AUTOMATIC REJECTIONS:
-   - Any name containing "test", "sample", "demo", "fake"
-   - Different states when HubSpot has state data
-   - No meaningful name similarity between first or last names
-   - Clear gender mismatches
-   - Completely unrelated names
-
-Be extremely conservative - false positives are worse than false negatives. If uncertain, REJECT.
-
-OUTPUT JSON ONLY (no explanation, no markdown):"""
-
-        # Load prompts from Braintrust (with local fallback)
-        prompt = load_prompt_from_braintrust(
-            prompt_name="hubspot-ddhq-match-validator",
-            fallback_prompt=fallback_prompt,
-            variables={
-                "hubspoot_name": hubspot_info['name'],
-                "hubspoot_full_name": hubspot_info['full_name'],
-                "hubspoot_state": hubspot_info['state'],
-                "hubspoot_city": hubspot_info['city'],
-                "hubspoot_office": hubspot_info['office'],
-                "hubspoot_embedding_text": hubspot_info['embedding_text'],
-                "candidates_text": candidates_text,
-
-            }
-        )
+        # Build prompt using cached Braintrust template (1 API call at init, local builds thereafter)
+        prompt = self._build_prompt(hubspot_info, candidates_text)
         llm_validation_start = time.time()
 
         try:

--- a/hubspot_ddhq_match/parallel_production_matcher.py
+++ b/hubspot_ddhq_match/parallel_production_matcher.py
@@ -481,7 +481,6 @@ Be extremely conservative - false positives are worse than false negatives. If u
 OUTPUT JSON ONLY (no explanation, no markdown):"""
 
         result = build_cached_prompt(self._prompt_name, variables, fallback_prompt=fallback)
-        self.logger.info("Resulting prompt: %s", result)  # remove after testing
         return result if result else fallback
 
     def _search_similar_candidates(self, hubspot_record: Dict, k: int = 5) -> tuple[List[Dict[str, Any]], str]:

--- a/hubspot_ddhq_match/parallel_production_matcher.py
+++ b/hubspot_ddhq_match/parallel_production_matcher.py
@@ -33,6 +33,7 @@ from shared.braintrust import (
     init_braintrust,
     cache_prompt,
     build_cached_prompt,
+    flush_logs,
 )
 from shared.llm_gemini_3 import Gemini3Client, GeminiModelType, ThinkingLevel
 from shared.logger import get_logger
@@ -1460,6 +1461,9 @@ async def main():
 
         matcher.logger.info(f"\n🎉 Parallel matching complete! Results saved to {results_file}")
 
+        # Flush Braintrust logs before exit (os._exit bypasses cleanup handlers)
+        flush_logs()
+
         # Force immediate exit - all work is done, files saved
         matcher.logger.info("💥 Forcing immediate exit to allow S3 upload to proceed...")
         os._exit(0)
@@ -1467,6 +1471,7 @@ async def main():
     except Exception as e:
         matcher.logger.error(f"❌ Pipeline failed: {e}")
         matcher.logger.error(f"Stack trace:", exc_info=True)
+        flush_logs()
         os._exit(1)
 
 if __name__ == "__main__":

--- a/hubspot_ddhq_match/parallel_production_matcher.py
+++ b/hubspot_ddhq_match/parallel_production_matcher.py
@@ -34,10 +34,7 @@ from shared.braintrust import (
     cache_prompt,
     build_cached_prompt,
 )
-from shared.llm_gemini import GeminiClient, GeminiModelType
-=======
 from shared.llm_gemini_3 import Gemini3Client, GeminiModelType, ThinkingLevel
->>>>>>> develop
 from shared.logger import get_logger
 
 class ParallelProductionMatcher:
@@ -365,15 +362,16 @@ class ParallelProductionMatcher:
         self.logger.info("🤖 Initializing Gemini LLM...")
         # Configure for HIGH THROUGHPUT with reliability (reduced from 1200 to avoid API corruption)
         target_concurrency = 500  # Balanced for throughput + reliability (~5k/min target)
-        self.llm_client = GeminiClient(
-            default_model=GeminiModelType.FLASH,
+        self.llm_client = Gemini3Client(
+            default_model=GeminiModelType.FLASH_3,
             default_temperature=0.0,
+            thinking_level=ThinkingLevel.MINIMAL,
             max_connections=target_concurrency,
-            max_keepalive_connections=target_concurrency // 4,  # 125 keepalive
-            max_retries=9,  # Handle all retries in LLM client (no outer retry loop)
-            base_delay=1.0  # Exponential backoff starting at 1 second
+            max_keepalive_connections=target_concurrency // 4,
+            max_retries=9,
+            base_delay=1.0
         )
-        self.logger.info(f"   Gemini Flash initialized with {target_concurrency} max connections, 9 retries (HIGH THROUGHPUT with reliability)")
+        self.logger.info(f"   Gemini 3 Flash initialized with {target_concurrency} max connections, 9 retries (HIGH THROUGHPUT with reliability)")
 
         environment = os.getenv("ENVIRONMENT", "local")
         self.logger.info(f"Braintrust environment: {environment}")
@@ -758,7 +756,7 @@ Match {i}:
 
         try:
             # Use dedicated thread pool for maximum LLM concurrency
-            # Retries are handled internally by GeminiClient (max_retries=9)
+            # Retries are handled internally by Gemini3Client (max_retries=9)
             llm_call_start = time.time()
 
             # Hard timeout to prevent infinite hangs (even if HTTP client stalls)

--- a/hubspot_ddhq_match/parallel_production_matcher.py
+++ b/hubspot_ddhq_match/parallel_production_matcher.py
@@ -478,14 +478,8 @@ MATCHING RULES:
 Be extremely conservative - false positives are worse than false negatives. If uncertain, REJECT.
 
 OUTPUT JSON ONLY (no explanation, no markdown):"""
-        print(candidates_text)
+
         result = build_cached_prompt(self._prompt_name, variables, fallback_prompt=fallback)
-        if candidates_text is None or candidates_text in ('', ' '):
-            print("candidates_text is None or candidates_text in ('', ' ')")
-            print(candidates_text)
-        else:
-            print("candidates_text is not None or candidates_text not in ('', ' ')")
-            print(candidates_text)
         return result if result else fallback
 
     def _search_similar_candidates(self, hubspot_record: Dict, k: int = 5) -> tuple[List[Dict[str, Any]], str]:

--- a/hubspot_ddhq_match/parallel_production_matcher.py
+++ b/hubspot_ddhq_match/parallel_production_matcher.py
@@ -480,6 +480,7 @@ Be extremely conservative - false positives are worse than false negatives. If u
 OUTPUT JSON ONLY (no explanation, no markdown):"""
 
         result = build_cached_prompt(self._prompt_name, variables, fallback_prompt=fallback)
+        self.logger.info("Resulting prompt: %s", result)  # remove after testing
         return result if result else fallback
 
     def _search_similar_candidates(self, hubspot_record: Dict, k: int = 5) -> tuple[List[Dict[str, Any]], str]:

--- a/hubspot_ddhq_match/parallel_production_matcher.py
+++ b/hubspot_ddhq_match/parallel_production_matcher.py
@@ -478,8 +478,14 @@ MATCHING RULES:
 Be extremely conservative - false positives are worse than false negatives. If uncertain, REJECT.
 
 OUTPUT JSON ONLY (no explanation, no markdown):"""
-
+        print(candidates_text)
         result = build_cached_prompt(self._prompt_name, variables, fallback_prompt=fallback)
+        if candidates_text is None or candidates_text in ('', ' '):
+            print("candidates_text is None or candidates_text in ('', ' ')")
+            print(candidates_text)
+        else:
+            print("candidates_text is not None or candidates_text not in ('', ' ')")
+            print(candidates_text)
         return result if result else fallback
 
     def _search_similar_candidates(self, hubspot_record: Dict, k: int = 5) -> tuple[List[Dict[str, Any]], str]:

--- a/infrastructure/modules/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/modules/ddhq-matcher-fargate/main.tf
@@ -318,6 +318,10 @@ resource "aws_ecs_task_definition" "matcher" {
         {
           name      = "DATABRICKS_SCHEMA"
           valueFrom = "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:AI_SECRETS_${upper(var.environment)}:DATABRICKS_SCHEMA::"
+        },
+        {
+          name      = "BRAINTRUST_API_KEY"
+          valueFrom = "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:AI_SECRETS_${upper(var.environment)}:BRAINTRUST_API_KEY::"
         }
       ]
 

--- a/shared/braintrust.py
+++ b/shared/braintrust.py
@@ -202,6 +202,16 @@ class BraintrustClient:
             logger.warning(f"Prompt template missing variable: {e}")
             return prompt
         except ValueError as e:
+            # If ValueError is due to invalid format syntax (like literal JSON braces from
+            # an already-interpolated f-string), the string is likely already interpolated.
+            # Return silently without warning to avoid spurious log entries.
+            error_msg = str(e).lower()
+            if any(phrase in error_msg for phrase in [
+                "single '}'", "unmatched", "invalid format", "expected ':'", 
+                "unexpected end of format string"
+            ]):
+                # String appears to be already interpolated (e.g., f-string fallback)
+                return prompt
             logger.warning(f"Prompt template format error: {e}")
             return prompt
 

--- a/shared/braintrust.py
+++ b/shared/braintrust.py
@@ -245,7 +245,7 @@ class BraintrustClient:
                 )
 
                 if prompt_obj is None:
-                    logger.warning(f"Prompt '{prompt_name}' not found in Braintrust")
+                    logger.warning(f"Prompt '{prompt_name}' not found in Braintrust project '{self._project}'")
                     self._cached_prompts[cache_key] = None
                     return None
 

--- a/shared/braintrust.py
+++ b/shared/braintrust.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import re
 import threading
 from typing import Optional, Dict, Any, Callable, TypeVar
 
@@ -196,23 +197,28 @@ class BraintrustClient:
         if not variables:
             return prompt
 
+        # Use a safer formatting approach that only replaces variables that exist
+        # This handles cases where the template has example placeholders like {best_match}
+        # that aren't meant to be replaced. Also handles escaped braces {{ and }}
+        def safe_format(match):
+            # Check if this is an escaped brace ({{ or }})
+            full_match = match.group(0)
+            if full_match == '{{' or full_match == '}}':
+                return full_match  # Keep escaped braces as-is
+            
+            var_name = match.group(1)
+            if var_name in variables:
+                return str(variables[var_name])
+            # Keep the original placeholder if variable doesn't exist
+            return match.group(0)
+
         try:
-            return prompt.format(**variables)
-        except KeyError as e:
-            logger.warning(f"Prompt template missing variable: {e}")
-            return prompt
-        except ValueError as e:
-            # If ValueError is due to invalid format syntax (like literal JSON braces from
-            # an already-interpolated f-string), the string is likely already interpolated.
-            # Return silently without warning to avoid spurious log entries.
-            error_msg = str(e).lower()
-            if any(phrase in error_msg for phrase in [
-                "single '}'", "unmatched", "invalid format", "expected ':'", 
-                "unexpected end of format string"
-            ]):
-                # String appears to be already interpolated (e.g., f-string fallback)
-                return prompt
-            logger.warning(f"Prompt template format error: {e}")
+            # Match {variable_name} but skip {{ and }} (escaped braces)
+            # This regex matches single braces with variable names, but not double braces
+            result = re.sub(r'(?<!\{)\{([a-zA-Z_][a-zA-Z0-9_]*)\}(?!\})', safe_format, prompt)
+            return result
+        except Exception as e:
+            logger.debug(f"Prompt template format error (non-critical): {e}")
             return prompt
 
     def get_cached_prompt_object(

--- a/shared/braintrust.py
+++ b/shared/braintrust.py
@@ -199,13 +199,8 @@ class BraintrustClient:
 
         # Use a safer formatting approach that only replaces variables that exist
         # This handles cases where the template has example placeholders like {best_match}
-        # that aren't meant to be replaced. Also handles escaped braces {{ and }}
+        # that aren't meant to be replaced
         def safe_format(match):
-            # Check if this is an escaped brace ({{ or }})
-            full_match = match.group(0)
-            if full_match == '{{' or full_match == '}}':
-                return full_match  # Keep escaped braces as-is
-            
             var_name = match.group(1)
             if var_name in variables:
                 return str(variables[var_name])
@@ -280,14 +275,14 @@ class BraintrustClient:
                     if messages and isinstance(messages[0], dict):
                         return messages[0].get('content', '')
                     elif messages and hasattr(messages[0], 'content'):
-                        return messages[0].content
+                        return str(messages[0].content) if messages[0].content is not None else ''
 
                 if hasattr(rendered, 'messages') and rendered.messages:
                     msg = rendered.messages[0]
                     if isinstance(msg, dict):
                         return msg.get('content', '')
                     elif hasattr(msg, 'content'):
-                        return str(msg.content)
+                        return str(msg.content) if msg.content is not None else ''
 
                 return str(rendered)
 

--- a/shared/braintrust.py
+++ b/shared/braintrust.py
@@ -24,6 +24,8 @@ class BraintrustClient:
         self._enabled = False
         self._project: Optional[str] = None
         self._initialized = False
+        self._cached_prompts: Dict[str, Any] = {}
+        self._prompt_cache_lock = threading.Lock()
 
     @classmethod
     def get_instance(cls) -> 'BraintrustClient':
@@ -50,6 +52,7 @@ class BraintrustClient:
         self._braintrust_module = None
         self._enabled = False
         self._initialized = False
+        self._cached_prompts = {}
 
     def init(self, project: str, api_key: Optional[str] = None) -> bool:
         if self._initialized:
@@ -202,6 +205,84 @@ class BraintrustClient:
             logger.warning(f"Prompt template format error: {e}")
             return prompt
 
+    def get_cached_prompt_object(
+        self,
+        prompt_name: str,
+        warmup_variables: Optional[Dict[str, Any]] = None
+    ) -> Optional[Any]:
+        if not self._enabled or self._braintrust_module is None:
+            return None
+
+        cache_key = f"{self._project}:{prompt_name}"
+
+        if cache_key in self._cached_prompts:
+            return self._cached_prompts[cache_key]
+
+        with self._prompt_cache_lock:
+            if cache_key in self._cached_prompts:
+                return self._cached_prompts[cache_key]
+
+            try:
+                prompt_obj = self._braintrust_module.load_prompt(
+                    project=self._project,
+                    slug=prompt_name
+                )
+
+                if prompt_obj is None:
+                    logger.warning(f"Prompt '{prompt_name}' not found in Braintrust")
+                    self._cached_prompts[cache_key] = None
+                    return None
+
+                if warmup_variables:
+                    _ = prompt_obj.build(**warmup_variables)
+                    logger.debug(f"Prompt '{prompt_name}' cached and warmed up")
+                else:
+                    logger.debug(f"Prompt '{prompt_name}' cached (no warmup)")
+
+                self._cached_prompts[cache_key] = prompt_obj
+                return prompt_obj
+
+            except Exception as e:
+                logger.warning(f"Failed to cache prompt '{prompt_name}': {e}")
+                self._cached_prompts[cache_key] = None
+                return None
+
+    def build_cached_prompt(
+        self,
+        prompt_name: str,
+        variables: Dict[str, Any],
+        fallback_prompt: Optional[str] = None
+    ) -> str:
+        prompt_obj = self._cached_prompts.get(f"{self._project}:{prompt_name}")
+
+        if prompt_obj is not None:
+            try:
+                rendered = prompt_obj.build(**variables)
+
+                if isinstance(rendered, dict) and 'messages' in rendered:
+                    messages = rendered['messages']
+                    if messages and isinstance(messages[0], dict):
+                        return messages[0].get('content', '')
+                    elif messages and hasattr(messages[0], 'content'):
+                        return messages[0].content
+
+                if hasattr(rendered, 'messages') and rendered.messages:
+                    msg = rendered.messages[0]
+                    if isinstance(msg, dict):
+                        return msg.get('content', '')
+                    elif hasattr(msg, 'content'):
+                        return str(msg.content)
+
+                return str(rendered)
+
+            except Exception as e:
+                logger.debug(f"Braintrust build failed for '{prompt_name}': {e}")
+
+        if fallback_prompt:
+            return self._render_prompt(fallback_prompt, variables)
+
+        return ""
+
     def flush(self) -> None:
         if self._braintrust_logger is not None:
             try:
@@ -251,3 +332,18 @@ def is_enabled() -> bool:
 
 def get_client() -> BraintrustClient:
     return BraintrustClient.get_instance()
+
+
+def cache_prompt(
+    prompt_name: str,
+    warmup_variables: Optional[Dict[str, Any]] = None
+) -> Optional[Any]:
+    return BraintrustClient.get_instance().get_cached_prompt_object(prompt_name, warmup_variables)
+
+
+def build_cached_prompt(
+    prompt_name: str,
+    variables: Dict[str, Any],
+    fallback_prompt: Optional[str] = None
+) -> str:
+    return BraintrustClient.get_instance().build_cached_prompt(prompt_name, variables, fallback_prompt)

--- a/shared/docs/braintrust.md
+++ b/shared/docs/braintrust.md
@@ -25,6 +25,7 @@ Each folder in gp-ai-projects maps to a Braintrust project. Pass the project nam
 | `serve/hierarchical_discovery` | `hierarchical-discovery` |
 | `ai_generated_campaign_plan` | `campaign-plan` |
 | `serve/analyze_texts` | `analyze-texts` |
+| `hubspot_ddhq_match` | `hubspot-ddhq-match` |
 
 ## Usage
 


### PR DESCRIPTION
To test, I made a call against the braintrust prompt in `hubspot-ddhq-match.hubspot-ddhq-match-validator` against the fallback and confirmed that after string substitution the results are identical.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new external dependency/config (Braintrust API key) and changes how LLM prompts are constructed and traced, which can affect matching behavior and production observability if misconfigured.
> 
> **Overview**
> The matcher now initializes Braintrust (`init_braintrust`) and replaces the inline LLM validation prompt with a Braintrust-managed template that is cached once at startup and rendered per request via `cache_prompt`/`build_cached_prompt`, with a local fallback prompt when Braintrust is unavailable.
> 
> LLM calls are updated to pass a `trace_name` for observability and the pipeline now explicitly calls `flush_logs()` before `os._exit` in both success and failure paths. Infrastructure is updated to provide `BRAINTRUST_API_KEY` to the ECS task, and Braintrust docs are updated to include the `hubspot-ddhq-match` project mapping. Additionally, `shared/braintrust.py` gains prompt-object caching and safer template variable substitution to avoid formatting errors from unmatched placeholders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b973b824ed7c65481015620bbc95c6b22444e691. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->