### PR TITLE
Unify publish_events and publish_empty_poll_event into single publish…

### DIFF
--- a/serve/v1_pipeline/pipeline/orchestrator.py
+++ b/serve/v1_pipeline/pipeline/orchestrator.py
@@ -280,30 +280,15 @@ class V1PipelineOrchestrator:
                 logger.warning(f"⚠️ No messages found for campaign: {campaign_name}")
                 logger.info("✅ Pipeline completed with 0 messages to process")
 
-                # Publish completion events for all poll_ids with 0 responses
                 sqs_result: dict[str, Any] = {}
                 if self.sqs_publisher and self.config.get('sqs_events', {}).get('enabled', False):
-                    logger.info("💾 Publishing empty poll completion events")
-
-                    # Extract all poll_ids from consolidation analysis
-                    poll_ids = [file_info['poll_id'] for file_info in consolidation_analysis.get('files', [])]
-
+                    poll_ids = [f['poll_id'] for f in consolidation_analysis.get('files', [])]
                     if poll_ids:
-                        total_complete_events = 0
-                        for poll_id in poll_ids:
-                            try:
-                                stats = await self.sqs_publisher.publish_empty_poll_event(poll_id)
-                                total_complete_events += stats.get('complete_events_sent', 0)
-                            except Exception as e:
-                                logger.error(f"Failed to publish empty poll event for {poll_id}: {e}", exc_info=True)
-
-                        sqs_result = {
-                            'success': True,
-                            'complete_events_sent': total_complete_events
-                        }
-                        logger.info(f"✅ Published {total_complete_events} empty poll completion events")
-                    else:
-                        logger.warning("⚠️ No poll_ids found in consolidation analysis")
+                        sqs_result = await self.sqs_publisher.publish_poll_completion(
+                            poll_ids=poll_ids, unified_records=[], campaign_name=campaign_name
+                        )
+                        sqs_result['success'] = True
+                        logger.info(f"Published {len(poll_ids)} empty poll completion events")
 
                 processing_time = time.time() - start_time
                 return PipelineResult(
@@ -436,36 +421,18 @@ class V1PipelineOrchestrator:
             # Stage 4: Event Saving to S3 (validation mode - only runs on successful pipeline completion)
             sqs_result = {}
             if self.sqs_publisher and self.config.get('sqs_events', {}).get('enabled', False):
-                logger.info("💾 Stage 4: Event Saving to S3 (Validation Mode)")
+                logger.info("💾 Stage 4: Event Publishing")
                 sqs_start = time.time()
 
-                # Check if all messages were filtered out (had CSV data but 0 unified records)
-                if not unified_records and total_messages > 0:
-                    logger.warning(f"⚠️ All {total_messages} messages were filtered out - publishing empty poll completion events")
-
-                    # Extract poll_ids from consolidation analysis
-                    poll_ids = [file_info['poll_id'] for file_info in consolidation_analysis.get('files', [])]
-
-                    total_complete_events = 0
-                    for poll_id in poll_ids:
-                        try:
-                            stats = await self.sqs_publisher.publish_empty_poll_event(poll_id)
-                            total_complete_events += stats.get('complete_events_sent', 0)
-                        except Exception as e:
-                            logger.error(f"Failed to publish empty poll event for {poll_id}: {e}", exc_info=True)
-
-                    sqs_stats = {
-                        'polls_processed': len(poll_ids),
-                        'complete_events_sent': total_complete_events
-                    }
-                else:
-                    # Normal flow - publish events from unified records
-                    sqs_stats = await self.sqs_publisher.publish_events(unified_records, campaign_name)
+                poll_ids = [f['poll_id'] for f in consolidation_analysis.get('files', [])]
+                sqs_stats = await self.sqs_publisher.publish_poll_completion(
+                    poll_ids=poll_ids, unified_records=unified_records, campaign_name=campaign_name
+                )
 
                 sqs_time = time.time() - sqs_start
 
-                logger.info(f"✅ Event saving completed in {sqs_time:.2f}s")
-                logger.info(f"   Saved {sqs_stats['complete_events_sent']} complete events")
+                logger.info(f"Event publishing completed in {sqs_time:.2f}s")
+                logger.info(f"   Published {sqs_stats['complete_events_sent']} events")
 
                 sqs_result = {
                     'success': True,
@@ -554,18 +521,41 @@ class V1PipelineOrchestrator:
 
             logger.info(f"Found {len(csv_files)} CSV file(s) for campaign '{campaign_name}' in {input_dir}")
 
-            dfs = []
-            poll_ids = []
+            loaded_dfs = []
+            loaded_files = []
+            skipped_files = []
             for csv_file in csv_files:
                 poll_id = csv_file.stem
-                poll_ids.append(poll_id)
+
+                if csv_file.stat().st_size == 0:
+                    logger.warning(f"Skipping zero-byte CSV: {csv_file.name} (poll_id: {poll_id})")
+                    skipped_files.append({"filename": csv_file.name, "poll_id": poll_id})
+                    continue
 
                 logger.info(f"Loading: {csv_file.name} (poll_id: {poll_id})")
-                df = pd.read_csv(csv_file)
-                df = self._normalize_csv_columns(df)
-                dfs.append(df)
+                try:
+                    df = pd.read_csv(csv_file)
+                except pd.errors.EmptyDataError:
+                    logger.warning(f"EmptyDataError reading {csv_file.name} (poll_id: {poll_id}), treating as empty")
+                    skipped_files.append({"filename": csv_file.name, "poll_id": poll_id})
+                    continue
 
-            combined_df = pd.concat(dfs, ignore_index=True) if len(dfs) > 1 else dfs[0]
+                df = self._normalize_csv_columns(df)
+                loaded_dfs.append(df)
+                loaded_files.append({"filename": csv_file.name, "poll_id": poll_id})
+
+            all_file_entries = loaded_files + skipped_files
+
+            if not loaded_dfs:
+                analysis = {
+                    "mode": "filename_based_loading",
+                    "file_count": len(csv_files),
+                    "total_rows": 0,
+                    "files": all_file_entries,
+                }
+                return pd.DataFrame(), analysis
+
+            combined_df = pd.concat(loaded_dfs, ignore_index=True) if len(loaded_dfs) > 1 else loaded_dfs[0]
 
             # Validate required columns (case-insensitive)
             columns_lower = [col.lower() for col in combined_df.columns]
@@ -596,11 +586,11 @@ class V1PipelineOrchestrator:
                 "mode": "filename_based_loading",
                 "file_count": len(csv_files),
                 "total_rows": len(combined_df),
-                "files": [{"filename": f.name, "poll_id": poll_id} for f, poll_id in zip(csv_files, poll_ids)]
+                "files": all_file_entries,
             }
 
-            logger.info(f"Loaded {len(combined_df)} rows from {len(csv_files)} file(s)")
-            logger.info(f"Poll IDs: {poll_ids}")
+            logger.info(f"Loaded {len(combined_df)} rows from {len(loaded_files)} file(s), skipped {len(skipped_files)}")
+            logger.info(f"Poll IDs: {[f['poll_id'] for f in all_file_entries]}")
             return combined_df, analysis
 
         except Exception as e:

--- a/serve/v1_pipeline/pipeline/sqs_publisher.py
+++ b/serve/v1_pipeline/pipeline/sqs_publisher.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+import uuid
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
@@ -26,26 +27,24 @@ logger = get_logger(__name__)
 
 
 class SQSEventPublisher:
-    def __init__(self, config: dict[str, Any]):
-        # Enable/disable SQS publishing
+    def __init__(self, config: dict[str, Any], s3_client: Any = None, sqs_client: Any = None):
         self.publish_to_sqs = config.get('publish_to_sqs', True)
-
-        # Output directory configuration (configurable, defaults to /app for Docker)
         self.output_dir = config.get('output_dir', '/app/serve/v1_pipeline/output')
+        self.s3_bucket = config.get('s3_bucket', os.getenv('S3_BUCKET', ''))
+        self._s3_client = s3_client
 
-        # SQS configuration (optional publishing)
         if self.publish_to_sqs:
             self.queue_url = config.get('queue_url', os.getenv('SQS_QUEUE_URL'))
-            self.sqs_client = boto3.client('sqs', region_name='us-west-2')
+            if not self.queue_url:
+                raise ValueError("publish_to_sqs=True but no queue_url configured (config or SQS_QUEUE_URL env)")
+            self.sqs_client = sqs_client or boto3.client('sqs', region_name='us-west-2')
             logger.info("SQS publishing: ENABLED")
             logger.info(f"  Queue URL: {self.queue_url}")
-            logger.info(f"  MessageGroupId: gp-queue-polls")
         else:
             self.queue_url = None
-            self.sqs_client = None
+            self.sqs_client = sqs_client
             logger.info("SQS publishing: DISABLED")
 
-        # Common configuration
         self.top_n = config.get('publish_top_n', 3)
         self.min_respondents = config.get('min_unique_respondents', 1)
         self.s3_output_path = config.get('s3_output_path', os.getenv('S3_OUTPUT_PATH', ''))
@@ -56,73 +55,100 @@ class SQSEventPublisher:
         logger.info(f"  Top N clusters: {self.top_n}")
         logger.info(f"  Min unique respondents: {self.min_respondents}")
 
-    async def publish_events(self, unified_records: list[UnifiedCampaignRecord], campaign_name: str = "") -> dict[str, Any]:
-        polls = defaultdict(list)
+    @property
+    def s3_client(self):
+        if self._s3_client is None:
+            self._s3_client = boto3.client('s3', region_name='us-west-2')
+        return self._s3_client
+
+    def _compute_responses_location(self, campaign_name: str) -> str:
+        if not campaign_name or not self.s3_output_path:
+            return ""
+        if self.s3_output_path.startswith("s3://"):
+            s3_prefix = "/".join(self.s3_output_path.split("/")[3:]).rstrip("/")
+        else:
+            s3_prefix = self.s3_output_path.rstrip("/")
+        key = f"{s3_prefix}/consolidated/{campaign_name}_all_cluster_analysis.json"
+        return key.lstrip("/")
+
+    def _upload_responses_to_s3(self, campaign_name: str, responses_location: str) -> None:
+        filename = f"{campaign_name}_all_cluster_analysis.json"
+        json_file = Path(self.output_dir) / filename
+        if not json_file.exists():
+            json_file = Path(self.output_dir) / "consolidated" / filename
+        if json_file.exists():
+            file_bytes = json_file.read_bytes()
+            try:
+                json.loads(file_bytes)
+            except (json.JSONDecodeError, ValueError):
+                logger.warning(f"Corrupted JSON at {json_file}, uploading empty array instead")
+                file_bytes = b"[]"
+        else:
+            file_bytes = b"[]"
+            logger.info(f"No local JSON file at {json_file}, uploading empty array")
+
+        try:
+            self.s3_client.put_object(
+                Bucket=self.s3_bucket,
+                Key=responses_location,
+                Body=file_bytes,
+            )
+        except Exception as e:
+            raise RuntimeError(f"S3 upload failed for s3://{self.s3_bucket}/{responses_location}: {e}") from e
+        logger.info(f"Uploaded responses to s3://{self.s3_bucket}/{responses_location} ({len(file_bytes)} bytes)")
+
+    async def publish_poll_completion(
+        self,
+        poll_ids: list[str],
+        unified_records: list[UnifiedCampaignRecord],
+        campaign_name: str = "",
+    ) -> dict[str, Any]:
+        responses_location = self._compute_responses_location(campaign_name)
+
+        if responses_location:
+            self._upload_responses_to_s3(campaign_name, responses_location)
+
+        polls: dict[str, list[UnifiedCampaignRecord]] = defaultdict(list)
         for record in unified_records:
             if record.poll_id:
                 polls[record.poll_id].append(record)
 
-        total_complete_events = 0
         all_events = []
-
-        responses_location = ""
-        if campaign_name and self.s3_output_path:
-            if self.s3_output_path.startswith("s3://"):
-                s3_prefix = "/".join(self.s3_output_path.split("/")[3:]).rstrip("/")
-            else:
-                s3_prefix = self.s3_output_path.rstrip("/")
-            responses_location = f"{s3_prefix}/consolidated/{campaign_name}_all_cluster_analysis.json"
-
-        for poll_id, records in polls.items():
-            poll_issues = []
-            logger.info(f"Processing poll_id: {poll_id} ({len(records)} records)")
-
-            cluster_stats = self._aggregate_cluster_stats(records)
-            logger.info(f"  Found {len(cluster_stats)} clusters")
-
-            top_clusters = self._rank_clusters(cluster_stats)
-            logger.info(f"  Processing top {len(top_clusters)} clusters")
-
-            for rank, cluster_data in enumerate(top_clusters, start=1):
-                poll_issues.append(
+        for poll_id in poll_ids:
+            records = polls.get(poll_id, [])
+            if records:
+                cluster_stats = self._aggregate_cluster_stats(records)
+                top_clusters = self._rank_clusters(cluster_stats)
+                poll_issues = [
                     PollIssueAnalysisData(
                         pollId=poll_id,
                         rank=rank,
-                        clusterId=cluster_data['cluster_id'],
-                        theme=cluster_data['theme'],
-                        summary=cluster_data['summary'],
-                        analysis=cluster_data['analysis'],
-                        quotes=cluster_data['quotes'],
-                        responseCount=cluster_data['responseCount']
+                        clusterId=c['cluster_id'],
+                        theme=c['theme'],
+                        summary=c['summary'],
+                        analysis=c['analysis'],
+                        quotes=c['quotes'],
+                        responseCount=c['responseCount'],
                     )
-                )
+                    for rank, c in enumerate(top_clusters, 1)
+                ]
+                unique_respondents = len(set(r.phone_number for r in records if not r.is_opt_out))
+                logger.info(f"Poll {poll_id}: {unique_respondents} respondents, {len(poll_issues)} issues")
+            else:
+                poll_issues = []
+                unique_respondents = 0
+                logger.info(f"Poll {poll_id}: 0 records, sending empty completion")
 
-                logger.info(f"  ✅ Rank {rank}: {cluster_data['theme']} ({cluster_data['responseCount']} respondents) - saved locally")
-
-            unique_respondents = len(set(record.phone_number for record in records if not record.is_opt_out))
-            logger.info(f"  Total unique respondents: {unique_respondents} (from {len(records)} atomic messages)")
-
-            complete_event = self._build_complete_event(poll_id, unique_respondents, poll_issues, responses_location)
-            all_events.append(complete_event.to_json())
+            event = self._build_complete_event(poll_id, unique_respondents, poll_issues, responses_location)
+            all_events.append(event.to_json())
 
             if self.publish_to_sqs:
-                try:
-                    self._send_to_sqs(complete_event)
-                    logger.info("  ✅ Completion event - sent to SQS + saved locally")
-                except Exception as e:
-                    logger.warning(f"  ⚠️ SQS send failed (continuing): {e}")
-                    logger.info("  ✅ Completion event - saved locally only")
-            else:
-                logger.info("  ✅ Completion event - saved locally")
-
-            total_complete_events += 1
+                self._send_to_sqs(event)
+                logger.info(f"  Sent completion event for {poll_id} to SQS")
 
         self._save_events_locally(all_events)
 
-        return {
-            'polls_processed': len(polls),
-            'complete_events_sent': total_complete_events
-        }
+        return {'polls_processed': len(poll_ids), 'complete_events_sent': len(poll_ids)}
 
     def _aggregate_cluster_stats(self, records: list[UnifiedCampaignRecord]) -> dict[int, dict]:
         cluster_key = self._get_optimal_cluster_key(records)
@@ -195,33 +221,6 @@ class SQSEventPublisher:
             )
         )
 
