### PR TITLE
Integrate Braintrust prompt caching into gold data production matcher…

### DIFF
--- a/shared/docs/braintrust.md
+++ b/shared/docs/braintrust.md
@@ -26,6 +26,7 @@ Each folder in gp-ai-projects maps to a Braintrust project. Pass the project nam
 | `ai_generated_campaign_plan` | `campaign-plan` |
 | `serve/analyze_texts` | `analyze-texts` |
 | `hubspot_ddhq_match` | `hubspot-ddhq-match` |
+| `stitch_golden_data` | `stitch-golden-data` |
 
 ## Usage
 
@@ -125,6 +126,7 @@ terraform apply
 | Service | Environment | Status | Date |
 |---------|-------------|--------|------|
 | serve-analyze (hierarchical_discovery) | dev | Experiment | TBD |
+| stitch_golden_data (prod_gold_data) | dev | Prompt caching | TBD |
 
 ## Architecture Notes
 

--- a/stitch_golden_data/prod_gold_data/production_matcher.py
+++ b/stitch_golden_data/prod_gold_data/production_matcher.py
@@ -35,6 +35,7 @@ from shared.databricks_client import DatabricksClient
 from shared.llm_gemini_3 import Gemini3Client, GeminiModelType, ThinkingLevel
 from shared.llm_gemini import GeminiEmbeddingClient
 from shared.logger import get_logger
+from shared.braintrust import init_braintrust, cache_prompt, build_cached_prompt, flush_logs
 from tqdm.asyncio import tqdm
 import time
 
@@ -111,6 +112,17 @@ class ProductionMatcher:
         
         # Create ThreadPoolExecutor for maximum concurrency
         self.thread_pool = ThreadPoolExecutor(max_workers=self.max_workers)
+
+        init_braintrust(project="stitch-golden-data")
+        self._init_prompt_cache()
+
+    def _init_prompt_cache(self):
+        self._prompt_name = "stitch-golden-data-matcher"
+        prompt_obj = cache_prompt(self._prompt_name)
+        if prompt_obj is not None:
+            self.logger.info("Braintrust prompt cached for stitch-golden-data-matcher")
+        else:
+            self.logger.warning("Braintrust prompt not available, using fallback")
 
     def get_available_states(self) -> List[str]:
         """Get list of states with available vector stores"""
@@ -370,36 +382,46 @@ class ProductionMatcher:
         
         districts_text = "\n".join(district_descriptions)
         state = districts[0].state if districts else "Unknown"
-        
-        prompt = f"""
+        num_districts = str(len(districts))
+
+        variables = {
+            "br_name": br_name,
+            "state": state,
+            "districts_text": districts_text,
+            "num_districts": num_districts,
+        }
+
+        fallback_prompt = f"""
 You are analyzing a political position to find the best L2 district match from candidate districts.
 
 BR Position Details:
 - Name: "{br_name}"
 - State: {state}
 
-Top {len(districts)} District Candidates:
+Top {num_districts} District Candidates:
 {districts_text}
 
 Analyze the BR position and select the BEST matching candidate. Consider:
 - Geographic alignment (city/county matching)
 - Office type and district type compatibility
-- Specific identifiers or numbers in names 
+- Specific identifiers or numbers in names
 - Functional role alignment (e.g., School Board → School Board districts)
 - Ignore seats and positions
 - if the office is greater than the state level, match to the state level
 
 Return JSON with:
-• selected_candidate_number: Number (1-{len(districts)}) of your choice, or 0 if no good match
+• selected_candidate_number: Number (1-{num_districts}) of your choice, or 0 if no good match
 • selection_confidence: Confidence level (0-100)
 • reasoning: Detailed explanation of your selection or rejection
 • close_alternatives: Array of candidate numbers that were very close (only if multiple options were neck-and-neck)
 
