### PR TITLE
Add urls to returned events.

### DIFF
--- a/campaign_plan_lambda/README.md
+++ b/campaign_plan_lambda/README.md
@@ -1,6 +1,6 @@
 # Campaign Plan Lambda
 
-AWS Lambda that finds community events for political candidates using Gemini 3 with Google Search grounding. Triggered by SQS, writes results to S3, and notifies gp-api via SQS.
+AWS Lambda that finds community events for political candidates using Gemini 3 with Google Search grounding. Triggered by SQS, writes results to S3, and notifies gp-api via SQS. Prompts are managed in Braintrust (project: "campaign-plan") with hardcoded fallbacks.
 
 ## What it does
 
@@ -16,7 +16,7 @@ AWS Lambda that finds community events for political candidates using Gemini 3 w
 
 - Python 3.12+
 - Project venv activated: `source .venv/bin/activate` (from the `gp-ai-projects` root)
-- `GEMINI_API_KEY` set in `.env` at the project root
+- `GEMINI_API_KEY` and `BRAINTRUST_API_KEY` set in `.env` at the project root
 
 ### Run the SQS harness
 
@@ -48,7 +48,7 @@ cd /gp-ai-projects
 bash campaign_plan_lambda/build.sh
 ```
 
-This creates `campaign_plan_lambda/lambda.zip` (~9MB zipped, ~28MB unzipped).
+This creates `campaign_plan_lambda/lambda.zip` (~11MB zipped, ~33MB unzipped).
 
 ### Upload to Lambda (dev)
 
@@ -153,13 +153,16 @@ aws s3 ls s3://campaign-plan-results-dev/results/99999/ --region us-west-2 --pro
       "cta": "Attend event",
       "flowType": "events",
       "week": 22,
-      "date": "2026-06-06"
+      "date": "2026-06-06",
+      "url": "https://www.bostonprideforthepeople.org"
     }
   ],
   "taskCount": 7,
   "generationTimestamp": "2026-04-02T15:30:00.000000+00:00"
 }
 ```
+
+The `url` field is optional — it is omitted when no direct event link is available.
 
 ## Error handling
 

--- a/campaign_plan_lambda/event_generator.py
+++ b/campaign_plan_lambda/event_generator.py
@@ -11,7 +11,7 @@ Prompts are loaded from Braintrust (with hardcoded fallbacks if unavailable).
 from datetime import date
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from shared.llm_gemini_3 import Gemini3Client
 from shared.braintrust import load_prompt_from_braintrust
@@ -22,7 +22,9 @@ logger = get_logger(__name__)
 SEARCH_PROMPT_FALLBACK = """Find community events where a political candidate can connect with voters.
 
 Location: {city}, {state}
-Date range: {today} to {election_date}"""
+Date range: {today} to {election_date}
+
+For each event, include the direct URL to the event page if available."""
 
 FILTER_PROMPT_FALLBACK = """Select the best 5-8 community events from the data below for a candidate in {city}, {state}.
 
@@ -33,6 +35,7 @@ RULES:
 - Dates must be in YYYY-MM-DD format
 - Title should be the event name
 - Description should explain why this event helps the campaign (one sentence)
