### PR TITLE
Add Gemini 3 model support with ThinkingLevel configuration

### DIFF
--- a/hubspot_ddhq_match/parallel_production_matcher.py
+++ b/hubspot_ddhq_match/parallel_production_matcher.py
@@ -29,7 +29,7 @@ from tqdm.asyncio import tqdm
 from concurrent.futures import ThreadPoolExecutor
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
-from shared.llm_gemini import GeminiClient, GeminiModelType
+from shared.llm_gemini_3 import Gemini3Client, GeminiModelType, ThinkingLevel
 from shared.logger import get_logger
 
 class ParallelProductionMatcher:
@@ -357,15 +357,16 @@ class ParallelProductionMatcher:
         self.logger.info("🤖 Initializing Gemini LLM...")
         # Configure for HIGH THROUGHPUT with reliability (reduced from 1200 to avoid API corruption)
         target_concurrency = 500  # Balanced for throughput + reliability (~5k/min target)
-        self.llm_client = GeminiClient(
-            default_model=GeminiModelType.FLASH,
+        self.llm_client = Gemini3Client(
+            default_model=GeminiModelType.FLASH_3,
             default_temperature=0.0,
+            thinking_level=ThinkingLevel.MINIMAL,
             max_connections=target_concurrency,
-            max_keepalive_connections=target_concurrency // 4,  # 125 keepalive
-            max_retries=9,  # Handle all retries in LLM client (no outer retry loop)
-            base_delay=1.0  # Exponential backoff starting at 1 second
+            max_keepalive_connections=target_concurrency // 4,
+            max_retries=9,
+            base_delay=1.0
         )
-        self.logger.info(f"   Gemini Flash initialized with {target_concurrency} max connections, 9 retries (HIGH THROUGHPUT with reliability)")
+        self.logger.info(f"   Gemini 3 Flash initialized with {target_concurrency} max connections, 9 retries (HIGH THROUGHPUT with reliability)")
 
     def _search_similar_candidates(self, hubspot_record: Dict, k: int = 5) -> tuple[List[Dict[str, Any]], str]:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "fastapi>=0.116.0",
     "uvicorn>=0.35.0",
     "reportlab>=4.4.2",
-    "google-genai>=1.24.0",
+    "google-genai>=1.56.0",
     "databricks-sql-connector>=4.0.5",
     "pandas>=2.2.3",
     "pyarrow>=21.0.0",
@@ -93,5 +93,6 @@ ignore_missing_imports = true
 [dependency-groups]
 dev = [
     "pre-commit>=4.3.0",
+    "pytest>=8.4.2",
     "types-pyyaml>=6.0.12.20250915",
 ]

--- a/shared/llm_gemini_3.py
+++ b/shared/llm_gemini_3.py
@@ -96,7 +96,7 @@ class Gemini3Client:
             raise ValueError("PRO_3 model does not support MINIMAL thinking level. Use LOW, MEDIUM, or HIGH instead.")
 
         return types.GenerateContentConfig(
-            temperature=temperature or self.default_temperature,
+            temperature=temperature if temperature is not None else self.default_temperature,
             thinking_config=types.ThinkingConfig(
                 thinking_level=level.value,
                 include_thoughts=thoughts
@@ -142,7 +142,7 @@ class Gemini3Client:
             prompt=prompt,
             metadata={
                 "model": model_name,
-                "temperature": temperature or self.default_temperature,
+                "temperature": temperature if temperature is not None else self.default_temperature,
                 "environment": environment
             }
         )

--- a/shared/llm_gemini_3.py
+++ b/shared/llm_gemini_3.py
@@ -1,0 +1,367 @@
+import os
+import json
+import time
+from typing import Optional, Type, Union, List, Dict, Any
+from enum import Enum
+from pydantic import BaseModel
+from dotenv import load_dotenv
+import httpx
+from google import genai
+from google.genai import types
+from shared.logger import get_logger
+from shared.braintrust import is_enabled as braintrust_enabled, get_client as get_braintrust_client
+
+load_dotenv()
+
+GEMINI_3_PRICING = {
+    'gemini-3-flash-preview': {'input': 0.50, 'output': 3.00},
+    'gemini-3-pro-preview': {'input': 2.50, 'output': 15.00},
+}
+
+
+class GeminiModelType(Enum):
+    FLASH_3 = "gemini-3-flash-preview"
+    PRO_3 = "gemini-3-pro-preview"
+
+
+class ThinkingLevel(Enum):
+    MINIMAL = "minimal"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class Gemini3Client:
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        default_model: GeminiModelType = GeminiModelType.FLASH_3,
+        default_temperature: float = 0.7,
+        thinking_level: ThinkingLevel = ThinkingLevel.MINIMAL,
+        include_thoughts: bool = False,
+        max_connections: int = 100,
+        max_keepalive_connections: int = 20,
+        max_retries: int = 3,
+        base_delay: float = 1.0
+    ):
+        self.api_key = api_key or os.getenv("GEMINI_API_KEY")
+        if not self.api_key:
+            raise ValueError("GEMINI_API_KEY is required")
+
+        self.default_model = default_model
+        self.default_temperature = default_temperature
+        self.thinking_level = thinking_level
+        self.include_thoughts = include_thoughts
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+
+        http_options = types.HttpOptions(
+            client_args={
+                "limits": httpx.Limits(
+                    max_connections=max_connections,
+                    max_keepalive_connections=max_keepalive_connections
+                ),
+                "timeout": httpx.Timeout(connect=10.0, read=120.0, write=30.0, pool=10.0)
+            },
+            async_client_args={
+                "limits": httpx.Limits(
+                    max_connections=max_connections,
+                    max_keepalive_connections=max_keepalive_connections
+                ),
+                "timeout": httpx.Timeout(connect=10.0, read=120.0, write=30.0, pool=10.0)
+            }
+        )
+
+        self.client = genai.Client(api_key=self.api_key, http_options=http_options)
+        self.logger = get_logger(__name__)
+
+        self.total_prompt_tokens = 0
+        self.total_completion_tokens = 0
+        self.total_cost = 0.0
+        self.api_call_count = 0
+
+        self.logger.info(f"Gemini3Client initialized: model={default_model.value}, thinking={thinking_level.value}, connections={max_connections}")
+
+    def _build_config(
+        self,
+        model: GeminiModelType,
+        temperature: Optional[float] = None,
+        thinking_level: Optional[ThinkingLevel] = None,
+        include_thoughts: Optional[bool] = None
+    ) -> types.GenerateContentConfig:
+        level = thinking_level or self.thinking_level
+        thoughts = include_thoughts if include_thoughts is not None else self.include_thoughts
+
+        if model == GeminiModelType.PRO_3 and level == ThinkingLevel.MINIMAL:
+            raise ValueError("PRO_3 model does not support MINIMAL thinking level. Use LOW, MEDIUM, or HIGH instead.")
+
+        return types.GenerateContentConfig(
+            temperature=temperature or self.default_temperature,
+            thinking_config=types.ThinkingConfig(
+                thinking_level=level.value,
+                include_thoughts=thoughts
+            )
+        )
+
+    def _calculate_cost(self, model_name: str, prompt_tokens: int, completion_tokens: int) -> float:
+        pricing = GEMINI_3_PRICING.get(model_name, GEMINI_3_PRICING['gemini-3-flash-preview'])
+        input_cost = (prompt_tokens / 1_000_000) * pricing['input']
+        output_cost = (completion_tokens / 1_000_000) * pricing['output']
+        return input_cost + output_cost
+
+    def _update_usage(self, model_name: str, response):
+        if hasattr(response, 'usage_metadata') and response.usage_metadata:
+            usage = response.usage_metadata
+            prompt_tokens = getattr(usage, 'prompt_token_count', 0) or 0
+            completion_tokens = getattr(usage, 'candidates_token_count', 0) or 0
+
+            self.total_prompt_tokens += prompt_tokens
+            self.total_completion_tokens += completion_tokens
+            self.total_cost += self._calculate_cost(model_name, prompt_tokens, completion_tokens)
+
+        self.api_call_count += 1
+
+    def _traced_call(
+        self,
+        trace_name: Optional[str],
+        prompt: str,
+        llm_fn,
+        model_name: str,
+        default_trace_name: str,
+        temperature: Optional[float] = None
+    ):
+        if not braintrust_enabled():
+            return llm_fn()
+
+        name = trace_name or default_trace_name
+        environment = os.getenv("ENVIRONMENT", "local")
+        return get_braintrust_client().traced_call(
+            name=name,
+            input_data={"prompt": prompt},
+            llm_call_fn=llm_fn,
+            prompt=prompt,
+            metadata={
+                "model": model_name,
+                "temperature": temperature or self.default_temperature,
+                "environment": environment
+            }
+        )
+
+    def generate_structured_content(
+        self,
+        prompt: str,
+        response_schema: Type[BaseModel],
+        model: Optional[GeminiModelType] = None,
+        temperature: Optional[float] = None,
+        thinking_level: Optional[ThinkingLevel] = None,
+        system_instruction: Optional[str] = None,
+        trace_name: Optional[str] = None
+    ) -> Union[BaseModel, List[BaseModel], Dict[str, Any]]:
+        effective_model = model or self.default_model
+        model_name = effective_model.value
+        config = self._build_config(effective_model, temperature, thinking_level)
+        config.response_mime_type = "application/json"
+        config.response_schema = response_schema
+
+        if system_instruction:
+            config.system_instruction = system_instruction
+
+        def _execute_call():
+            for attempt in range(self.max_retries):
+                try:
+                    response = self.client.models.generate_content(
+                        model=model_name,
+                        contents=prompt,
+                        config=config
+                    )
+                    self._update_usage(model_name, response)
+
+                    if response.text:
+                        data = json.loads(response.text)
+                        if isinstance(data, list):
+                            return [response_schema(**item) for item in data]
+                        return response_schema(**data)
+
+                    raise ValueError("Empty response from API")
+
+                except Exception as e:
+                    if attempt < self.max_retries - 1:
+                        delay = self.base_delay * (2 ** attempt)
+                        self.logger.warning(f"Attempt {attempt + 1} failed: {e}. Retrying in {delay}s")
+                        time.sleep(delay)
+                    else:
+                        self.logger.error(f"All {self.max_retries} attempts failed: {e}")
+                        raise
+
+        return self._traced_call(
+            trace_name=trace_name,
+            prompt=prompt,
+            llm_fn=_execute_call,
+            model_name=model_name,
+            default_trace_name="generate_structured_content",
+            temperature=temperature
+        )
+
+    def generate_content(
+        self,
+        prompt: str,
+        model: Optional[GeminiModelType] = None,
+        temperature: Optional[float] = None,
+        thinking_level: Optional[ThinkingLevel] = None,
+        system_instruction: Optional[str] = None,
+        trace_name: Optional[str] = None
+    ) -> str:
+        effective_model = model or self.default_model
+        model_name = effective_model.value
+        config = self._build_config(effective_model, temperature, thinking_level)
+
+        if system_instruction:
+            config.system_instruction = system_instruction
+
+        def _execute_call():
+            for attempt in range(self.max_retries):
+                try:
+                    response = self.client.models.generate_content(
+                        model=model_name,
+                        contents=prompt,
+                        config=config
+                    )
+                    self._update_usage(model_name, response)
+
+                    if response.text:
+                        return response.text
+
+                    raise ValueError("Empty response from API")
+
+                except Exception as e:
+                    if attempt < self.max_retries - 1:
+                        delay = self.base_delay * (2 ** attempt)
+                        self.logger.warning(f"Attempt {attempt + 1} failed: {e}. Retrying in {delay}s")
+                        time.sleep(delay)
+                    else:
+                        self.logger.error(f"All {self.max_retries} attempts failed: {e}")
+                        raise
+
+        return self._traced_call(
+            trace_name=trace_name,
+            prompt=prompt,
+            llm_fn=_execute_call,
+            model_name=model_name,
+            default_trace_name="generate_content",
+            temperature=temperature
+        )
+
+    def get_usage_stats(self) -> Dict[str, Any]:
+        return {
+            "api_calls": self.api_call_count,
+            "prompt_tokens": self.total_prompt_tokens,
+            "completion_tokens": self.total_completion_tokens,
+            "total_cost": self.total_cost
+        }
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Gemini 3 Client Integration Tests")
+    print("=" * 60)
+
+    client = Gemini3Client(thinking_level=ThinkingLevel.MINIMAL)
+
+    print("\n1. Testing generate_content (simple text)...")
+    try:
+        result = client.generate_content(
+            prompt="Say 'hello world' and nothing else."
+        )
+        print(f"   Response: {result}")
+        assert "hello" in result.lower(), "Expected 'hello' in response"
+        print("   PASSED")
+    except Exception as e:
+        print(f"   FAILED: {e}")
+
+    print("\n2. Testing generate_content with different thinking levels...")
+    for level in ThinkingLevel:
+        try:
+            test_client = Gemini3Client(thinking_level=level)
+            result = test_client.generate_content(
+                prompt=f"What is 2+2? Just say the number."
+            )
+            print(f"   {level.value}: {result.strip()}")
+        except Exception as e:
+            print(f"   {level.value}: FAILED - {e}")
+
+    print("\n3. Testing generate_structured_content (JSON schema)...")
+
+    class MathResponse(BaseModel):
+        answer: int
+        explanation: str
+
+    try:
+        result = client.generate_structured_content(
+            prompt="What is 15 + 27? Provide the answer and a brief explanation.",
+            response_schema=MathResponse
+        )
+        print(f"   Answer: {result.answer}")
+        print(f"   Explanation: {result.explanation}")
+        assert result.answer == 42, f"Expected 42, got {result.answer}"
+        print("   PASSED")
+    except Exception as e:
+        print(f"   FAILED: {e}")
+
+    print("\n4. Testing generate_structured_content (list response)...")
+
+    class Item(BaseModel):
+        name: str
+        category: str
+
+    try:
+        result = client.generate_structured_content(
+            prompt="List 3 fruits with their category. Return as a JSON array.",
+            response_schema=Item
+        )
+        if isinstance(result, list):
+            print(f"   Got {len(result)} items:")
+            for item in result:
+                print(f"      - {item.name} ({item.category})")
+            print("   PASSED")
+        else:
+            print(f"   Got single item: {result}")
+            print("   PASSED (single item)")
+    except Exception as e:
+        print(f"   FAILED: {e}")
+
+    print("\n5. Testing system instruction...")
+    try:
+        result = client.generate_content(
+            prompt="What is your name?",
+            system_instruction="You are a helpful assistant named Bob. Always mention your name in responses."
+        )
+        print(f"   Response: {result}")
+        assert "bob" in result.lower(), "Expected 'Bob' in response"
+        print("   PASSED")
+    except Exception as e:
+        print(f"   FAILED: {e}")
+
+    print("\n6. Testing PRO_3 model (note: PRO_3 doesn't support MINIMAL, using LOW)...")
+    try:
+        pro_client = Gemini3Client(
+            default_model=GeminiModelType.PRO_3,
+            thinking_level=ThinkingLevel.LOW
+        )
+        result = pro_client.generate_content(
+            prompt="What is the capital of France? One word answer."
+        )
+        print(f"   Response: {result}")
+        assert "paris" in result.lower(), "Expected 'Paris' in response"
+        print("   PASSED")
+    except Exception as e:
+        print(f"   FAILED: {e}")
+
+    print("\n" + "=" * 60)
+    print("Usage Statistics")
+    print("=" * 60)
+    stats = client.get_usage_stats()
+    print(f"   API calls: {stats['api_calls']}")
+    print(f"   Prompt tokens: {stats['prompt_tokens']}")
+    print(f"   Completion tokens: {stats['completion_tokens']}")
+    print(f"   Total cost: ${stats['total_cost']:.6f}")
+    print("\nIntegration tests complete!")

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.11"
 dependencies = [
     "python-dotenv>=1.1.1",
     "pydantic>=2.0.0",
-    "google-genai>=1.24.0",
+    "google-genai>=1.56.0",
     "braintrust>=0.3.10",
     "httpx>=0.28.1",
     "numpy>=2.3.1",

--- a/shared/tests/test_llm_gemini_3.py
+++ b/shared/tests/test_llm_gemini_3.py
@@ -1,0 +1,665 @@
+import pytest
+from unittest.mock import Mock, patch
+from pydantic import BaseModel
+
+from shared.llm_gemini_3 import (
+    Gemini3Client,
+    GeminiModelType,
+    ThinkingLevel,
+    GEMINI_3_PRICING,
+)
+
+
+class TestEnums:
+    def test_model_types(self):
+        assert GeminiModelType.FLASH_3.value == "gemini-3-flash-preview"
+        assert GeminiModelType.PRO_3.value == "gemini-3-pro-preview"
+
+    def test_thinking_levels(self):
+        assert ThinkingLevel.MINIMAL.value == "minimal"
+        assert ThinkingLevel.LOW.value == "low"
+        assert ThinkingLevel.MEDIUM.value == "medium"
+        assert ThinkingLevel.HIGH.value == "high"
+
+
+class TestPricing:
+    def test_flash_3_pricing(self):
+        pricing = GEMINI_3_PRICING['gemini-3-flash-preview']
+        assert pricing['input'] == 0.50
+        assert pricing['output'] == 3.00
+
+    def test_pro_3_pricing(self):
+        pricing = GEMINI_3_PRICING['gemini-3-pro-preview']
+        assert pricing['input'] == 2.50
+        assert pricing['output'] == 15.00
+
+
+class TestGemini3ClientInit:
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_default_init(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        assert client.default_model == GeminiModelType.FLASH_3
+        assert client.default_temperature == 0.7
+        assert client.thinking_level == ThinkingLevel.MINIMAL
+        assert client.include_thoughts is False
+        assert client.max_retries == 3
+        assert client.api_call_count == 0
+        assert client.total_cost == 0.0
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_custom_init(self, _mock_genai):
+        client = Gemini3Client(
+            api_key="test-key",
+            default_model=GeminiModelType.PRO_3,
+            default_temperature=0.5,
+            thinking_level=ThinkingLevel.HIGH,
+            include_thoughts=True,
+            max_retries=5
+        )
+
+        assert client.default_model == GeminiModelType.PRO_3
+        assert client.default_temperature == 0.5
+        assert client.thinking_level == ThinkingLevel.HIGH
+        assert client.include_thoughts is True
+        assert client.max_retries == 5
+
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="GEMINI_API_KEY is required"):
+            Gemini3Client(api_key=None)
+
+
+class TestBuildConfig:
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_default_config(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+        config = client._build_config(GeminiModelType.FLASH_3)
+
+        assert config.temperature == 0.7
+        assert "minimal" in str(config.thinking_config.thinking_level).lower()
+        assert config.thinking_config.include_thoughts is False
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_override_thinking_level(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+        config = client._build_config(GeminiModelType.FLASH_3, thinking_level=ThinkingLevel.HIGH)
+
+        assert "high" in str(config.thinking_config.thinking_level).lower()
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_override_temperature(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+        config = client._build_config(GeminiModelType.FLASH_3, temperature=0.3)
+
+        assert config.temperature == 0.3
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_override_include_thoughts(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+        config = client._build_config(GeminiModelType.FLASH_3, include_thoughts=True)
+
+        assert config.thinking_config.include_thoughts is True
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_pro3_minimal_raises_error(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key", thinking_level=ThinkingLevel.MINIMAL)
+
+        with pytest.raises(ValueError, match="PRO_3 model does not support MINIMAL"):
+            client._build_config(GeminiModelType.PRO_3)
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_pro3_low_works(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key", thinking_level=ThinkingLevel.LOW)
+        config = client._build_config(GeminiModelType.PRO_3)
+
+        assert "low" in str(config.thinking_config.thinking_level).lower()
+
+
+class TestCostCalculation:
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_flash_cost_per_million(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+        cost = client._calculate_cost("gemini-3-flash-preview", 1_000_000, 1_000_000)
+
+        assert cost == 0.50 + 3.00
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_pro_cost_per_million(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+        cost = client._calculate_cost("gemini-3-pro-preview", 1_000_000, 1_000_000)
+
+        assert cost == 2.50 + 15.00
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_small_token_cost(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+        cost = client._calculate_cost("gemini-3-flash-preview", 1000, 500)
+
+        expected = (1000 / 1_000_000) * 0.50 + (500 / 1_000_000) * 3.00
+        assert abs(cost - expected) < 0.0001
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_unknown_model_defaults_to_flash(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+        cost = client._calculate_cost("unknown-model", 1_000_000, 1_000_000)
+
+        assert cost == 0.50 + 3.00
+
+
+class TestUsageTracking:
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_update_usage_tracks_tokens(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = Mock()
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 100
+        mock_response.usage_metadata.candidates_token_count = 50
+
+        client._update_usage("gemini-3-flash-preview", mock_response)
+
+        assert client.api_call_count == 1
+        assert client.total_prompt_tokens == 100
+        assert client.total_completion_tokens == 50
+        assert client.total_cost > 0
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_update_usage_handles_missing_metadata(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = Mock()
+        mock_response.usage_metadata = None
+
+        client._update_usage("gemini-3-flash-preview", mock_response)
+
+        assert client.api_call_count == 1
+        assert client.total_prompt_tokens == 0
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_get_usage_stats(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+        client.api_call_count = 10
+        client.total_prompt_tokens = 5000
+        client.total_completion_tokens = 2000
+        client.total_cost = 0.05
+
+        stats = client.get_usage_stats()
+
+        assert stats["api_calls"] == 10
+        assert stats["prompt_tokens"] == 5000
+        assert stats["completion_tokens"] == 2000
+        assert stats["total_cost"] == 0.05
+
+
+class SampleResponse(BaseModel):
+    answer: str
+    confidence: float
+
+
+class TestGenerateStructuredContent:
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_returns_pydantic_model(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = Mock()
+        mock_response.text = '{"answer": "test answer", "confidence": 0.95}'
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 100
+        mock_response.usage_metadata.candidates_token_count = 50
+
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        result = client.generate_structured_content(
+            prompt="Test prompt",
+            response_schema=SampleResponse
+        )
+
+        assert isinstance(result, SampleResponse)
+        assert result.answer == "test answer"
+        assert result.confidence == 0.95
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_returns_list_of_models(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = Mock()
+        mock_response.text = '[{"answer": "a1", "confidence": 0.9}, {"answer": "a2", "confidence": 0.8}]'
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 100
+        mock_response.usage_metadata.candidates_token_count = 50
+
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        result = client.generate_structured_content(
+            prompt="Test prompt",
+            response_schema=SampleResponse
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0].answer == "a1"
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_passes_system_instruction(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = Mock()
+        mock_response.text = '{"answer": "test", "confidence": 0.9}'
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 100
+        mock_response.usage_metadata.candidates_token_count = 50
+
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        client.generate_structured_content(
+            prompt="Test",
+            response_schema=SampleResponse,
+            system_instruction="Be helpful"
+        )
+
+        call_args = client.client.models.generate_content.call_args
+        assert call_args.kwargs['config'].system_instruction == "Be helpful"
+
+
+class TestGenerateContent:
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_returns_text(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = Mock()
+        mock_response.text = "This is the response"
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 50
+        mock_response.usage_metadata.candidates_token_count = 20
+
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        result = client.generate_content(prompt="Test prompt")
+
+        assert result == "This is the response"
+        assert client.api_call_count == 1
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_uses_specified_model(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key", thinking_level=ThinkingLevel.LOW)
+
+        mock_response = Mock()
+        mock_response.text = "Response"
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 50
+        mock_response.usage_metadata.candidates_token_count = 20
+
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        client.generate_content(prompt="Test", model=GeminiModelType.PRO_3)
+
+        call_args = client.client.models.generate_content.call_args
+        assert call_args.kwargs['model'] == "gemini-3-pro-preview"
+
+
+class TestRetryLogic:
+    @patch('shared.llm_gemini_3.genai.Client')
+    @patch('shared.llm_gemini_3.time.sleep')
+    def test_retries_on_failure(self, mock_sleep, _mock_genai):
+        client = Gemini3Client(api_key="test-key", max_retries=3)
+
+        mock_response = Mock()
+        mock_response.text = "Success"
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 50
+        mock_response.usage_metadata.candidates_token_count = 20
+
+        client.client.models.generate_content = Mock(
+            side_effect=[Exception("Error 1"), Exception("Error 2"), mock_response]
+        )
+
+        result = client.generate_content(prompt="Test")
+
+        assert result == "Success"
+        assert mock_sleep.call_count == 2
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    @patch('shared.llm_gemini_3.time.sleep')
+    def test_exponential_backoff(self, mock_sleep, _mock_genai):
+        client = Gemini3Client(api_key="test-key", max_retries=3, base_delay=1.0)
+
+        mock_response = Mock()
+        mock_response.text = "Success"
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 50
+        mock_response.usage_metadata.candidates_token_count = 20
+
+        client.client.models.generate_content = Mock(
+            side_effect=[Exception("Error"), Exception("Error"), mock_response]
+        )
+
+        client.generate_content(prompt="Test")
+
+        assert mock_sleep.call_args_list[0][0][0] == 1.0
+        assert mock_sleep.call_args_list[1][0][0] == 2.0
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    @patch('shared.llm_gemini_3.time.sleep')
+    def test_raises_after_max_retries(self, mock_sleep, _mock_genai):
+        client = Gemini3Client(api_key="test-key", max_retries=3)
+
+        client.client.models.generate_content = Mock(
+            side_effect=Exception("Persistent error")
+        )
+
+        with pytest.raises(Exception, match="Persistent error"):
+            client.generate_content(prompt="Test")
+
+        assert mock_sleep.call_count == 2
+
+
+class TestEmptyResponse:
+    @patch('shared.llm_gemini_3.genai.Client')
+    @patch('shared.llm_gemini_3.time.sleep')
+    def test_raises_on_empty_text(self, mock_sleep, _mock_genai):
+        client = Gemini3Client(api_key="test-key", max_retries=1)
+
+        mock_response = Mock()
+        mock_response.text = None
+        mock_response.usage_metadata = None
+
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        with pytest.raises(ValueError, match="Empty response"):
+            client.generate_content(prompt="Test")
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    @patch('shared.llm_gemini_3.time.sleep')
+    def test_raises_on_empty_string(self, mock_sleep, _mock_genai):
+        client = Gemini3Client(api_key="test-key", max_retries=1)
+
+        mock_response = Mock()
+        mock_response.text = ""
+        mock_response.usage_metadata = None
+
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        with pytest.raises(ValueError, match="Empty response"):
+            client.generate_content(prompt="Test")
+
+
+class TestBraintrustIntegration:
+    @patch('shared.llm_gemini_3.genai.Client')
+    @patch('shared.llm_gemini_3.braintrust_enabled')
+    def test_skips_tracing_when_disabled(self, mock_bt_enabled, _mock_genai):
+        mock_bt_enabled.return_value = False
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = Mock()
+        mock_response.text = "Response"
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 50
+        mock_response.usage_metadata.candidates_token_count = 20
+
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        result = client.generate_content(prompt="Test", trace_name="my-trace")
+
+        assert result == "Response"
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    @patch('shared.llm_gemini_3.braintrust_enabled')
+    @patch('shared.llm_gemini_3.get_braintrust_client')
+    def test_traces_when_enabled(self, mock_get_bt, mock_bt_enabled, _mock_genai):
+        mock_bt_enabled.return_value = True
+        mock_bt_client = Mock()
+        mock_bt_client.traced_call.return_value = "Traced response"
+        mock_get_bt.return_value = mock_bt_client
+
+        client = Gemini3Client(api_key="test-key")
+
+        result = client.generate_content(prompt="Test prompt", trace_name="custom-trace")
+
+        assert result == "Traced response"
+        mock_bt_client.traced_call.assert_called_once()
+        call_kwargs = mock_bt_client.traced_call.call_args.kwargs
+        assert call_kwargs['name'] == "custom-trace"
+        assert call_kwargs['input_data'] == {"prompt": "Test prompt"}
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    @patch('shared.llm_gemini_3.braintrust_enabled')
+    @patch('shared.llm_gemini_3.get_braintrust_client')
+    def test_uses_default_trace_name(self, mock_get_bt, mock_bt_enabled, _mock_genai):
+        mock_bt_enabled.return_value = True
+        mock_bt_client = Mock()
+        mock_bt_client.traced_call.return_value = "Response"
+        mock_get_bt.return_value = mock_bt_client
+
+        client = Gemini3Client(api_key="test-key")
+
+        client.generate_content(prompt="Test")
+
+        call_kwargs = mock_bt_client.traced_call.call_args.kwargs
+        assert call_kwargs['name'] == "generate_content"
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    @patch('shared.llm_gemini_3.braintrust_enabled')
+    @patch('shared.llm_gemini_3.get_braintrust_client')
+    def test_structured_content_traces(self, mock_get_bt, mock_bt_enabled, _mock_genai):
+        mock_bt_enabled.return_value = True
+        mock_bt_client = Mock()
+        mock_bt_client.traced_call.return_value = SampleResponse(answer="test", confidence=0.9)
+        mock_get_bt.return_value = mock_bt_client
+
+        client = Gemini3Client(api_key="test-key")
+
+        result = client.generate_structured_content(
+            prompt="Test",
+            response_schema=SampleResponse,
+            trace_name="structured-trace"
+        )
+
+        call_kwargs = mock_bt_client.traced_call.call_args.kwargs
+        assert call_kwargs['name'] == "structured-trace"
+
+
+class TestInvalidJsonResponse:
+    @patch('shared.llm_gemini_3.genai.Client')
+    @patch('shared.llm_gemini_3.time.sleep')
+    def test_raises_on_invalid_json(self, mock_sleep, _mock_genai):
+        client = Gemini3Client(api_key="test-key", max_retries=1)
+
+        mock_response = Mock()
+        mock_response.text = "not valid json {"
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 50
+        mock_response.usage_metadata.candidates_token_count = 20
+
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        with pytest.raises(Exception):
+            client.generate_structured_content(
+                prompt="Test",
+                response_schema=SampleResponse
+            )
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    @patch('shared.llm_gemini_3.time.sleep')
+    def test_raises_on_schema_mismatch(self, mock_sleep, _mock_genai):
+        client = Gemini3Client(api_key="test-key", max_retries=1)
+
+        mock_response = Mock()
+        mock_response.text = '{"wrong_field": "value"}'
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 50
+        mock_response.usage_metadata.candidates_token_count = 20
+
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        with pytest.raises(Exception):
+            client.generate_structured_content(
+                prompt="Test",
+                response_schema=SampleResponse
+            )
+
+
+class TestCumulativeUsage:
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_accumulates_across_calls(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response1 = Mock()
+        mock_response1.text = "Response 1"
+        mock_response1.usage_metadata = Mock()
+        mock_response1.usage_metadata.prompt_token_count = 100
+        mock_response1.usage_metadata.candidates_token_count = 50
+
+        mock_response2 = Mock()
+        mock_response2.text = "Response 2"
+        mock_response2.usage_metadata = Mock()
+        mock_response2.usage_metadata.prompt_token_count = 200
+        mock_response2.usage_metadata.candidates_token_count = 100
+
+        client.client.models.generate_content = Mock(
+            side_effect=[mock_response1, mock_response2]
+        )
+
+        client.generate_content(prompt="First")
+        client.generate_content(prompt="Second")
+
+        assert client.api_call_count == 2
+        assert client.total_prompt_tokens == 300
+        assert client.total_completion_tokens == 150
+
+
+class TestAllThinkingLevels:
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_minimal_level(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key", thinking_level=ThinkingLevel.MINIMAL)
+        config = client._build_config(GeminiModelType.FLASH_3)
+        assert "minimal" in str(config.thinking_config.thinking_level).lower()
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_low_level(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key", thinking_level=ThinkingLevel.LOW)
+        config = client._build_config(GeminiModelType.FLASH_3)
+        assert "low" in str(config.thinking_config.thinking_level).lower()
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_medium_level(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key", thinking_level=ThinkingLevel.MEDIUM)
+        config = client._build_config(GeminiModelType.FLASH_3)
+        assert "medium" in str(config.thinking_config.thinking_level).lower()
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_high_level(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key", thinking_level=ThinkingLevel.HIGH)
+        config = client._build_config(GeminiModelType.FLASH_3)
+        assert "high" in str(config.thinking_config.thinking_level).lower()
+
+
+class TestZeroTokens:
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_handles_zero_prompt_tokens(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = Mock()
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 0
+        mock_response.usage_metadata.candidates_token_count = 50
+
+        client._update_usage("gemini-3-flash-preview", mock_response)
+
+        assert client.total_prompt_tokens == 0
+        assert client.total_completion_tokens == 50
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_handles_zero_completion_tokens(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = Mock()
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 100
+        mock_response.usage_metadata.candidates_token_count = 0
+
+        client._update_usage("gemini-3-flash-preview", mock_response)
+
+        assert client.total_prompt_tokens == 100
+        assert client.total_completion_tokens == 0
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_zero_cost_for_zero_tokens(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+        cost = client._calculate_cost("gemini-3-flash-preview", 0, 0)
+        assert cost == 0.0
+
+
+class TestEnvVarApiKey:
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_uses_env_var_when_no_explicit_key(self, _mock_genai, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "env-api-key")
+        client = Gemini3Client()
+        assert client.api_key == "env-api-key"
+
+
+class TestConnectionConfig:
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_custom_connection_limits(self, mock_genai):
+        client = Gemini3Client(
+            api_key="test-key",
+            max_connections=500,
+            max_keepalive_connections=100
+        )
+
+        call_kwargs = mock_genai.call_args.kwargs
+        http_options = call_kwargs['http_options']
+
+        assert http_options.client_args['limits'].max_connections == 500
+        assert http_options.client_args['limits'].max_keepalive_connections == 100
+
+
+class TestBaseDelay:
+    @patch('shared.llm_gemini_3.genai.Client')
+    @patch('shared.llm_gemini_3.time.sleep')
+    def test_custom_base_delay(self, mock_sleep, _mock_genai):
+        client = Gemini3Client(api_key="test-key", max_retries=2, base_delay=2.0)
+
+        mock_response = Mock()
+        mock_response.text = "Success"
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 50
+        mock_response.usage_metadata.candidates_token_count = 20
+
+        client.client.models.generate_content = Mock(
+            side_effect=[Exception("Error"), mock_response]
+        )
+
+        client.generate_content(prompt="Test")
+
+        mock_sleep.assert_called_once_with(2.0)
+
+
+class TestNoneTokenCounts:
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_handles_none_prompt_token_count(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = Mock()
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = None
+        mock_response.usage_metadata.candidates_token_count = 50
+
+        client._update_usage("gemini-3-flash-preview", mock_response)
+
+        assert client.total_prompt_tokens == 0
+        assert client.total_completion_tokens == 50
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_handles_none_candidates_token_count(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = Mock()
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 100
+        mock_response.usage_metadata.candidates_token_count = None
+
+        client._update_usage("gemini-3-flash-preview", mock_response)
+
+        assert client.total_prompt_tokens == 100
+        assert client.total_completion_tokens == 0

--- a/uv.lock
+++ b/uv.lock
@@ -259,15 +259,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cachetools"
-version = "6.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/7e/b975b5814bd36faf009faebe22c1072a1fa1168db34d285ef0ba071ad78c/cachetools-6.2.1.tar.gz", hash = "sha256:3f391e4bd8f8bf0931169baf7456cc822705f4e2a31f840d218f445b9a854201", size = 31325, upload-time = "2025-10-12T14:55:30.139Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/c5/1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl", hash = "sha256:09868944b6dde876dfd44e1d47e18484541eaf12f26f29b7af91b26cc892d701", size = 11280, upload-time = "2025-10-12T14:55:28.382Z" },
-]
-
-[[package]]
 name = "catalogue"
 version = "2.0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -885,16 +876,20 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.41.1"
+version = "2.47.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cachetools" },
     { name = "pyasn1-modules" },
     { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/af/5129ce5b2f9688d2fa49b463e544972a7c82b0fdb50980dafee92e121d9f/google_auth-2.41.1.tar.gz", hash = "sha256:b76b7b1f9e61f0cb7e88870d14f6a94aeef248959ef6992670efee37709cbfd2", size = 292284, upload-time = "2025-09-30T22:51:26.363Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/3c/ec64b9a275ca22fa1cd3b6e77fefcf837b0732c890aa32d2bd21313d9b33/google_auth-2.47.0.tar.gz", hash = "sha256:833229070a9dfee1a353ae9877dcd2dec069a8281a4e72e72f77d4a70ff945da", size = 323719, upload-time = "2026-01-06T21:55:31.045Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/a4/7319a2a8add4cc352be9e3efeff5e2aacee917c85ca2fa1647e29089983c/google_auth-2.41.1-py2.py3-none-any.whl", hash = "sha256:754843be95575b9a19c604a848a41be03f7f2afd8c019f716dc1f51ee41c639d", size = 221302, upload-time = "2025-09-30T22:51:24.212Z" },
+    { url = "https://files.pythonhosted.org/packages/db/18/79e9008530b79527e0d5f79e7eef08d3b179b7f851cfd3a2f27822fbdfa9/google_auth-2.47.0-py3-none-any.whl", hash = "sha256:c516d68336bfde7cf0da26aab674a36fedcf04b37ac4edd59c597178760c3498", size = 234867, upload-time = "2026-01-06T21:55:28.6Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
 ]
 
 [[package]]
@@ -925,21 +920,23 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.45.0"
+version = "1.56.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "google-auth" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "requests" },
+    { name = "sniffio" },
     { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/77/776b92f6f7cf7d7d3bc77b44a323605ae0f94f807cf9a4977c90d296b6b4/google_genai-1.45.0.tar.gz", hash = "sha256:96ec32ae99a30b5a1b54cb874b577ec6e41b5d5b808bf0f10ed4620e867f9386", size = 238198, upload-time = "2025-10-15T23:03:07.713Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/ad/d3ac5a102135bd3f1e4b1475ca65d2bd4bcc22eb2e9348ac40fe3fadb1d6/google_genai-1.56.0.tar.gz", hash = "sha256:0491af33c375f099777ae207d9621f044e27091fafad4c50e617eba32165e82f", size = 340451, upload-time = "2025-12-17T12:35:05.412Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/8f/922116dabe3d0312f08903d324db6ac9d406832cf57707550bc61151d91b/google_genai-1.45.0-py3-none-any.whl", hash = "sha256:e755295063e5fd5a4c44acff782a569e37fa8f76a6c75d0ede3375c70d916b7f", size = 238495, upload-time = "2025-10-15T23:03:05.926Z" },
+    { url = "https://files.pythonhosted.org/packages/84/93/94bc7a89ef4e7ed3666add55cd859d1483a22737251df659bf1aa46e9405/google_genai-1.56.0-py3-none-any.whl", hash = "sha256:9e6b11e0c105ead229368cb5849a480e4d0185519f8d9f538d61ecfcf193b052", size = 426563, upload-time = "2025-12-17T12:35:03.717Z" },
 ]
 
 [[package]]
@@ -1007,6 +1004,7 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "types-pyyaml" },
 ]
 
@@ -1022,7 +1020,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2.40.3" },
     { name = "google-auth-httplib2", specifier = ">=0.2.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.2" },
-    { name = "google-genai", specifier = ">=1.24.0" },
+    { name = "google-genai", specifier = ">=1.56.0" },
     { name = "hdbscan", specifier = ">=0.8.40" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
@@ -1057,6 +1055,7 @@ provides-extras = ["dev"]
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "pytest", specifier = ">=8.4.2" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 
@@ -1109,7 +1108,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2.40.3" },
     { name = "google-auth-httplib2", specifier = ">=0.2.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.2" },
-    { name = "google-genai", specifier = ">=1.24.0" },
+    { name = "google-genai", specifier = ">=1.56.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "numpy", specifier = ">=2.3.1" },
     { name = "pandas", specifier = ">=2.2.3" },


### PR DESCRIPTION
-add new interface for gemini 3
- Upgrade google-genai to 1.56.0
- Add FLASH_3 and PRO_3 model types for gemini-3-flash-preview and gemini-3-pro-preview
- Add ThinkingLevel enum (MINIMAL, LOW, MEDIUM, HIGH) for Gemini 3's level-based thinking
- Implement backward compatibility: thinking_budget auto-converts to thinking_level for Gemini 3
- Add warnings when using deprecated thinking_budget on Gemini 3 or unsupported thinking_level on Gemini 2.5
- Fix Gemini 2.5 Flash pricing to reflect with-thinking costs ($0.30/$2.50)
- Update DDHQ matchers to use Gemini 3 Flash with ThinkingLevel.MINIMAL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Gemini 3 support and migrates the matcher to use it.
> 
> - New `shared/llm_gemini_3.py`: `Gemini3Client` with `GeminiModelType` (FLASH_3/PRO_3), `ThinkingLevel` (minimal–high), structured/text generation, retries with exponential backoff, usage/cost tracking, and Braintrust tracing; includes pricing map
> - Update `hubspot_ddhq_match/parallel_production_matcher.py` to use `Gemini3Client` with `FLASH_3` and `ThinkingLevel.MINIMAL`, configuring high-concurrency HTTP settings
> - Bump `google-genai` to `>=1.56.0` in `pyproject.toml` and `shared/pyproject.toml`; add `pytest` to dev deps; refresh `uv.lock`
> - Add extensive unit tests `shared/tests/test_llm_gemini_3.py` covering config, pricing, retries/backoff, tracing, token/cost accounting, and schema handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9d3557a0bfb8a3d1cf554f82a34dd310f497d0b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->