-IMPORTANT: Return 0 if no candidate represents a reasonable match. 
-There is a real probability that the match does not exist so return 0 if there is no clear match. 
+IMPORTANT: Return 0 if no candidate represents a reasonable match.
+There is a real probability that the match does not exist so return 0 if there is no clear match.
 
-Base decisions on semantic meaning, geography, and functional appropriateness. 
+Base decisions on semantic meaning, geography, and functional appropriateness.
 """
+
+        prompt = build_cached_prompt(self._prompt_name, variables, fallback_prompt=fallback_prompt)
         
         response_schema = {
             "type": "object",
@@ -420,7 +442,8 @@ Base decisions on semantic meaning, geography, and functional appropriateness.
                 self.thread_pool,
                 lambda: self.llm.generate_structured_content(
                     prompt=prompt,
-                    response_schema=response_schema
+                    response_schema=response_schema,
+                    trace_name="stitch-match-selection"
                 )
             )
         except Exception as e:
@@ -1346,5 +1369,10 @@ async def main():
         print(f"   # Process all states with maximum throughput:")
         print(f"   uv run stitch_golden_data/prod_gold_data/production_matcher.py all_states --batch-size 1000 --max-concurrent-states 2 --max-workers 1500")
 
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    finally:
+        flush_logs()

--- a/stitch_golden_data/prod_gold_data/production_matcher.py
+++ b/stitch_golden_data/prod_gold_data/production_matcher.py
@@ -422,6 +422,8 @@ Base decisions on semantic meaning, geography, and functional appropriateness.
 """
 
         prompt = build_cached_prompt(self._prompt_name, variables, fallback_prompt=fallback_prompt)
