### PR TITLE
fix: handle empty (0-byte) CSV files in V1 pipeline

### DIFF
--- a/serve/v1_pipeline/pipeline/orchestrator.py
+++ b/serve/v1_pipeline/pipeline/orchestrator.py
@@ -560,10 +560,24 @@ class V1PipelineOrchestrator:
                 poll_id = csv_file.stem
                 poll_ids.append(poll_id)
 
+                if csv_file.stat().st_size == 0:
+                    logger.warning(f"Skipping empty file (0 bytes): {csv_file.name}")
+                    continue
+
                 logger.info(f"Loading: {csv_file.name} (poll_id: {poll_id})")
                 df = pd.read_csv(csv_file)
                 df = self._normalize_csv_columns(df)
                 dfs.append(df)
+
+            if not dfs:
+                logger.warning("All CSV files were empty (0 bytes)")
+                analysis = {
+                    "mode": "filename_based_loading",
+                    "file_count": len(csv_files),
+                    "total_rows": 0,
+                    "files": [{"filename": f.name, "poll_id": f.stem} for f in csv_files]
+                }
+                return pd.DataFrame(), analysis
 
             combined_df = pd.concat(dfs, ignore_index=True) if len(dfs) > 1 else dfs[0]
 

--- a/serve/v1_pipeline/pipeline/orchestrator.py
+++ b/serve/v1_pipeline/pipeline/orchestrator.py
@@ -566,13 +566,18 @@ class V1PipelineOrchestrator:
                     continue
 
                 logger.info(f"Loading: {csv_file.name} (poll_id: {poll_id})")
-                df = pd.read_csv(csv_file)
+                try:
+                    df = pd.read_csv(csv_file)
+                except pd.errors.EmptyDataError:
+                    logger.warning(f"Skipping unparseable file (no columns): {csv_file.name}")
+                    skipped_files.append({"filename": csv_file.name, "poll_id": poll_id, "status": "skipped_empty"})
+                    continue
                 df = self._normalize_csv_columns(df)
                 dfs.append(df)
                 loaded_files.append({"filename": csv_file.name, "poll_id": poll_id})
 
             if not dfs:
-                logger.warning("All CSV files were empty (0 bytes)")
+                logger.warning("All CSV files were empty or unparseable")
                 analysis = {
                     "mode": "filename_based_loading",
                     "file_count": len(csv_files),

--- a/serve/v1_pipeline/pipeline/orchestrator.py
+++ b/serve/v1_pipeline/pipeline/orchestrator.py
@@ -555,19 +555,21 @@ class V1PipelineOrchestrator:
             logger.info(f"Found {len(csv_files)} CSV file(s) for campaign '{campaign_name}' in {input_dir}")
 
             dfs = []
-            poll_ids = []
+            loaded_files = []
+            skipped_files = []
             for csv_file in csv_files:
                 poll_id = csv_file.stem
-                poll_ids.append(poll_id)
 
                 if csv_file.stat().st_size == 0:
                     logger.warning(f"Skipping empty file (0 bytes): {csv_file.name}")
+                    skipped_files.append({"filename": csv_file.name, "poll_id": poll_id, "status": "skipped_empty"})
                     continue
 
                 logger.info(f"Loading: {csv_file.name} (poll_id: {poll_id})")
                 df = pd.read_csv(csv_file)
                 df = self._normalize_csv_columns(df)
                 dfs.append(df)
+                loaded_files.append({"filename": csv_file.name, "poll_id": poll_id})
 
             if not dfs:
                 logger.warning("All CSV files were empty (0 bytes)")
@@ -575,7 +577,7 @@ class V1PipelineOrchestrator:
                     "mode": "filename_based_loading",
                     "file_count": len(csv_files),
                     "total_rows": 0,
-                    "files": [{"filename": f.name, "poll_id": f.stem} for f in csv_files]
+                    "files": skipped_files
                 }
                 return pd.DataFrame(), analysis
 
@@ -606,14 +608,17 @@ class V1PipelineOrchestrator:
                     f"Found columns: {list(combined_df.columns)}"
                 )
 