+- Include the direct URL to the event page if one is present in the data
 
 COMMUNITY EVENTS DATA:
 {raw_events}"""
@@ -43,6 +46,15 @@ class LlmEventResult(BaseModel):
     title: str = Field(..., description="Event name")
     description: str = Field(..., description="Why this event matters for the campaign")
     date: str = Field(..., description="Event date in YYYY-MM-DD format")
+    url: Optional[str] = Field(None, description="Direct URL to the event page")
+
+    @field_validator("url", mode="before")
+    @classmethod
+    def validate_url(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and not v.startswith(("https://", "http://")):
+            logger.warning(f"Dropping invalid URL (not http/https): {v}")
+            return None
+        return v or None
 
 
 class LlmEventResultList(BaseModel):
@@ -57,6 +69,7 @@ class CampaignEventTask(BaseModel):
     flowType: str
     week: int
     date: str
+    url: Optional[str] = None
 
 
 async def generate_event_tasks(
@@ -151,6 +164,7 @@ async def _filter_and_structure_events(
             flowType="events",
             week=week,
             date=event.date,
+            url=event.url,
         ))
 
     # If the LLM returned events but none survived validation, that's a quality

--- a/campaign_plan_lambda/event_generator.py
+++ b/campaign_plan_lambda/event_generator.py
@@ -51,10 +51,18 @@ class LlmEventResult(BaseModel):
     @field_validator("url", mode="before")
     @classmethod
     def validate_url(cls, v: Optional[str]) -> Optional[str]:
-        if v is not None and not v.startswith(("https://", "http://")):
-            logger.warning(f"Dropping invalid URL (not http/https): {v}")
+        if not v:
             return None
-        return v or None
+        if not isinstance(v, str):
+            logger.warning(f"Dropping invalid URL (not a string): {repr(v)}")
+            return None
+        v = v.strip()
+        if not v:
+            return None
+        if not v.startswith(("https://", "http://")):
+            logger.warning(f"Dropping invalid URL (not http/https): {repr(v)}")
+            return None
+        return v
 
 
 class LlmEventResultList(BaseModel):

--- a/campaign_plan_lambda/handler.py
+++ b/campaign_plan_lambda/handler.py
@@ -151,8 +151,9 @@ async def _generate(campaign_id: int, msg: SqsMessageBody) -> CampaignPlanResult
 
     from campaign_plan_lambda.output import TaskDict
 
-    task_dicts: list[TaskDict] = [
-        {
+    task_dicts: list[TaskDict] = []
+    for task in event_tasks:
+        d: TaskDict = {
             "title": task.title,
             "description": task.description,
             "cta": task.cta,
@@ -160,8 +161,9 @@ async def _generate(campaign_id: int, msg: SqsMessageBody) -> CampaignPlanResult
             "week": task.week,
             "date": task.date,
         }
-        for task in event_tasks
-    ]
+        if task.url:
+            d["url"] = task.url
+        task_dicts.append(d)
 
     result: CampaignPlanResult = {
         "campaignId": campaign_id,

--- a/campaign_plan_lambda/output.py
+++ b/campaign_plan_lambda/output.py
@@ -38,13 +38,17 @@ class SqsMessage(TypedDict):
     data: CompletionData | ErrorData
 
 
-class TaskDict(TypedDict):
+class _TaskDictRequired(TypedDict):
     title: str
     description: str
     cta: str
     flowType: str
     week: int
     date: str
+
+
+class TaskDict(_TaskDictRequired, total=False):
+    url: str
 
 
 class CampaignPlanResult(TypedDict):

--- a/campaign_plan_lambda/tests/test_event_generator.py
+++ b/campaign_plan_lambda/tests/test_event_generator.py
@@ -128,3 +128,11 @@ class TestFilterAndStructureEvents:
     def test_http_url_allowed(self):
         event = LlmEventResult(title="HTTP", description="Test", date="2026-07-04", url="http://example.com")
         assert event.url == "http://example.com"
+
+    def test_non_string_url_dropped(self):
+        event = LlmEventResult(title="Bool URL", description="Test", date="2026-07-04", url=True)
+        assert event.url is None
+
+    def test_whitespace_url_dropped(self):
+        event = LlmEventResult(title="Spaces", description="Test", date="2026-07-04", url="   ")
+        assert event.url is None

--- a/campaign_plan_lambda/tests/test_event_generator.py
+++ b/campaign_plan_lambda/tests/test_event_generator.py
@@ -96,3 +96,35 @@ class TestFilterAndStructureEvents:
         one_week_task = next(t for t in result if t.title == "One Week Before")
         assert election_week_task.week == 1
         assert one_week_task.week == 2
+
+    @pytest.mark.asyncio
+    async def test_url_passed_through_when_present(self):
+        mock_client = Mock()
+        mock_client.generate_structured_content.return_value = LlmEventResultList(
+            events=[
+                LlmEventResult(title="Event With URL", description="Test", date="2026-07-04", url="https://example.com/event"),
+                LlmEventResult(title="Event Without URL", description="Test", date="2026-07-05"),
+            ]
+        )
+
+        result = await _filter_and_structure_events(
+            mock_client, "Boston", "MA", date(2026, 11, 4), date(2026, 1, 1), "raw events text"
+        )
+
+        assert len(result) == 2
+        with_url = next(t for t in result if t.title == "Event With URL")
+        without_url = next(t for t in result if t.title == "Event Without URL")
+        assert with_url.url == "https://example.com/event"
+        assert without_url.url is None
+
+    def test_invalid_url_dropped(self):
+        event = LlmEventResult(title="Bad URL", description="Test", date="2026-07-04", url="javascript:alert(1)")
+        assert event.url is None
+
+    def test_empty_url_dropped(self):
+        event = LlmEventResult(title="Empty URL", description="Test", date="2026-07-04", url="")
+        assert event.url is None
+
+    def test_http_url_allowed(self):
+        event = LlmEventResult(title="HTTP", description="Test", date="2026-07-04", url="http://example.com")
+        assert event.url == "http://example.com"


### PR DESCRIPTION
Add the urls to the returned events if available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `url` field to generated tasks with basic http/https validation; main behavior is unchanged aside from extra output data.
> 
> **Overview**
> Adds support for returning a direct event `url` in campaign plan tasks when the LLM provides one.
> 
> The event generation prompts now request URLs, structured output/schema (`LlmEventResult`/`CampaignEventTask`) carries an optional `url` with http/https-only validation, and the Lambda output JSON only includes `url` when present. Tests and README are updated to cover/describe the new optional field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 336ac094b4d3ef34b803371f9825d0c3a3134d23. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->