### PR TITLE
Provide a local server for testing gp-api's integration with campaign_plan_lambda.

### DIFF
--- a/campaign_plan_lambda/README.md
+++ b/campaign_plan_lambda/README.md
@@ -39,6 +39,41 @@ source .venv/bin/activate
 python -m pytest campaign_plan_lambda/tests/ -v
 ```
 
+### Run with gp-api locally
+
+The local server lets gp-api trigger event generation on your machine instead of going through SQS + Lambda. Real Gemini API calls are made, results are written to dev S3, and completion messages are sent to your personal SQS queue.
+
+**1. Set up `.env` in gp-ai-projects root:**
+
+```
+GEMINI_API_KEY=...
+AWS_PROFILE=your-admin-profile
+AWS_DEFAULT_REGION=us-west-2
+S3_RESULTS_BUCKET=campaign-plan-results-dev
+OUTPUT_SQS_QUEUE_URL=https://sqs.us-west-2.amazonaws.com/333022194791/YourName_Queue.fifo
+```
+
+Each engineer should have their own dedicated SQS queue (e.g. `YourName_Queue.fifo`). This is the same queue your local gp-api reads from (`SQS_QUEUE` in gp-api's `.env`).
+
+**2. Start the local server:**
+
+```bash
+cd /gp-ai-projects
+source .venv/bin/activate
+python campaign_plan_lambda/local_server.py
+```
+
+**3. Set up gp-api `.env`:**
+
+```
+CAMPAIGN_PLAN_LOCAL_URL=http://localhost:8089/generate
+CAMPAIGN_PLAN_RESULTS_BUCKET=campaign-plan-results-dev
+```
+
+**4. Start gp-api:** `npm run start:dev`
+
+When a user with no tasks opens the dashboard, gp-api POSTs to `localhost:8089`, the local server runs Gemini, writes to S3, and sends a completion message to your queue. gp-api picks it up and saves the event tasks.
+
 ## Deploying to Lambda
 
 ### Build the zip

--- a/campaign_plan_lambda/local_server.py
+++ b/campaign_plan_lambda/local_server.py
@@ -43,7 +43,7 @@ def process_request(body: dict) -> None:
     import campaign_plan_lambda.handler as handler_module
 
     handler_module._secrets_cache = handler_module.Secrets(
-        GEMINI_API_KEY=os.environ.get("GEMINI_API_KEY", ""),
+        GEMINI_API_KEY=os.environ["GEMINI_API_KEY"],
         BRAINTRUST_API_KEY=os.environ.get("BRAINTRUST_API_KEY", ""),
     )
 
@@ -71,7 +71,23 @@ def process_request(body: dict) -> None:
 class RequestHandler(BaseHTTPRequestHandler):
     def do_POST(self):
         content_length = int(self.headers.get("Content-Length", 0))
-        body = json.loads(self.rfile.read(content_length))
+        raw_body = self.rfile.read(content_length)
+
+        try:
+            body = json.loads(raw_body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": "invalid JSON"}).encode())
+            return
+
+        if not isinstance(body, dict):
+            self.send_response(400)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": "request body must be a JSON object"}).encode())
+            return
 
         print(f"\n{'=' * 60}")
         print(f"Received request:")
@@ -84,7 +100,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(json.dumps({"accepted": True}).encode())
 
         # Process in background so the HTTP response returns immediately
-        thread = Thread(target=run_generation, args=(body,))
+        thread = Thread(target=run_generation, args=(body,), daemon=True)
         thread.start()
 
     def log_message(self, format, *args):
@@ -104,11 +120,16 @@ def run_generation(body: dict) -> None:
 
 
 def main():
-    output_queue = os.environ.get("OUTPUT_SQS_QUEUE_URL", "")
+    missing = [v for v in ("GEMINI_API_KEY", "OUTPUT_SQS_QUEUE_URL") if not os.environ.get(v)]
+    if missing:
+        print(f"ERROR: missing required env vars: {', '.join(missing)}", file=sys.stderr)
+        print("Set them in .env before starting the local server.", file=sys.stderr)
+        raise SystemExit(1)
+
     print(f"Campaign Plan Local Server")
     print(f"  Port: {PORT}")
     print(f"  S3 Bucket: {os.environ.get('S3_RESULTS_BUCKET')}")
-    print(f"  Output Queue: {output_queue or '(not set — completion messages will fail)'}")
+    print(f"  Output Queue: {os.environ['OUTPUT_SQS_QUEUE_URL']}")
     print(f"\nSet in gp-api .env:")
     print(f"  CAMPAIGN_PLAN_LOCAL_URL=http://localhost:{PORT}/generate")
     print(f"\nWaiting for requests...\n")

--- a/campaign_plan_lambda/local_server.py
+++ b/campaign_plan_lambda/local_server.py
@@ -1,0 +1,125 @@
+"""
+Local HTTP server for testing campaign plan generation with gp-api.
+
+Accepts POST requests with {campaignId, election_date, city, state},
+runs real Gemini API calls, writes results to dev S3, and sends
+completion to your personal SQS queue.
+
+Usage:
+    source .venv/bin/activate
+    python campaign_plan_lambda/local_server.py
+
+Requires in .env:
+    GEMINI_API_KEY
+    BRAINTRUST_API_KEY (optional)
+    OUTPUT_SQS_QUEUE_URL (your personal queue, e.g. Felicks_Queue.fifo)
+
+In gp-api .env, set:
+    CAMPAIGN_PLAN_LOCAL_URL=http://localhost:8089/generate
+"""
+
+import json
+import os
+import sys
+import uuid
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+from threading import Thread
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from dotenv import load_dotenv
+load_dotenv(project_root / ".env")
+
+PORT = int(os.environ.get("LOCAL_SERVER_PORT", "8089"))
+
+os.environ.setdefault("ENVIRONMENT", "local")
+os.environ.setdefault("S3_RESULTS_BUCKET", "campaign-plan-results-dev")
+
+
+def process_request(body: dict) -> None:
+    """Run the Lambda handler with the given input, using real S3 and SQS."""
+    import campaign_plan_lambda.handler as handler_module
+
+    handler_module._secrets_cache = handler_module.Secrets(
+        GEMINI_API_KEY=os.environ.get("GEMINI_API_KEY", ""),
+        BRAINTRUST_API_KEY=os.environ.get("BRAINTRUST_API_KEY", ""),
+    )
+
+    lambda_event = {
+        "Records": [
+            {
+                "messageId": str(uuid.uuid4()),
+                "receiptHandle": "local-receipt",
+                "body": json.dumps(body),
+                "attributes": {
+                    "ApproximateReceiveCount": "1",
+                },
+                "messageAttributes": {},
+                "md5OfBody": "local",
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "local",
+                "awsRegion": "us-west-2",
+            }
+        ]
+    }
+
+    handler_module.handler(lambda_event, None)
+
+
+class RequestHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(content_length))
+
+        print(f"\n{'=' * 60}")
+        print(f"Received request:")
+        print(json.dumps(body, indent=2))
+        print(f"{'=' * 60}\n")
+
+        self.send_response(202)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"accepted": True}).encode())
+
+        # Process in background so the HTTP response returns immediately
+        thread = Thread(target=run_generation, args=(body,))
+        thread.start()
+
+    def log_message(self, format, *args):
+        print(f"[HTTP] {args[0]}")
+
+
+def run_generation(body: dict) -> None:
+    try:
+        process_request(body)
+        print(f"\n{'=' * 60}")
+        print("Generation completed successfully")
+        print(f"{'=' * 60}\n")
+    except Exception as e:
+        print(f"\n{'=' * 60}")
+        print(f"Generation FAILED: {e}")
+        print(f"{'=' * 60}\n")
+
+
+def main():
+    output_queue = os.environ.get("OUTPUT_SQS_QUEUE_URL", "")
+    print(f"Campaign Plan Local Server")
+    print(f"  Port: {PORT}")
+    print(f"  S3 Bucket: {os.environ.get('S3_RESULTS_BUCKET')}")
+    print(f"  Output Queue: {output_queue or '(not set — completion messages will fail)'}")
+    print(f"\nSet in gp-api .env:")
+    print(f"  CAMPAIGN_PLAN_LOCAL_URL=http://localhost:{PORT}/generate")
+    print(f"\nWaiting for requests...\n")
+
+    server = HTTPServer(("localhost", PORT), RequestHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Related to ENG-7099.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new local-only server script and documentation without changing Lambda runtime behavior or production infrastructure.
> 
> **Overview**
> Adds a new `campaign_plan_lambda/local_server.py` that accepts local HTTP `POST` requests, wraps them into a synthetic SQS `Records` event, and invokes the existing Lambda `handler` in a background thread while using real dev S3/SQS and locally provided API keys.
> 
> Updates `campaign_plan_lambda/README.md` with step-by-step instructions for wiring `gp-api` to this local server via `CAMPAIGN_PLAN_LOCAL_URL`, plus required `.env` settings for dev bucket and a per-engineer output queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2897c24a21a7390d807d2584a4bf7be1808144ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->