### PR TITLE
Add generate_with_search to gemini 3 code.

### DIFF
--- a/shared/llm_gemini_3.py
+++ b/shared/llm_gemini_3.py
@@ -44,6 +44,10 @@ class SearchResult(BaseModel):
     sources: List[SearchSource] = []
 
 
+class _BlockedResponseError(Exception):
+    pass
+
+
 class Gemini3Client:
     def __init__(
         self,
@@ -310,6 +314,14 @@ class Gemini3Client:
                     )
                     self._update_usage(model_name, response)
 
+                    if hasattr(response, 'candidates') and response.candidates:
+                        finish_reason = getattr(response.candidates[0], 'finish_reason', None)
+                        # STOP means the model finished successfully. Anything else
+                        # (SAFETY, PROHIBITED_CONTENT, etc.) means the response was
+                        # blocked and retrying won't help.
+                        if finish_reason is not None and finish_reason != "STOP":
+                            raise _BlockedResponseError(f"Response blocked: {finish_reason}")
+
                     if not response.text:
                         raise ValueError("Empty response from API")
 
@@ -339,6 +351,9 @@ class Gemini3Client:
                         sources=sources
                     )
 
+                except _BlockedResponseError as e:
+                    self.logger.warning(f"Search response blocked (not retrying): {e}")
+                    raise
                 except Exception as e:
                     if attempt < self.max_retries - 1:
                         delay = self.base_delay * (2 ** attempt)

--- a/shared/llm_gemini_3.py
+++ b/shared/llm_gemini_3.py
@@ -1,7 +1,9 @@
 import os
 import json
 import time
-from typing import Optional, Type, Union, List, Dict, Any
+from typing import Optional, Type, TypeVar, Union, Callable, List, Dict, Any
+
+T = TypeVar('T')
 from enum import Enum
 from pydantic import BaseModel
 from dotenv import load_dotenv
@@ -29,6 +31,17 @@ class ThinkingLevel(Enum):
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
+
+
+class SearchSource(BaseModel):
+    title: str
+    uri: str
+
+
+class SearchResult(BaseModel):
+    text: str
+    search_queries: List[str] = []
+    sources: List[SearchSource] = []
 
 
 class Gemini3Client:
@@ -139,11 +152,11 @@ class Gemini3Client:
         self,
         trace_name: Optional[str],
         prompt: str,
-        llm_fn,
+        llm_fn: Callable[[], T],
         model_name: str,
         default_trace_name: str,
         temperature: Optional[float] = None
-    ):
+    ) -> T:
         if not braintrust_enabled():
             return llm_fn()
 
@@ -277,7 +290,7 @@ class Gemini3Client:
         thinking_level: Optional[ThinkingLevel] = None,
         system_instruction: Optional[str] = None,
         trace_name: Optional[str] = None
-    ):
+    ) -> SearchResult:
         effective_model = model or self.default_model
         model_name = effective_model.value
         config = self._build_config(effective_model, temperature, thinking_level)
@@ -300,11 +313,8 @@ class Gemini3Client:
                     if not response.text:
                         raise ValueError("Empty response from API")
 
-                    result = {
-                        "text": response.text,
-                        "search_queries": [],
-                        "sources": []
-                    }
+                    search_queries = []
+                    sources = []
 
                     if hasattr(response, 'candidates') and response.candidates:
                         candidate = response.candidates[0]
@@ -312,18 +322,22 @@ class Gemini3Client:
                             metadata = candidate.grounding_metadata
 
                             if hasattr(metadata, 'web_search_queries') and metadata.web_search_queries:
-                                result["search_queries"] = metadata.web_search_queries
+                                search_queries = metadata.web_search_queries
 
                             if hasattr(metadata, 'grounding_chunks') and metadata.grounding_chunks:
                                 for chunk in metadata.grounding_chunks:
                                     web = getattr(chunk, 'web', None)
                                     if web:
-                                        result["sources"].append({
-                                            "title": web.title or "Unknown",
-                                            "uri": web.uri or "Unknown"
-                                        })
+                                        sources.append(SearchSource(
+                                            title=web.title or "Unknown",
+                                            uri=web.uri or "Unknown"
+                                        ))
 
-                    return result
+                    return SearchResult(
+                        text=response.text,
+                        search_queries=search_queries,
+                        sources=sources
+                    )
 
                 except Exception as e:
                     if attempt < self.max_retries - 1:
@@ -454,11 +468,11 @@ if __name__ == "__main__":
         result = client.generate_with_search(
             prompt="Find community events happening in Boston, MA in 2026"
         )
-        print(f"   Text length: {len(result['text'])} chars")
-        print(f"   Sources found: {len(result['sources'])}")
-        for source in result['sources'][:3]:
-            print(f"      - {source['title']}: {source['uri']}")
-        assert result['text'], "Expected non-empty text response"
+        print(f"   Text length: {len(result.text)} chars")
+        print(f"   Sources found: {len(result.sources)}")
+        for source in result.sources[:3]:
+            print(f"      - {source.title}: {source.uri}")
+        assert result.text, "Expected non-empty text response"
         print("   PASSED")
     except Exception as e:
         print(f"   FAILED: {e}")