+            poll_ids = [f["poll_id"] for f in loaded_files]
             analysis = {
                 "mode": "filename_based_loading",
                 "file_count": len(csv_files),
                 "total_rows": len(combined_df),
-                "files": [{"filename": f.name, "poll_id": poll_id} for f, poll_id in zip(csv_files, poll_ids)]
+                "files": loaded_files + skipped_files
             }
 
-            logger.info(f"Loaded {len(combined_df)} rows from {len(csv_files)} file(s)")
+            logger.info(f"Loaded {len(combined_df)} rows from {len(loaded_files)} file(s)")
+            if skipped_files:
+                logger.warning(f"Skipped {len(skipped_files)} empty file(s)")
             logger.info(f"Poll IDs: {poll_ids}")
             return combined_df, analysis
 

--- a/serve/v1_pipeline/tests/test_empty_csv.py
+++ b/serve/v1_pipeline/tests/test_empty_csv.py
@@ -101,3 +101,46 @@ def test_mixed_empty_and_valid_csvs_uses_correct_poll_id(pipeline_with_mixed_csv
     assert loaded_files[0]["poll_id"] == valid_poll_id, (
         f"First loaded file should be the valid poll, got: {loaded_files}"
     )
+
+
+@pytest.fixture
+def pipeline_with_unparseable_csv(tmp_path):
+    campaign_name = "testcampaign"
+    campaign_dir = tmp_path / "input" / campaign_name
+    campaign_dir.mkdir(parents=True)
+
+    poll_id = "unparseable-poll"
+    csv_file = campaign_dir / f"{poll_id}.csv"
+    csv_file.write_text("\n\n  \n")
+
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        f"consolidation:\n"
+        f"  input_dir: {tmp_path / 'input'}\n"
+        f"  output_dir: {output_dir}\n"
+        f"clustering:\n"
+        f"  enabled: false\n"
+        f"sqs_events:\n"
+        f"  enabled: false\n"
+    )
+
+    orchestrator = V1PipelineOrchestrator(config_path=str(config_path))
+
+    return orchestrator, campaign_name, poll_id
+
+
+def test_pipeline_handles_whitespace_only_csv(pipeline_with_unparseable_csv):
+    orchestrator, campaign_name, poll_id = pipeline_with_unparseable_csv
+
+    result = asyncio.run(orchestrator.run_pipeline(campaign_name))
+
+    assert result.errors == [], f"Expected no errors, got: {result.errors}"
+    assert result.input_messages == 0
+    assert result.output_records == 0
+
+    files = result.consolidation_result.get("files", [])
+    poll_ids_in_result = [f["poll_id"] for f in files]
+    assert poll_id in poll_ids_in_result

--- a/serve/v1_pipeline/tests/test_empty_csv.py
+++ b/serve/v1_pipeline/tests/test_empty_csv.py
@@ -1,0 +1,52 @@
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from serve.v1_pipeline.pipeline.orchestrator import V1PipelineOrchestrator
+
+
+@pytest.fixture
+def pipeline_with_empty_csv(tmp_path):
+    campaign_name = "testcampaign"
+    campaign_dir = tmp_path / "input" / campaign_name
+    campaign_dir.mkdir(parents=True)
+
+    poll_id = "019c4875-97a2-7889-93d6-13929bc4d6ae"
+    csv_file = campaign_dir / f"{poll_id}.csv"
+    csv_file.write_bytes(b"")
+
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        f"consolidation:\n"
+        f"  input_dir: {tmp_path / 'input'}\n"
+        f"  output_dir: {output_dir}\n"
+        f"clustering:\n"
+        f"  enabled: false\n"
+        f"sqs_events:\n"
+        f"  enabled: false\n"
+    )
+
+    orchestrator = V1PipelineOrchestrator(config_path=str(config_path))
+
+    return orchestrator, campaign_name, poll_id
+
+
+def test_pipeline_handles_zero_byte_csv(pipeline_with_empty_csv):
+    orchestrator, campaign_name, poll_id = pipeline_with_empty_csv
+
+    result = asyncio.run(orchestrator.run_pipeline(campaign_name))
+
+    assert result.errors == [], f"Expected no errors, got: {result.errors}"
+    assert result.input_messages == 0
+    assert result.output_records == 0
+
+    files = result.consolidation_result.get("files", [])
+    poll_ids_in_result = [f["poll_id"] for f in files]
+    assert poll_id in poll_ids_in_result, (
+        f"Expected poll_id '{poll_id}' in consolidation_result files, got: {files}"
+    )

