### PR TITLE
importing sns and adding kms to them

### DIFF
--- a/infrastructure/modules/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/modules/ddhq-matcher-fargate/main.tf
@@ -474,7 +474,8 @@ output "security_group_id" {
 }
 
 resource "aws_sns_topic" "matcher_failures" {
-  name = "ddhq-matcher-failures-${var.environment}"
+  name              = "ddhq-matcher-failures-${var.environment}"
+  kms_master_key_id = "alias/aws/sns"
 
   tags = {
     Name        = "DDHQ Matcher Failures"

--- a/infrastructure/modules/serve-analyze-fargate/main.tf
+++ b/infrastructure/modules/serve-analyze-fargate/main.tf
@@ -444,7 +444,8 @@ output "security_group_id" {
 }
 
 resource "aws_sns_topic" "pipeline_failures" {
-  name = "serve-analyze-pipeline-failures-${var.environment}"
+  name              = "serve-analyze-pipeline-failures-${var.environment}"
+  kms_master_key_id = "alias/aws/sns"
 
   tags = {
     Name        = "Pipeline Failures"


### PR DESCRIPTION
Adding kms_master_key_id = "alias/aws/sns" to the `ddhq-matcher` and `serve-analyze` SNS topic resources. These were the only 2 modules missing it I believe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated Terraform change that only enables default SNS encryption using an AWS-managed KMS key; low chance of impacting runtime behavior aside from any environment-specific KMS policy restrictions.
> 
> **Overview**
> Adds `kms_master_key_id = "alias/aws/sns"` to the `ddhq-matcher-fargate` and `serve-analyze-fargate` failure SNS topics, enabling server-side encryption at rest for messages published to these topics.
> 
> No behavioral changes to subscriptions or publishing paths are introduced beyond the encryption setting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78e4da5e487df20c6d81aff48ead1d0624be0bbc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->