--- a/shared/llm_gemini_3.py
+++ b/shared/llm_gemini_3.py
@@ -269,6 +269,80 @@ class Gemini3Client:
             temperature=temperature
         )
 
+    def generate_with_search(
+        self,
+        prompt: str,
+        model: Optional[GeminiModelType] = None,
+        temperature: Optional[float] = None,
+        thinking_level: Optional[ThinkingLevel] = None,
+        system_instruction: Optional[str] = None,
+        trace_name: Optional[str] = None
+    ):
+        effective_model = model or self.default_model
+        model_name = effective_model.value
+        config = self._build_config(effective_model, temperature, thinking_level)
+
+        if system_instruction:
+            config.system_instruction = system_instruction
+
+        config.tools = [types.Tool(google_search=types.GoogleSearch())]
+
+        def _execute_call():
+            for attempt in range(self.max_retries):
+                try:
+                    response = self.client.models.generate_content(
+                        model=model_name,
+                        contents=prompt,
+                        config=config
+                    )
+                    self._update_usage(model_name, response)
+
+                    if not response.text:
+                        raise ValueError("Empty response from API")
+
+                    result = {
+                        "text": response.text,
+                        "search_queries": [],
+                        "sources": []
+                    }
+
+                    if hasattr(response, 'candidates') and response.candidates:
+                        candidate = response.candidates[0]
+                        if hasattr(candidate, 'grounding_metadata') and candidate.grounding_metadata:
+                            metadata = candidate.grounding_metadata
+
+                            if hasattr(metadata, 'web_search_queries') and metadata.web_search_queries:
+                                result["search_queries"] = metadata.web_search_queries
+
+                            if hasattr(metadata, 'grounding_chunks') and metadata.grounding_chunks:
+                                for chunk in metadata.grounding_chunks:
+                                    web = getattr(chunk, 'web', None)
+                                    if web:
+                                        result["sources"].append({
+                                            "title": web.title or "Unknown",
+                                            "uri": web.uri or "Unknown"
+                                        })
+
+                    return result
+
+                except Exception as e:
+                    if attempt < self.max_retries - 1:
+                        delay = self.base_delay * (2 ** attempt)
+                        self.logger.warning(f"Search attempt {attempt + 1} failed: {e}. Retrying in {delay}s")
+                        time.sleep(delay)
+                    else:
+                        self.logger.error(f"All {self.max_retries} search attempts failed: {e}")
+                        raise
+
+        return self._traced_call(
+            trace_name=trace_name,
+            prompt=prompt,
+            llm_fn=_execute_call,
+            model_name=model_name,
+            default_trace_name="generate_with_search",
+            temperature=temperature
+        )
+
     def get_usage_stats(self) -> Dict[str, Any]:
         return {
             "api_calls": self.api_call_count,
@@ -371,6 +445,20 @@ if __name__ == "__main__":
         )
         print(f"   Response: {result}")
         assert "paris" in result.lower(), "Expected 'Paris' in response"
+        print("   PASSED")
+    except Exception as e:
+        print(f"   FAILED: {e}")
+
+    print("\n7. Testing generate_with_search (Google Search grounding)...")
+    try:
+        result = client.generate_with_search(
+            prompt="Find community events happening in Boston, MA in 2026"
+        )
+        print(f"   Text length: {len(result['text'])} chars")
+        print(f"   Sources found: {len(result['sources'])}")
+        for source in result['sources'][:3]:
+            print(f"      - {source['title']}: {source['uri']}")
+        assert result['text'], "Expected non-empty text response"
         print("   PASSED")
     except Exception as e:
         print(f"   FAILED: {e}")

--- a/shared/tests/test_llm_gemini_3.py
+++ b/shared/tests/test_llm_gemini_3.py
@@ -6,6 +6,7 @@ from shared.llm_gemini_3 import (
     Gemini3Client,
     GeminiModelType,
     ThinkingLevel,
+    SearchResult,
     GEMINI_3_PRICING,
 )
 
@@ -820,3 +821,132 @@ class TestCallTimeout:
 
         result = client.generate_content(prompt="Test")
         assert result == "Success"