--- a/serve/v1_pipeline/tests/test_empty_csv.py
+++ b/serve/v1_pipeline/tests/test_empty_csv.py
@@ -50,3 +50,54 @@ def test_pipeline_handles_zero_byte_csv(pipeline_with_empty_csv):
     assert poll_id in poll_ids_in_result, (
         f"Expected poll_id '{poll_id}' in consolidation_result files, got: {files}"
     )
+
+
+@pytest.fixture
+def pipeline_with_mixed_csvs(tmp_path):
+    campaign_name = "testcampaign"
+    campaign_dir = tmp_path / "input" / campaign_name
+    campaign_dir.mkdir(parents=True)
+
+    empty_poll_id = "aaaa-empty-poll"
+    empty_csv = campaign_dir / f"{empty_poll_id}.csv"
+    empty_csv.write_bytes(b"")
+
+    valid_poll_id = "zzzz-valid-poll"
+    valid_csv = campaign_dir / f"{valid_poll_id}.csv"
+    valid_csv.write_text(
+        "phone_number,message_text\n"
+        "+15551234567,I support better roads\n"
+    )
+
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        f"consolidation:\n"
+        f"  input_dir: {tmp_path / 'input'}\n"
+        f"  output_dir: {output_dir}\n"
+        f"clustering:\n"
+        f"  enabled: false\n"
+        f"sqs_events:\n"
+        f"  enabled: false\n"
+    )
+
+    orchestrator = V1PipelineOrchestrator(config_path=str(config_path))
+
+    return orchestrator, campaign_name, empty_poll_id, valid_poll_id
+
+
+def test_mixed_empty_and_valid_csvs_uses_correct_poll_id(pipeline_with_mixed_csvs):
+    orchestrator, campaign_name, empty_poll_id, valid_poll_id = pipeline_with_mixed_csvs
+
+    result = asyncio.run(orchestrator.run_pipeline(campaign_name))
+
+    assert result.errors == [], f"Expected no errors, got: {result.errors}"
+    assert result.input_messages == 1
+
+    files = result.consolidation_result.get("files", [])
+    loaded_files = [f for f in files if f.get("status") != "skipped_empty"]
+    assert loaded_files[0]["poll_id"] == valid_poll_id, (
+        f"First loaded file should be the valid poll, got: {loaded_files}"
+    )


### PR DESCRIPTION
## Summary
- ECS task `78236edc` crashed with `EmptyDataError` because input CSV was 0 bytes
- Added file size check before `pd.read_csv()` — skips empty files with a warning
- When all CSVs are empty, returns empty DataFrame so existing handler publishes `pollAnalysisComplete` with `totalResponses: 0` and empty `issues: []`
- Verified gp-api Zod schema contract is satisfied (pollId, totalResponses, issues all present and correctly typed)

## Test plan
- [x] Added `test_pipeline_handles_zero_byte_csv` — creates 0-byte CSV, runs pipeline, asserts no errors and correct output shape
- [x] Deploy to dev and trigger with an empty CSV to verify SQS event flow end-to-end

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change in CSV ingestion/error handling plus focused tests; main risk is subtle behavior changes in how poll/file metadata is reported when some inputs are skipped.
> 
> **Overview**
> Prevents consolidation in `V1PipelineOrchestrator` from crashing on 0-byte or whitespace-only CSV inputs by skipping those files (with warnings) and tracking them in the consolidation `analysis.files` output with a `skipped_empty` status.
> 
> If all discovered CSVs are empty/unparseable, consolidation now returns an empty `DataFrame` plus analysis so the pipeline can complete with 0 messages instead of raising `pandas` `EmptyDataError`. Adds tests covering zero-byte, whitespace-only, and mixed valid+empty CSV scenarios to ensure poll IDs and counts remain correct.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57e6542fafa64dbb444f384bdbf6603080306c56. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->