### PR TITLE
ENG 7058 braintrust

### DIFF
--- a/campaign_plan_lambda/build.sh
+++ b/campaign_plan_lambda/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -16,11 +16,12 @@ mkdir -p "$BUILD_DIR"
 
 # Install Python dependencies into build dir
 echo "Installing dependencies..."
-uv pip install \
+uv export --only-group campaign-plan-lambda --no-hashes --no-header --no-emit-project --frozen \
+    | uv pip install \
     --target "$BUILD_DIR" \
     --python-platform x86_64-unknown-linux-gnu \
     --python-version 3.12 \
-    -r "$SCRIPT_DIR/requirements.txt" \
+    -r - \
     --quiet
 
 # Copy campaign_plan_lambda package

--- a/campaign_plan_lambda/event_generator.py
+++ b/campaign_plan_lambda/event_generator.py
@@ -4,6 +4,8 @@ Generates community event tasks using Gemini Google Search grounding.
 2 AI calls:
 1. Google Search: find real community events in the candidate's area
 2. Filter, rank, and structure events as tasks
+
+Prompts are loaded from Braintrust (with hardcoded fallbacks if unavailable).
 """
 
 from datetime import date
@@ -12,9 +14,28 @@ from typing import List, Optional
 from pydantic import BaseModel, Field
 
 from shared.llm_gemini_3 import Gemini3Client
+from shared.braintrust import load_prompt_from_braintrust
 from shared.logger import get_logger
 
 logger = get_logger(__name__)
+
+SEARCH_PROMPT_FALLBACK = """Find community events where a political candidate can connect with voters.
+
+Location: {city}, {state}
+Date range: {today} to {election_date}"""
+
+FILTER_PROMPT_FALLBACK = """Select the best 5-8 community events from the data below for a candidate in {city}, {state}.
+
+RULES:
+- Only events between {today} and {election_date}
+- Prioritize events where the candidate can speak to or meet voters
+- Include a mix of formal meetings and community events
+- Dates must be in YYYY-MM-DD format
+- Title should be the event name
+- Description should explain why this event helps the campaign (one sentence)
+
+COMMUNITY EVENTS DATA:
+{raw_events}"""
 
 
 class LlmEventResult(BaseModel):
@@ -59,10 +80,16 @@ async def generate_event_tasks(
 async def _search_community_events(llm_client: Gemini3Client, city: str, state: str, election_date: date) -> str:
     logger.info(f"Searching for community events in {city}, {state}")
 
-    prompt = f"""Find community events where a political candidate can connect with voters.
-
-Location: {city}, {state}
-Date range: {date.today()} to {election_date}"""
+    prompt = load_prompt_from_braintrust(
+        prompt_name="search-community-events",
+        fallback_prompt=SEARCH_PROMPT_FALLBACK,
+        variables={
+            "city": city,
+            "state": state,
+            "today": str(date.today()),
+            "election_date": str(election_date),
+        },
+    )
 
     response = llm_client.generate_with_search(prompt)
     return response.text
@@ -79,18 +106,17 @@ async def _filter_and_structure_events(
 
     today = date.today()
 
-    prompt = f"""Select the best 5-8 community events from the data below for a candidate in {city}, {state}.
-
-RULES:
-- Only events between {today} and {election_date}
-- Prioritize events where the candidate can speak to or meet voters
-- Include a mix of formal meetings and community events
-- Dates must be in YYYY-MM-DD format
-- Title should be the event name
-- Description should explain why this event helps the campaign (one sentence)
-
-COMMUNITY EVENTS DATA:
-{raw_events}"""
+    prompt = load_prompt_from_braintrust(
+        prompt_name="filter-and-structure-events",
+        fallback_prompt=FILTER_PROMPT_FALLBACK,
+        variables={
+            "city": city,
+            "state": state,
+            "today": str(today),
+            "election_date": str(election_date),
+            "raw_events": raw_events,
+        },
+    )
 
     raw_response = llm_client.generate_structured_content(
         prompt=prompt,

--- a/campaign_plan_lambda/event_generator.py
+++ b/campaign_plan_lambda/event_generator.py
@@ -67,17 +67,18 @@ async def generate_event_tasks(
 ) -> List[CampaignEventTask]:
     llm_client = llm_client or Gemini3Client()
 
+    today = date.today()
     logger.info(f"Generating events for {city}, {state} (election: {election_date})")
 
-    raw_events = await _search_community_events(llm_client, city, state, election_date)
-    event_tasks = await _filter_and_structure_events(llm_client, city, state, election_date, raw_events)
+    raw_events = await _search_community_events(llm_client, city, state, election_date, today)
+    event_tasks = await _filter_and_structure_events(llm_client, city, state, election_date, today, raw_events)
 
     stats = llm_client.get_usage_stats()
     logger.info(f"Generated {len(event_tasks)} event tasks | Gemini: {stats['api_calls']} calls, ${stats['total_cost']:.4f}")
     return event_tasks
 
 
-async def _search_community_events(llm_client: Gemini3Client, city: str, state: str, election_date: date) -> str:
+async def _search_community_events(llm_client: Gemini3Client, city: str, state: str, election_date: date, today: date) -> str:
     logger.info(f"Searching for community events in {city}, {state}")
 
     prompt = load_prompt_from_braintrust(
@@ -86,7 +87,7 @@ async def _search_community_events(llm_client: Gemini3Client, city: str, state: 
         variables={
             "city": city,
             "state": state,
-            "today": str(date.today()),
+            "today": str(today),
             "election_date": str(election_date),
         },
     )
@@ -100,11 +101,10 @@ async def _filter_and_structure_events(
     city: str,
     state: str,
     election_date: date,
+    today: date,
     raw_events: str,
 ) -> List[CampaignEventTask]:
     logger.info("Filtering and structuring events as tasks")
-
-    today = date.today()
 
     prompt = load_prompt_from_braintrust(
         prompt_name="filter-and-structure-events",

--- a/campaign_plan_lambda/handler.py
+++ b/campaign_plan_lambda/handler.py
@@ -37,6 +37,7 @@ class LambdaEvent(TypedDict):
 
 class Secrets(BaseModel):
     GEMINI_API_KEY: str
+    BRAINTRUST_API_KEY: str
 
 
 _secrets_cache: Optional[Secrets] = None
@@ -77,11 +78,15 @@ def _load_secrets() -> Secrets:
 def _inject_secrets() -> None:
     secrets = _load_secrets()
     os.environ["GEMINI_API_KEY"] = secrets.GEMINI_API_KEY
+    os.environ["BRAINTRUST_API_KEY"] = secrets.BRAINTRUST_API_KEY
 
 
 def handler(event: LambdaEvent, context=None) -> None:
     _inject_secrets()
     os.environ.setdefault("ENVIRONMENT", "dev")
+
+    from shared.braintrust import init_braintrust
+    init_braintrust(project="campaign-plan")
 
     for record in event.get("Records", []):
         receive_count = int(

--- a/campaign_plan_lambda/handler.py
+++ b/campaign_plan_lambda/handler.py
@@ -37,7 +37,7 @@ class LambdaEvent(TypedDict):
 
 class Secrets(BaseModel):
     GEMINI_API_KEY: str
-    BRAINTRUST_API_KEY: str
+    BRAINTRUST_API_KEY: Optional[str] = None
 
 
 _secrets_cache: Optional[Secrets] = None
@@ -78,7 +78,8 @@ def _load_secrets() -> Secrets:
 def _inject_secrets() -> None:
     secrets = _load_secrets()
     os.environ["GEMINI_API_KEY"] = secrets.GEMINI_API_KEY
-    os.environ["BRAINTRUST_API_KEY"] = secrets.BRAINTRUST_API_KEY
+    if secrets.BRAINTRUST_API_KEY:
+        os.environ["BRAINTRUST_API_KEY"] = secrets.BRAINTRUST_API_KEY
 
 
 def handler(event: LambdaEvent, context=None) -> None:

--- a/campaign_plan_lambda/handler.py
+++ b/campaign_plan_lambda/handler.py
@@ -84,7 +84,6 @@ def _inject_secrets() -> None:
 
 def handler(event: LambdaEvent, context=None) -> None:
     _inject_secrets()
-    os.environ.setdefault("ENVIRONMENT", "dev")
 
     from shared.braintrust import init_braintrust
     init_braintrust(project="campaign-plan")

--- a/campaign_plan_lambda/requirements.txt
+++ b/campaign_plan_lambda/requirements.txt
@@ -2,3 +2,4 @@ pydantic>=2.0.0
 python-dotenv>=1.1.1
 google-genai>=1.56.0
 httpx>=0.28.1
+braintrust>=0.3.10

--- a/campaign_plan_lambda/requirements.txt
+++ b/campaign_plan_lambda/requirements.txt
@@ -1,5 +1,0 @@
-pydantic>=2.0.0
-python-dotenv>=1.1.1
-google-genai>=1.56.0
-httpx>=0.28.1
-braintrust>=0.3.10

--- a/campaign_plan_lambda/test_sqs_harness.py
+++ b/campaign_plan_lambda/test_sqs_harness.py
@@ -98,6 +98,7 @@ def main():
 
     handler_module._secrets_cache = handler_module.Secrets(
         GEMINI_API_KEY=os.environ.get("GEMINI_API_KEY", ""),
+        BRAINTRUST_API_KEY=os.environ.get("BRAINTRUST_API_KEY", ""),
     )
 
     output_module._s3_client = mock_s3_client

--- a/campaign_plan_lambda/tests/test_event_generator.py
+++ b/campaign_plan_lambda/tests/test_event_generator.py
@@ -26,7 +26,7 @@ class TestFilterAndStructureEvents:
 
         with pytest.raises(RuntimeError, match="none had valid dates"):
             await _filter_and_structure_events(
-                mock_client, "Boston", "MA", date(2026, 11, 4), date.today(), "raw events text"
+                mock_client, "Boston", "MA", date(2026, 11, 4), date(2026, 1, 1), "raw events text"
             )
 
     @pytest.mark.asyncio
@@ -41,7 +41,7 @@ class TestFilterAndStructureEvents:
 
         with pytest.raises(RuntimeError, match="none had valid dates"):
             await _filter_and_structure_events(
-                mock_client, "Boston", "MA", date(2026, 11, 4), date.today(), "raw events text"
+                mock_client, "Boston", "MA", date(2026, 11, 4), date(2026, 1, 1), "raw events text"
             )
 
     @pytest.mark.asyncio
@@ -52,7 +52,7 @@ class TestFilterAndStructureEvents:
         )
 
         result = await _filter_and_structure_events(
-            mock_client, "Boston", "MA", date(2026, 11, 4), date.today(), "raw events text"
+            mock_client, "Boston", "MA", date(2026, 11, 4), date(2026, 1, 1), "raw events text"
         )
 
         assert result == []
@@ -69,7 +69,7 @@ class TestFilterAndStructureEvents:
         )
 
         result = await _filter_and_structure_events(
-            mock_client, "Boston", "MA", date(2026, 11, 4), date.today(), "raw events text"
+            mock_client, "Boston", "MA", date(2026, 11, 4), date(2026, 1, 1), "raw events text"
         )
 
         assert len(result) == 1
@@ -88,7 +88,7 @@ class TestFilterAndStructureEvents:
         )
 
         result = await _filter_and_structure_events(
-            mock_client, "Boston", "MA", date(2026, 11, 4), date.today(), "raw events text"
+            mock_client, "Boston", "MA", date(2026, 11, 4), date(2026, 1, 1), "raw events text"
         )
 
         assert len(result) == 2

--- a/campaign_plan_lambda/tests/test_event_generator.py
+++ b/campaign_plan_lambda/tests/test_event_generator.py
@@ -26,7 +26,7 @@ class TestFilterAndStructureEvents:
 
         with pytest.raises(RuntimeError, match="none had valid dates"):
             await _filter_and_structure_events(
-                mock_client, "Boston", "MA", date(2026, 11, 4), "raw events text"
+                mock_client, "Boston", "MA", date(2026, 11, 4), date.today(), "raw events text"
             )
 
     @pytest.mark.asyncio
@@ -41,7 +41,7 @@ class TestFilterAndStructureEvents:
 
         with pytest.raises(RuntimeError, match="none had valid dates"):
             await _filter_and_structure_events(
-                mock_client, "Boston", "MA", date(2026, 11, 4), "raw events text"
+                mock_client, "Boston", "MA", date(2026, 11, 4), date.today(), "raw events text"
             )
 
     @pytest.mark.asyncio
@@ -52,7 +52,7 @@ class TestFilterAndStructureEvents:
         )
 
         result = await _filter_and_structure_events(
-            mock_client, "Boston", "MA", date(2026, 11, 4), "raw events text"
+            mock_client, "Boston", "MA", date(2026, 11, 4), date.today(), "raw events text"
         )
 
         assert result == []
@@ -69,7 +69,7 @@ class TestFilterAndStructureEvents:
         )
 
         result = await _filter_and_structure_events(
-            mock_client, "Boston", "MA", date(2026, 11, 4), "raw events text"
+            mock_client, "Boston", "MA", date(2026, 11, 4), date.today(), "raw events text"
         )
 
         assert len(result) == 1
@@ -88,7 +88,7 @@ class TestFilterAndStructureEvents:
         )
 
         result = await _filter_and_structure_events(
-            mock_client, "Boston", "MA", date(2026, 11, 4), "raw events text"
+            mock_client, "Boston", "MA", date(2026, 11, 4), date.today(), "raw events text"
         )
 
         assert len(result) == 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,10 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "types-pyyaml>=6.0.12.20250915",
 ]
+campaign-plan-lambda = [
+    "pydantic>=2.0.0",
+    "python-dotenv>=1.1.1",
+    "google-genai>=1.56.0",
+    "httpx>=0.28.1",
+    "braintrust>=0.3.10",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,9 +103,6 @@ dev = [
     "types-pyyaml>=6.0.12.20250915",
 ]
 campaign-plan-lambda = [
-    "pydantic>=2.0.0",
-    "python-dotenv>=1.1.1",
     "google-genai>=1.56.0",
-    "httpx>=0.28.1",
     "braintrust>=0.3.10",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1154,6 +1154,13 @@ dev = [
 ]
 
 [package.dev-dependencies]
+campaign-plan-lambda = [
+    { name = "braintrust" },
+    { name = "google-genai" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+]
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1208,6 +1215,13 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
+campaign-plan-lambda = [
+    { name = "braintrust", specifier = ">=0.3.10" },
+    { name = "google-genai", specifier = ">=1.56.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "python-dotenv", specifier = ">=1.1.1" },
+]
 dev = [
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pytest", specifier = ">=8.4.2" },
@@ -1235,7 +1249,7 @@ dependencies = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.50" },
     { name = "faiss-cpu", specifier = ">=1.12.0" },
-    { name = "gp-shared", virtual = "shared" },
+    { name = "gp-shared", editable = "shared" },
     { name = "pyarrow", specifier = ">=21.0.0" },
 ]
 
@@ -1253,13 +1267,13 @@ dependencies = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.50" },
     { name = "claude-agent-sdk", specifier = ">=0.1.19" },
-    { name = "gp-shared", virtual = "shared" },
+    { name = "gp-shared", editable = "shared" },
 ]
 
 [[package]]
 name = "gp-shared"
 version = "0.1.0"
-source = { virtual = "shared" }
+source = { editable = "shared" }
 dependencies = [
     { name = "braintrust" },
     { name = "databricks-sql-connector" },
@@ -1318,7 +1332,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.50" },
-    { name = "gp-shared", virtual = "shared" },
+    { name = "gp-shared", editable = "shared" },
     { name = "matplotlib", specifier = ">=3.10.0" },
     { name = "plotly", specifier = ">=5.27.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1157,9 +1157,6 @@ dev = [
 campaign-plan-lambda = [
     { name = "braintrust" },
     { name = "google-genai" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
 ]
 dev = [
     { name = "pre-commit" },
@@ -1218,9 +1215,6 @@ provides-extras = ["dev"]
 campaign-plan-lambda = [
     { name = "braintrust", specifier = ">=0.3.10" },
     { name = "google-genai", specifier = ">=1.56.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "python-dotenv", specifier = ">=1.1.1" },
 ]
 dev = [
     { name = "pre-commit", specifier = ">=4.3.0" },


### PR DESCRIPTION
Add braintrust to campaign plan generation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new external dependency and secret (`BRAINTRUST_API_KEY`) and changes how LLM prompts are sourced at runtime, which can alter generated campaign tasks if Braintrust prompts differ or are unavailable.
> 
> **Overview**
> **Event-generation prompts are now sourced from Braintrust** (with hardcoded fallback templates) instead of being fully inlined in code.
> 
> The Lambda handler now injects `BRAINTRUST_API_KEY`, initializes Braintrust logging (`init_braintrust(project="campaign-plan")`), and the package dependency `braintrust` is added. Event generation is updated to pass an explicit `today` value through helper functions, and tests/harness are adjusted for the new function signature and secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3373fcaa695fd4bbc04eacee3a1d528f62813753. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->