+
+
+class TestGenerateWithSearch:
+    def _make_mock_response(self, text="Search result text", with_grounding=True):
+        mock_response = Mock()
+        mock_response.text = text
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 50
+        mock_response.usage_metadata.candidates_token_count = 100
+        mock_response.usage_metadata.thoughts_token_count = 0
+
+        if with_grounding:
+            mock_chunk = Mock()
+            mock_chunk.web = Mock()
+            mock_chunk.web.title = "Example Source"
+            mock_chunk.web.uri = "https://example.com"
+
+            mock_metadata = Mock()
+            mock_metadata.web_search_queries = ["test query"]
+            mock_metadata.grounding_chunks = [mock_chunk]
+
+            mock_candidate = Mock()
+            mock_candidate.grounding_metadata = mock_metadata
+            mock_response.candidates = [mock_candidate]
+        else:
+            mock_response.candidates = []
+
+        return mock_response
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_returns_text_and_sources(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+        client.client.models.generate_content = Mock(
+            return_value=self._make_mock_response()
+        )
+
+        result = client.generate_with_search(prompt="Find events in Boston")
+
+        assert isinstance(result, SearchResult)
+        assert result.text == "Search result text"
+        assert result.search_queries == ["test query"]
+        assert len(result.sources) == 1
+        assert result.sources[0].title == "Example Source"
+        assert result.sources[0].uri == "https://example.com"
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_returns_empty_lists_without_grounding(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+        client.client.models.generate_content = Mock(
+            return_value=self._make_mock_response(with_grounding=False)
+        )
+
+        result = client.generate_with_search(prompt="Find events")
+
+        assert result.text == "Search result text"
+        assert result.search_queries == []
+        assert result.sources == []
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_raises_on_empty_response(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = Mock()
+        mock_response.text = None
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 50
+        mock_response.usage_metadata.candidates_token_count = 0
+        mock_response.usage_metadata.thoughts_token_count = 0
+        mock_response.candidates = []
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        with pytest.raises(ValueError, match="Empty response from API"):
+            client.generate_with_search(prompt="Find events")
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_configures_google_search_tool(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+        client.client.models.generate_content = Mock(
+            return_value=self._make_mock_response()
+        )
+
+        client.generate_with_search(prompt="Find events")
+
+        call_args = client.client.models.generate_content.call_args
+        config = call_args.kwargs['config']
+        assert config.tools is not None
+        assert len(config.tools) == 1
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    @patch('shared.llm_gemini_3.time.sleep')
+    def test_retries_on_failure(self, mock_sleep, _mock_genai):
+        client = Gemini3Client(api_key="test-key", max_retries=3)
+        client.client.models.generate_content = Mock(
+            side_effect=[
+                Exception("API error"),
+                Exception("API error again"),
+                self._make_mock_response()
+            ]
+        )
+
+        result = client.generate_with_search(prompt="Find events")
+
+        assert result.text == "Search result text"
+        assert mock_sleep.call_count == 2
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_handles_none_web_search_queries(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = self._make_mock_response()
+        mock_response.candidates[0].grounding_metadata.web_search_queries = None
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        result = client.generate_with_search(prompt="Find events")
+
+        assert result.search_queries == []
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_handles_chunk_without_web(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key")
+
+        mock_response = self._make_mock_response()
+        bad_chunk = Mock(spec=[])
+        mock_response.candidates[0].grounding_metadata.grounding_chunks = [bad_chunk]
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        result = client.generate_with_search(prompt="Find events")
+
+        assert result.sources == []

--- a/shared/tests/test_llm_gemini_3.py
+++ b/shared/tests/test_llm_gemini_3.py
@@ -843,6 +843,7 @@ class TestGenerateWithSearch:
             mock_metadata.grounding_chunks = [mock_chunk]
 
             mock_candidate = Mock()
+            mock_candidate.finish_reason = "STOP"
             mock_candidate.grounding_metadata = mock_metadata
             mock_response.candidates = [mock_candidate]
         else:
@@ -950,3 +951,25 @@ class TestGenerateWithSearch:
         result = client.generate_with_search(prompt="Find events")
 
         assert result.sources == []
+
+    @patch('shared.llm_gemini_3.genai.Client')
+    def test_blocked_response_does_not_retry(self, _mock_genai):
+        client = Gemini3Client(api_key="test-key", max_retries=3)
+
+        mock_response = Mock()
+        mock_response.text = None
+        mock_response.usage_metadata = Mock()
+        mock_response.usage_metadata.prompt_token_count = 50
+        mock_response.usage_metadata.candidates_token_count = 0
+        mock_response.usage_metadata.thoughts_token_count = 0
+
+        mock_candidate = Mock()
+        mock_candidate.finish_reason = "SAFETY"
+        mock_response.candidates = [mock_candidate]
+
+        client.client.models.generate_content = Mock(return_value=mock_response)
+
+        with pytest.raises(Exception, match="Response blocked: SAFETY"):
+            client.generate_with_search(prompt="blocked prompt")
+
+        assert client.client.models.generate_content.call_count == 1


### PR DESCRIPTION
This will be used for fetching events for the new campaign plan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Gemini call path that enables Google Search grounding and returns extracted source URLs, which may affect external data access, latency, and output format for callers that adopt it.
> 
> **Overview**
> Adds `Gemini3Client.generate_with_search`, which enables **Google Search grounding** via `config.tools` and returns a structured dict containing generated `text` plus extracted `search_queries` and cited `sources` from `grounding_metadata`.
> 
> Extends the module’s `__main__` integration test harness with a new test case exercising `generate_with_search` and printing a few returned sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eae9afdfc1b100f589b45a1ae8a23c05dbed2e78. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->