### PR TITLE
Add post-generation QA hook to generate_briefing.py

### DIFF
--- a/meeting_pipeline/scripts/generate_briefing.py
+++ b/meeting_pipeline/scripts/generate_briefing.py
@@ -758,37 +758,43 @@ def assemble_briefing(
 # ============================================================================
 
 def _run_qa_hook(briefing_key: str) -> None:
-    """Invoke the QA pipeline for a newly-written briefing. Non-blocking.
+    """Invoke the QA pipeline for a newly-written briefing. Fire-and-forget.
 
+    Runs in a daemon thread so it never blocks or delays briefing generation.
     Set QA_REPO_PATH in .env to the root of the meeting-briefing-qa repo.
     If unset, this is a no-op.
     """
     import os
     import subprocess
+    import threading
 
     qa_root = os.environ.get("QA_REPO_PATH", "")
     if not qa_root:
         return
-    print("  Running QA...")
-    try:
-        proc = subprocess.run(
-            ["uv", "run", "python", "scripts/run_qa.py", briefing_key, "--output-s3"],
-            cwd=qa_root,
-            capture_output=True,
-            text=True,
-            timeout=600,
-        )
-        status = "✓" if proc.returncode == 0 else f"✗ exit {proc.returncode}"
-        print(f"  QA: {status}")
-        for line in (proc.stdout or "").strip().splitlines()[-8:]:
-            print(f"  QA: {line}")
-        if proc.returncode != 0 and proc.stderr:
-            for line in proc.stderr.strip().splitlines()[-4:]:
-                print(f"  QA err: {line}")
-    except subprocess.TimeoutExpired:
-        print("  QA: timed out (>10 min) — results available on next --batch run")
-    except Exception as e:
-        print(f"  QA: hook error — {e}")
+
+    def _run() -> None:
+        try:
+            proc = subprocess.run(
+                ["uv", "run", "python", "scripts/run_qa.py", briefing_key, "--output-s3"],
+                cwd=qa_root,
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+            status = "✓" if proc.returncode == 0 else f"✗ exit {proc.returncode}"
+            print(f"  QA [{briefing_key.split('/')[-1]}]: {status}")
+            for line in (proc.stdout or "").strip().splitlines()[-8:]:
+                print(f"  QA: {line}")
+            if proc.returncode != 0 and proc.stderr:
+                for line in proc.stderr.strip().splitlines()[-4:]:
+                    print(f"  QA err: {line}")
+        except subprocess.TimeoutExpired:
+            print(f"  QA [{briefing_key.split('/')[-1]}]: timed out (>10 min)")
+        except Exception as e:
+            print(f"  QA [{briefing_key.split('/')[-1]}]: hook error — {e}")
+
+    threading.Thread(target=_run, daemon=True).start()
+    print("  QA: running in background")
 
 
 # ============================================================================

--- a/meeting_pipeline/scripts/generate_briefing.py
+++ b/meeting_pipeline/scripts/generate_briefing.py
@@ -754,6 +754,44 @@ def assemble_briefing(
 
 
 # ============================================================================
+# QA HOOK
+# ============================================================================
+
+def _run_qa_hook(briefing_key: str) -> None:
+    """Invoke the QA pipeline for a newly-written briefing. Non-blocking.
+
+    Set QA_REPO_PATH in .env to the root of the meeting-briefing-qa repo.
+    If unset, this is a no-op.
+    """
+    import os
+    import subprocess
+
+    qa_root = os.environ.get("QA_REPO_PATH", "")
+    if not qa_root:
+        return
+    print("  Running QA...")
+    try:
+        proc = subprocess.run(
+            ["uv", "run", "python", "scripts/run_qa.py", briefing_key, "--output-s3"],
+            cwd=qa_root,
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        status = "✓" if proc.returncode == 0 else f"✗ exit {proc.returncode}"
+        print(f"  QA: {status}")
+        for line in (proc.stdout or "").strip().splitlines()[-8:]:
+            print(f"  QA: {line}")
+        if proc.returncode != 0 and proc.stderr:
+            for line in proc.stderr.strip().splitlines()[-4:]:
+                print(f"  QA err: {line}")
+    except subprocess.TimeoutExpired:
+        print("  QA: timed out (>10 min) — results available on next --batch run")
+    except Exception as e:
+        print(f"  QA: hook error — {e}")
+
+
+# ============================================================================
 # MAIN PIPELINE
 # ============================================================================
 
@@ -897,6 +935,8 @@ def generate_briefing_for_meeting(
     output_key = f"{cfg.output_prefix}/briefings/{safe_name}"
     storage.write_json(output_key, briefing)
     print(f"  Saved: {output_key}")
+
+    _run_qa_hook(output_key)
 
     return {
         "status": "ok",


### PR DESCRIPTION
## Summary

- Adds `_run_qa_hook(briefing_key)` to `generate_briefing.py`, called immediately after each briefing is written to S3
- Invokes the [meeting-briefing-qa](https://github.com/melecia-gp/meeting_briefings_qa) pipeline as a subprocess, which runs LLM-based claim adjudication and writes QA artifacts back to S3 at `meeting_pipeline/qa_outputs/{city-slug}_{date}/`
- **Non-blocking** — timeouts and errors are logged but never fail or delay briefing generation

## Activation

Add to `.env` in `gp-ai-projects`:
```
QA_REPO_PATH=/path/to/meeting-briefing-qa
```

If `QA_REPO_PATH` is unset the hook is a no-op — no behaviour change for existing runs.

## QA outputs (S3)

```
meeting_pipeline/qa_outputs/{city-slug}_{date}/
  {city-slug}_{date}_qa_summary.md     ← 🔴 Block / 🟢 OK routing decision
  {city-slug}_{date}_review_log.xlsx   ← per-claim adjudication workbook
  {city-slug}_{date}_trace.json        ← machine-readable routing trace
```

## Test plan

- [ ] Set `QA_REPO_PATH` and generate one briefing — confirm QA output appears in S3 and generation result is unaffected
- [ ] Unset `QA_REPO_PATH` — confirm no change to existing behaviour
- [ ] Kill the QA process mid-run — confirm generation still returns `status: ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an optional post-write subprocess call that depends on local environment/config (`QA_REPO_PATH`) and can introduce extra runtime/timeout and operational variability, though failures are swallowed and do not block briefing generation.
> 
> **Overview**
> Adds an *optional* post-generation QA hook in `generate_briefing.py` that runs after each briefing JSON is written to storage.
> 
> When `QA_REPO_PATH` is set, the pipeline shells out to `uv run python scripts/run_qa.py <briefing_key> --output-s3` (10-minute timeout), logs a small tail of stdout/stderr, and continues regardless of failures/timeouts; when unset, behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c8933a4b22784a7c32a3c3a3b1bdc6fc906d29. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->