### PR TITLE
ENG-7244 Ensure proper capitalization is respected.

### DIFF
--- a/campaign_plan_lambda/event_generator.py
+++ b/campaign_plan_lambda/event_generator.py
@@ -33,7 +33,7 @@ RULES:
 - Prioritize events where the candidate can speak to or meet voters
 - Include a mix of formal meetings and community events
 - Dates must be in YYYY-MM-DD format
-- Title should be the event name
+- Title should be the event name in sentence case: capitalize only the first word and proper nouns (city names, organization names, named events/festivals). Example: "Attend the Boston Pride Festival" — "Boston Pride Festival" stays capitalized because it's a named event.
 - Description should explain why this event helps the campaign (one sentence)
 - Include the direct URL to the event page if one is present in the data
 

--- a/campaign_plan_lambda/event_generator.py
+++ b/campaign_plan_lambda/event_generator.py
@@ -33,7 +33,7 @@ RULES:
 - Prioritize events where the candidate can speak to or meet voters
 - Include a mix of formal meetings and community events
 - Dates must be in YYYY-MM-DD format
-- Title should be the event name in sentence case: capitalize only the first word and proper nouns (city names, organization names, named events/festivals). Example: "Attend the Boston Pride Festival" — "Boston Pride Festival" stays capitalized because it's a named event.
+- Title should be the event name in sentence case: capitalize only the first word and proper nouns (city names, organization names, named events/festivals). Examples: "Boston Pride Festival" (entire title is a named event, all words capitalized); "Community town hall in Cambridge" (generic event — only the first word and the proper noun "Cambridge" are capitalized).
 - Description should explain why this event helps the campaign (one sentence)
 - Include the direct URL to the event page if one is present in the data
 


### PR DESCRIPTION
The old stand in had issues with inconsistent capitalization. Looking at the lambda's history though, it looks fine, however, it's good to add this to prevent regressions.

Prompt already updated in braintrust.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change affecting LLM output formatting; no code-path, data, or security logic is modified.
> 
> **Overview**
> Updates the `FILTER_PROMPT_FALLBACK` in `campaign_plan_lambda/event_generator.py` to explicitly require event titles be returned in *sentence case* (only first word + proper nouns capitalized), to reduce inconsistent capitalization in LLM-generated event tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da8ba0bad5259ae67ea1f87dc9bbb0cf81c1335c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->