+        if not prompt:
+            prompt = fallback_prompt
         
         response_schema = {
             "type": "object",

--- a/stitch_golden_data/prod_gold_data/tests/test_braintrust_integration.py
+++ b/stitch_golden_data/prod_gold_data/tests/test_braintrust_integration.py
@@ -1,0 +1,131 @@
+from unittest.mock import patch, MagicMock
+import pytest
+
+from stitch_golden_data.prod_gold_data.production_matcher import (
+    ProductionMatcher,
+    EmbeddingDistrict,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_braintrust_singleton():
+    from shared.braintrust import BraintrustClient
+    BraintrustClient.reset_instance()
+    yield
+    BraintrustClient.reset_instance()
+
+
+@pytest.fixture
+def mock_dependencies():
+    with (
+        patch("stitch_golden_data.prod_gold_data.production_matcher.DatabricksClient") as mock_db,
+        patch("stitch_golden_data.prod_gold_data.production_matcher.Gemini3Client") as mock_llm_cls,
+        patch("stitch_golden_data.prod_gold_data.production_matcher.GeminiEmbeddingClient") as mock_emb_cls,
+        patch("stitch_golden_data.prod_gold_data.production_matcher.init_braintrust") as mock_init_bt,
+        patch("stitch_golden_data.prod_gold_data.production_matcher.cache_prompt") as mock_cache,
+    ):
+        mock_llm = MagicMock()
+        mock_llm_cls.return_value = mock_llm
+        mock_emb = MagicMock()
+        mock_emb_cls.return_value = mock_emb
+
+        yield {
+            "databricks": mock_db,
+            "llm_cls": mock_llm_cls,
+            "llm": mock_llm,
+            "embedding_cls": mock_emb_cls,
+            "embedding": mock_emb,
+            "init_braintrust": mock_init_bt,
+            "cache_prompt": mock_cache,
+        }
+
+
+class TestBraintrustInit:
+    def test_init_braintrust_called_on_construction(self, mock_dependencies):
+        matcher = ProductionMatcher()
+
+        mock_dependencies["init_braintrust"].assert_called_once_with(project="stitch-golden-data")
+
+    def test_cache_prompt_called_on_construction(self, mock_dependencies):
+        matcher = ProductionMatcher()
+
+        mock_dependencies["cache_prompt"].assert_called_once_with(
+            "stitch-golden-data-matcher",
+        )
+
+
+class TestPromptBuilding:
+    def test_build_cached_prompt_called_with_correct_variables(self, mock_dependencies):
+        matcher = ProductionMatcher()
+
+        districts = [
+            EmbeddingDistrict(
+                l2_district_name="City Council District 1",
+                l2_district_type="CITY_COUNCIL",
+                similarity_score=0.95,
+                l2_full_text="City Council District 1",
+                state="DE",
+            ),
+            EmbeddingDistrict(
+                l2_district_name="County Board District 2",
+                l2_district_type="COUNTY_BOARD",
+                similarity_score=0.85,
+                l2_full_text="County Board District 2",
+                state="DE",
+            ),
+        ]
+
+        mock_dependencies["llm"].generate_structured_content.return_value = {
+            "selected_candidate_number": 1,
+            "selection_confidence": 90,
+            "reasoning": "Best geographic match",
+        }
+
+        with patch("stitch_golden_data.prod_gold_data.production_matcher.build_cached_prompt") as mock_build:
+            mock_build.return_value = "rendered prompt"
+
+            import asyncio
+            result = asyncio.run(matcher.llm_select_best_match("Wilmington City Council", districts))
+
+            mock_build.assert_called_once()
+            call_args = mock_build.call_args
+            assert call_args[0][0] == "stitch-golden-data-matcher"
+
+            variables = call_args[0][1]
+            assert variables["br_name"] == "Wilmington City Council"
+            assert variables["state"] == "DE"
+            assert variables["num_districts"] == "2"
+            assert "City Council District 1" in variables["districts_text"]
+            assert "County Board District 2" in variables["districts_text"]
+
+            assert call_args[1]["fallback_prompt"] is not None
+            assert len(call_args[1]["fallback_prompt"]) > 0
+
+class TestTraceNamePassthrough:
+    def test_trace_name_passed_to_generate_structured_content(self, mock_dependencies):
+        matcher = ProductionMatcher()
+
+        districts = [
+            EmbeddingDistrict(
+                l2_district_name="School Board",
+                l2_district_type="SCHOOL_BOARD",
+                similarity_score=0.88,
+                l2_full_text="School Board",
+                state="NY",
+            ),
+        ]
+
+        mock_dependencies["llm"].generate_structured_content.return_value = {
+            "selected_candidate_number": 1,
+            "selection_confidence": 92,
+            "reasoning": "Exact match",
+        }
+
+        with patch("stitch_golden_data.prod_gold_data.production_matcher.build_cached_prompt", return_value="prompt"):
+            import asyncio
+            asyncio.run(matcher.llm_select_best_match("School Board", districts))
+
+        call_kwargs = mock_dependencies["llm"].generate_structured_content.call_args[1]
+        assert call_kwargs["trace_name"] == "stitch-match-selection"
+
+


### PR DESCRIPTION
… Adds cached prompt loading with fallback to inline prompts when Braintrust is unavailable. Adds trace_name for LLM call attribution Braintrust wiring.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production LLM-matching path by changing how prompts are built and adding Braintrust initialization/tracing; behavior should be unchanged when Braintrust is disabled, but prompt rendering differences could affect match outputs.
> 
> **Overview**
> Integrates Braintrust into `stitch_golden_data`’s `ProductionMatcher` by initializing Braintrust on construction, caching a named prompt (`stitch-golden-data-matcher`), and building the LLM prompt via `build_cached_prompt` with a local fallback string.
> 
> Adds per-call attribution via `trace_name="stitch-match-selection"` on the `generate_structured_content` LLM call, ensures Braintrust logs are flushed on script exit, and updates Braintrust docs to include the new `stitch-golden-data` project plus rollout entry. Includes new tests covering Braintrust init/prompt caching, prompt variable wiring, and trace name passthrough.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 809a94b79516d7df1f88c19a921dec2769ea53e0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->