-    async def publish_empty_poll_event(self, poll_id: str) -> dict[str, Any]:
-        """
-        Publish completion event for a poll with 0 responses
-        Used when CSV has no valid messages after filtering
-        """
-        logger.info(f"Publishing empty poll completion event for poll_id: {poll_id}")
-
-        complete_event = self._build_complete_event(poll_id, total_responses=0, issues=[])
-        events = [complete_event.to_json()]
-
-        if self.publish_to_sqs:
-            try:
-                self._send_to_sqs(complete_event)
-                logger.info("  ✅ Empty poll completion event - sent to SQS + saved locally")
-            except Exception as e:
-                logger.warning(f"  ⚠️ SQS send failed (continuing): {e}")
-                logger.info("  ✅ Empty poll completion event - saved locally only")
-        else:
-            logger.info("  ✅ Empty poll completion event - saved locally")
-
-        self._save_events_locally(events)
-
-        return {
-            'polls_processed': 1,
-            'complete_events_sent': 1
-        }
-
     def _save_events_locally(self, events: list[dict]) -> None:
         """
         Save events to local filesystem
@@ -249,7 +248,6 @@ class SQSEventPublisher:
         if not self.publish_to_sqs or not self.sqs_client:
             logger.warning("SQS publishing disabled but _send_to_sqs called")
             return
-        import uuid
 
         message_body = json.dumps(event.to_json())
 

--- a/serve/v1_pipeline/tests/test_sqs_publisher.py
+++ b/serve/v1_pipeline/tests/test_sqs_publisher.py
@@ -1,0 +1,429 @@
+import json
+import uuid
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from serve.v1_pipeline.models.unified_record import UnifiedCampaignRecord
+from serve.v1_pipeline.pipeline.sqs_publisher import SQSEventPublisher
+
+
+def _make_record(
+    phone_number: str,
+    poll_id: str,
+    cluster_id: int = 1,
+    theme: str = "Roads",
+    is_opt_out: bool = False,
+) -> UnifiedCampaignRecord:
+    cluster_data = {
+        "15": {
+            "cluster_id": cluster_id,
+            "cluster_theme": theme,
+            "issues_summary": f"Summary for {theme}",
+            "detailed_analysis": f"Analysis for {theme}",
+            "quotes": [{"quote": "Fix the roads", "phone_number": phone_number}],
+        }
+    }
+    return UnifiedCampaignRecord(
+        campaign_id="test-campaign",
+        record_id=str(uuid.uuid4()),
+        atomic_id=str(uuid.uuid4()),
+        phone_number=phone_number,
+        message_text="Fix the roads please",
+        sent_at=datetime.now(timezone.utc),
+        round="R1",
+        poll_id=poll_id,
+        multi_cluster_data=cluster_data if not is_opt_out else None,
+        is_opt_out=is_opt_out,
+    )
+
+
+def _make_config(
+    tmp_path: Path,
+    publish_to_sqs: bool = False,
+    s3_output_path: str = "s3://bucket/prefix/path",
+    s3_bucket: str = "test-bucket",
+    queue_url: str = "https://sqs.us-west-2.amazonaws.com/123/test-queue.fifo",
+) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "publish_to_sqs": publish_to_sqs,
+        "output_dir": str(tmp_path / "output"),
+        "s3_output_path": s3_output_path,
+        "s3_bucket": s3_bucket,
+        "publish_top_n": 3,
+        "min_unique_respondents": 1,
+    }
+    if publish_to_sqs:
+        config["queue_url"] = queue_url
+    return config
+
+
+@pytest.fixture
+def call_log():
+    return []
+
+
+@pytest.fixture
+def mock_s3(call_log):
+    client = MagicMock()
+
+    def put_object(**kwargs):
+        call_log.append(("s3_put_object", kwargs))
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    client.put_object.side_effect = put_object
+    return client
+
+
+@pytest.fixture
+def mock_sqs(call_log):
+    client = MagicMock()
+
+    def send_message(**kwargs):
+        call_log.append(("sqs_send_message", kwargs))
+        return {"MessageId": str(uuid.uuid4())}
+
+    client.send_message.side_effect = send_message
+    return client
+
+
+@pytest.fixture
+def publisher(tmp_path, mock_s3, mock_sqs, call_log):
+    json_dir = tmp_path / "output" / "consolidated"
+    json_dir.mkdir(parents=True)
+    json_file = json_dir / "test-campaign_all_cluster_analysis.json"
+    json_file.write_text(json.dumps([{"atomicId": "a1", "phoneNumber": "+1111"}]))
+
+    config = _make_config(tmp_path, publish_to_sqs=True)
+    pub = SQSEventPublisher(config, s3_client=mock_s3, sqs_client=mock_sqs)
+    return pub
+
+
+@pytest.fixture
+def publisher_no_local_file(tmp_path, mock_s3, mock_sqs, call_log):
+    (tmp_path / "output").mkdir(parents=True, exist_ok=True)
+    config = _make_config(tmp_path, publish_to_sqs=True)
+    pub = SQSEventPublisher(config, s3_client=mock_s3, sqs_client=mock_sqs)
+    return pub
+
+
+class TestContractCompliance:
+    @pytest.mark.asyncio
+    async def test_event_structure_matches_gp_api_schema(self, publisher, call_log):
+        records = [_make_record("+1111111111", "poll-1")]
+        result = await publisher.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=records, campaign_name="test-campaign"
+        )
+
+        sqs_calls = [c for c in call_log if c[0] == "sqs_send_message"]
+        assert len(sqs_calls) == 1
+        body = json.loads(sqs_calls[0][1]["MessageBody"])
+        assert body["type"] == "pollAnalysisComplete"
+        assert "pollId" in body["data"]
+        assert "totalResponses" in body["data"]
+        assert "responsesLocation" in body["data"]
+        assert "issues" in body["data"]
+        assert isinstance(body["data"]["issues"], list)
+
+    @pytest.mark.asyncio
+    async def test_responses_location_format(self, publisher, call_log):
+        records = [_make_record("+1111111111", "poll-1")]
+        await publisher.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=records, campaign_name="test-campaign"
+        )
+        sqs_calls = [c for c in call_log if c[0] == "sqs_send_message"]
+        body = json.loads(sqs_calls[0][1]["MessageBody"])
+        assert body["data"]["responsesLocation"] == "prefix/path/consolidated/test-campaign_all_cluster_analysis.json"
+
+    @pytest.mark.asyncio
+    async def test_responses_location_with_trailing_slash(self, tmp_path, mock_s3, mock_sqs):
+        config = _make_config(tmp_path, publish_to_sqs=True, s3_output_path="s3://bucket/prefix/path/")
+        pub = SQSEventPublisher(config, s3_client=mock_s3, sqs_client=mock_sqs)
+        loc = pub._compute_responses_location("test-campaign")
+        assert loc == "prefix/path/consolidated/test-campaign_all_cluster_analysis.json"
+
+
+class TestS3UploadBeforeSqsSend:
+    @pytest.mark.asyncio
+    async def test_s3_upload_happens_before_sqs_send(self, publisher, call_log):
+        records = [_make_record("+1111111111", "poll-1")]
+        await publisher.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=records, campaign_name="test-campaign"
+        )
+        ops = [c[0] for c in call_log]
+        s3_idx = ops.index("s3_put_object")
+        sqs_idx = ops.index("sqs_send_message")
+        assert s3_idx < sqs_idx, f"S3 upload (index {s3_idx}) must happen before SQS send (index {sqs_idx})"
+
+    @pytest.mark.asyncio
+    async def test_s3_upload_uses_correct_bucket_and_key(self, publisher, call_log):
+        records = [_make_record("+1111111111", "poll-1")]
+        await publisher.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=records, campaign_name="test-campaign"
+        )
+        s3_calls = [c for c in call_log if c[0] == "s3_put_object"]
+        assert len(s3_calls) == 1
+        assert s3_calls[0][1]["Bucket"] == "test-bucket"
+        assert s3_calls[0][1]["Key"] == "prefix/path/consolidated/test-campaign_all_cluster_analysis.json"
+
+    @pytest.mark.asyncio
+    async def test_s3_upload_sends_file_content(self, publisher, call_log):
+        records = [_make_record("+1111111111", "poll-1")]
+        await publisher.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=records, campaign_name="test-campaign"
+        )
+        s3_calls = [c for c in call_log if c[0] == "s3_put_object"]
+        body = s3_calls[0][1]["Body"]
+        parsed = json.loads(body)
+        assert isinstance(parsed, list)
+        assert len(parsed) > 0
+
+    @pytest.mark.asyncio
+    async def test_s3_failure_prevents_sqs_send(self, tmp_path, mock_sqs, call_log):
+        failing_s3 = MagicMock()
+        failing_s3.put_object.side_effect = Exception("S3 network error")
+
+        json_dir = tmp_path / "output" / "consolidated"
+        json_dir.mkdir(parents=True)
+        json_file = json_dir / "test-campaign_all_cluster_analysis.json"
+        json_file.write_text(json.dumps([{"atomicId": "a1"}]))
+
+        config = _make_config(tmp_path, publish_to_sqs=True)
+        pub = SQSEventPublisher(config, s3_client=failing_s3, sqs_client=mock_sqs)
+
+        records = [_make_record("+1111111111", "poll-1")]
+        with pytest.raises(RuntimeError, match="S3 upload failed.*S3 network error"):
+            await pub.publish_poll_completion(
+                poll_ids=["poll-1"], unified_records=records, campaign_name="test-campaign"
+            )
+
+        sqs_calls = [c for c in call_log if c[0] == "sqs_send_message"]
+        assert len(sqs_calls) == 0, "SQS must NOT send if S3 upload fails"
+
+
+class TestEmptyPollCompletion:
+    @pytest.mark.asyncio
+    async def test_empty_poll_has_valid_responses_location(self, publisher_no_local_file, call_log):
+        await publisher_no_local_file.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=[], campaign_name="test-campaign"
+        )
+        sqs_calls = [c for c in call_log if c[0] == "sqs_send_message"]
+        body = json.loads(sqs_calls[0][1]["MessageBody"])
+        loc = body["data"]["responsesLocation"]
+        assert loc != "", "responsesLocation must not be empty string"
+        assert "consolidated" in loc
+
+    @pytest.mark.asyncio
+    async def test_empty_poll_uploads_empty_array_to_s3(self, publisher_no_local_file, call_log):
+        await publisher_no_local_file.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=[], campaign_name="test-campaign"
+        )
+        s3_calls = [c for c in call_log if c[0] == "s3_put_object"]
+        assert len(s3_calls) == 1
+        body = s3_calls[0][1]["Body"]
+        parsed = json.loads(body)
+        assert parsed == []
+
+    @pytest.mark.asyncio
+    async def test_empty_poll_s3_upload_before_sqs(self, publisher_no_local_file, call_log):
+        await publisher_no_local_file.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=[], campaign_name="test-campaign"
+        )
+        ops = [c[0] for c in call_log]
+        s3_idx = ops.index("s3_put_object")
+        sqs_idx = ops.index("sqs_send_message")
+        assert s3_idx < sqs_idx
+
+    @pytest.mark.asyncio
+    async def test_empty_poll_event_has_zero_responses_and_no_issues(self, publisher_no_local_file, call_log):
+        await publisher_no_local_file.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=[], campaign_name="test-campaign"
+        )
+        sqs_calls = [c for c in call_log if c[0] == "sqs_send_message"]
+        body = json.loads(sqs_calls[0][1]["MessageBody"])
+        assert body["data"]["totalResponses"] == 0
+        assert body["data"]["issues"] == []
+
+
+class TestMultiPollCompleteness:
+    @pytest.mark.asyncio
+    async def test_poll_with_zero_records_still_gets_event(self, publisher, call_log):
+        records = [_make_record("+1111111111", "poll-1")]
+        await publisher.publish_poll_completion(
+            poll_ids=["poll-1", "poll-2"], unified_records=records, campaign_name="test-campaign"
+        )
+        sqs_calls = [c for c in call_log if c[0] == "sqs_send_message"]
+        assert len(sqs_calls) == 2, "Both poll-1 and poll-2 must get SQS events"
+        poll_ids_sent = [json.loads(c[1]["MessageBody"])["data"]["pollId"] for c in sqs_calls]
+        assert "poll-1" in poll_ids_sent
+        assert "poll-2" in poll_ids_sent
+
+        poll_2_body = next(
+            json.loads(c[1]["MessageBody"]) for c in sqs_calls
+            if json.loads(c[1]["MessageBody"])["data"]["pollId"] == "poll-2"
+        )
+        assert poll_2_body["data"]["totalResponses"] == 0
+        assert poll_2_body["data"]["issues"] == []
+
+    @pytest.mark.asyncio
+    async def test_single_s3_upload_for_multiple_polls(self, publisher, call_log):
+        records = [
+            _make_record("+1111111111", "poll-1"),
+            _make_record("+2222222222", "poll-2"),
+        ]
+        await publisher.publish_poll_completion(
+            poll_ids=["poll-1", "poll-2"], unified_records=records, campaign_name="test-campaign"
+        )
+        s3_calls = [c for c in call_log if c[0] == "s3_put_object"]
+        assert len(s3_calls) == 1, "Only one S3 put_object regardless of poll count"
+
+
+class TestRespondentCounting:
+    @pytest.mark.asyncio
+    async def test_unique_phones_excluding_opt_outs(self, publisher, call_log):
+        records = [
+            _make_record("+1111111111", "poll-1"),
+            _make_record("+1111111111", "poll-1", cluster_id=2, theme="Water"),
+            _make_record("+2222222222", "poll-1"),
+            _make_record("+3333333333", "poll-1", is_opt_out=True),
+        ]
+        await publisher.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=records, campaign_name="test-campaign"
+        )
+        sqs_calls = [c for c in call_log if c[0] == "sqs_send_message"]
+        body = json.loads(sqs_calls[0][1]["MessageBody"])
+        assert body["data"]["totalResponses"] == 2, "Only 2 unique non-opt-out phones"
+
+    @pytest.mark.asyncio
+    async def test_all_opt_out_campaign_sends_zero_responses(self, publisher, call_log):
+        records = [
+            _make_record("+1111111111", "poll-1", is_opt_out=True),
+            _make_record("+2222222222", "poll-1", is_opt_out=True),
+        ]
+        await publisher.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=records, campaign_name="test-campaign"
+        )
+        sqs_calls = [c for c in call_log if c[0] == "sqs_send_message"]
+        body = json.loads(sqs_calls[0][1]["MessageBody"])
+        assert body["data"]["totalResponses"] == 0
+
+
+class TestClusterRanking:
+    @pytest.mark.asyncio
+    async def test_top_n_by_response_count(self, publisher, call_log):
+        records = []
+        for i in range(10):
+            records.append(_make_record(f"+{i:010d}", "poll-1", cluster_id=1, theme="Roads"))
+        for i in range(10, 15):
+            records.append(_make_record(f"+{i:010d}", "poll-1", cluster_id=2, theme="Water"))
+        for i in range(15, 23):
+            records.append(_make_record(f"+{i:010d}", "poll-1", cluster_id=3, theme="Schools"))
+        for i in range(23, 25):
+            records.append(_make_record(f"+{i:010d}", "poll-1", cluster_id=4, theme="Parks"))
+
+        await publisher.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=records, campaign_name="test-campaign"
+        )
+        sqs_calls = [c for c in call_log if c[0] == "sqs_send_message"]
+        body = json.loads(sqs_calls[0][1]["MessageBody"])
+        issues = body["data"]["issues"]
+        assert len(issues) == 3, "top_n=3 means only 3 issues"
+        response_counts = [i["responseCount"] for i in issues]
+        assert response_counts == sorted(response_counts, reverse=True)
+
+    @pytest.mark.asyncio
+    async def test_respects_min_respondents_threshold(self, tmp_path, mock_s3, mock_sqs, call_log):
+        json_dir = tmp_path / "output" / "consolidated"
+        json_dir.mkdir(parents=True)
+        (json_dir / "test-campaign_all_cluster_analysis.json").write_text("[]")
+
+        config = _make_config(tmp_path, publish_to_sqs=True)
+        config["min_unique_respondents"] = 5
+        pub = SQSEventPublisher(config, s3_client=mock_s3, sqs_client=mock_sqs)
+
+        records = [_make_record(f"+{i:010d}", "poll-1", cluster_id=1, theme="Roads") for i in range(3)]
+        await pub.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=records, campaign_name="test-campaign"
+        )
+        sqs_calls = [c for c in call_log if c[0] == "sqs_send_message"]
+        body = json.loads(sqs_calls[0][1]["MessageBody"])
+        assert body["data"]["issues"] == [], "Cluster with 3 respondents < min 5 should be excluded"
+
+
+class TestLocalEventSaving:
+    @pytest.mark.asyncio
+    async def test_events_saved_locally_even_when_sqs_disabled(self, tmp_path, mock_s3):
+        config = _make_config(tmp_path, publish_to_sqs=False)
+        pub = SQSEventPublisher(config, s3_client=mock_s3)
+
+        records = [_make_record("+1111111111", "poll-1")]
+        await pub.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=records, campaign_name="test-campaign"
+        )
+
+        events_dir = tmp_path / "output" / "events"
+        assert events_dir.exists()
+        event_files = list(events_dir.glob("events_*.json"))
+        assert len(event_files) == 1
+        events = json.loads(event_files[0].read_text())
+        assert len(events) == 1
+        assert events[0]["data"]["pollId"] == "poll-1"
+
+
+class TestValidation:
+    def test_publish_to_sqs_without_queue_url_raises(self, tmp_path):
+        config = {
+            "publish_to_sqs": True,
+            "output_dir": str(tmp_path),
+            "s3_output_path": "s3://bucket/prefix",
+            "s3_bucket": "test-bucket",
+        }
+        with pytest.raises(ValueError, match="no queue_url configured"):
+            SQSEventPublisher(config)
+
+    @pytest.mark.asyncio
+    async def test_corrupted_json_file_uploads_empty_array(self, tmp_path, mock_s3, mock_sqs, call_log):
+        json_dir = tmp_path / "output" / "consolidated"
+        json_dir.mkdir(parents=True)
+        (json_dir / "test-campaign_all_cluster_analysis.json").write_text('{"truncated": ')
+
+        config = _make_config(tmp_path, publish_to_sqs=True)
+        pub = SQSEventPublisher(config, s3_client=mock_s3, sqs_client=mock_sqs)
+
+        await pub.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=[], campaign_name="test-campaign"
+        )
+        s3_calls = [c for c in call_log if c[0] == "s3_put_object"]
+        body = s3_calls[0][1]["Body"]
+        assert json.loads(body) == [], "Corrupted JSON should fall back to empty array"
+
+    def test_leading_slash_stripped_from_s3_key(self, tmp_path):
+        config = _make_config(tmp_path, publish_to_sqs=False, s3_output_path="s3://mybucket")
+        pub = SQSEventPublisher(config)
+        loc = pub._compute_responses_location("test-campaign")
+        assert not loc.startswith("/"), f"S3 key must not start with /: {loc}"
+        assert loc == "consolidated/test-campaign_all_cluster_analysis.json"
+
+    @pytest.mark.asyncio
+    async def test_finds_json_when_output_dir_is_consolidated(self, tmp_path, mock_s3, mock_sqs, call_log):
+        consolidated_dir = tmp_path / "output" / "consolidated"
+        consolidated_dir.mkdir(parents=True)
+        (consolidated_dir / "test-campaign_all_cluster_analysis.json").write_text(
+            json.dumps([{"atomicId": "a1", "phoneNumber": "+1111"}])
+        )
+
+        config = _make_config(tmp_path, publish_to_sqs=True)
+        config["output_dir"] = str(consolidated_dir)
+        pub = SQSEventPublisher(config, s3_client=mock_s3, sqs_client=mock_sqs)
+
+        await pub.publish_poll_completion(
+            poll_ids=["poll-1"], unified_records=[], campaign_name="test-campaign"
+        )
+        s3_calls = [c for c in call_log if c[0] == "s3_put_object"]
+        body = json.loads(s3_calls[0][1]["Body"])
+        assert len(body) == 1, "Should upload real JSON, not empty array fallback"
+        assert body[0]["atomicId"] == "a1"


### PR DESCRIPTION
…_poll_completion method. S3 put_object now happens in Python before SQS send, fixing race condition where gp-api received the event before the file existed. Empty polls upload [] to a real S3 key instead of sending empty responsesLocation. Add zero-byte CSV and EmptyDataError handling in orchestrator.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches event delivery and S3/SQS ordering/validation, which can impact downstream consumers if misconfigured or if upload behavior differs across environments; changes are well-covered by new tests.
> 
> **Overview**
> Unifies SQS completion publishing into a single `publish_poll_completion` flow, including for empty polls, and removes the separate empty-poll publisher path.
> 
> The publisher now uploads the campaign’s consolidated responses JSON to S3 *before* sending completion events to SQS (falling back to uploading `[]` and validating/correcting corrupted JSON), and validates required SQS config when enabled.
> 
> The orchestrator now skips zero-byte/empty CSVs during consolidation while still emitting completion events for all discovered `poll_id`s, and adds a comprehensive test suite covering event contract, S3 key formatting, S3-before-SQS ordering, multi-poll/empty-poll behavior, and error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef108b0851fbefc574a3e2d7fbe249b9d9898a94. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->