### PR TITLE
Fix github-actions IAM permissions for Lambda deploys

### DIFF
--- a/infrastructure/shared/github-actions-iam/main.tf
+++ b/infrastructure/shared/github-actions-iam/main.tf
@@ -105,6 +105,15 @@ resource "aws_iam_role_policy" "github_actions_ecr_push" {
         Resource = [
           "arn:aws:ecr:us-west-2:${data.aws_caller_identity.current.account_id}:repository/gp-ai-projects"
         ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "lambda:UpdateFunctionCode"
+        ]
+        Resource = [
+          "arn:aws:lambda:us-west-2:${data.aws_caller_identity.current.account_id}:function:clickup-bot-*"
+        ]
       }
     ]
   })
@@ -122,7 +131,8 @@ resource "aws_iam_role_policy" "github_actions_lambda_deploy" {
         Effect = "Allow"
         Action = [
           "lambda:UpdateFunctionCode",
-          "lambda:GetFunction"
+          "lambda:GetFunction",
+          "lambda:GetFunctionConfiguration"
         ]
         Resource = "arn:aws:lambda:us-west-2:${data.aws_caller_identity.current.account_id}:function:*"
       }


### PR DESCRIPTION
## Summary

The `Deploy Campaign Plan Lambda` workflow has been failing since PR #57 because the IAM policy granting Lambda deploy permissions to `github-actions-ecr-push` was added to TF but never applied (and was also missing `lambda:GetFunctionConfiguration` for the post-update wait step).

This PR brings the TF config in sync with what's now applied in AWS:

- **`lambda-deploy-policy`** (new in PR #57, applied here): adds `lambda:UpdateFunctionCode`, `lambda:GetFunction`, `lambda:GetFunctionConfiguration` on `function:*`. The third action is needed by `aws lambda wait function-updated` in the deploy workflow.
- **`ecr-push-policy`** (drift reconciled): the live policy already has a `lambda:UpdateFunctionCode` statement scoped to `clickup-bot-*` that was added directly in the AWS console. Importing it back into TF so future applies don't remove it.

`terraform apply` was already run against this state (out-of-band) to unblock the deploy. After this PR merges, `terraform plan` should be clean.

## Test plan

- [x] `terraform plan` is clean after apply
- [x] Re-triggered failed `deploy-campaign-plan-lambda` run — got past `UpdateFunctionCode`, then past `GetFunctionConfiguration`
- [ ] Next push to `develop` triggers a fully green Lambda deploy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes IAM permissions for the GitHub Actions role, expanding Lambda read access (`GetFunctionConfiguration`) and adding a scoped `UpdateFunctionCode` permission; mistakes could either break CI deploys or over-grant access.
> 
> **Overview**
> Fixes GitHub Actions Lambda deploy failures by updating Terraform IAM policies for `github-actions-ecr-push`.
> 
> Adds a scoped `lambda:UpdateFunctionCode` allow on `clickup-bot-*` to the `ecr-push-policy`, and expands `lambda-deploy-policy` to include `lambda:GetFunctionConfiguration` (in addition to `UpdateFunctionCode`/`GetFunction`) for `function:*` to support the deploy workflow wait step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 518159fe346b83b83d70d278c28988b35eaf5c9b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->