### PR TITLE
PMF engine: qa + prod terraform, drop WebFetch from runner

### DIFF
--- a/broker/ARCHITECTURE.md
+++ b/broker/ARCHITECTURE.md
@@ -115,11 +115,11 @@ The Lambda has a `vpc_config` attaching it to the VPC with its own SG (`pmf-disp
 
 Broker mounts the Anthropic proxy router at `/anthropic`. Dispatch Lambda sets `ANTHROPIC_BASE_URL = https://broker-{env}.ai.goodparty.org/anthropic` as a container override on the runner task. Claude Agent SDK transparently routes its `/v1/messages` calls under that base URL. Anthropic API key lives only in the broker's env (from `broker-{env}` secret).
 
-### 6. WebFetch + WebSearch allowed; no broker research/fetch route
+### 6. WebSearch allowed via Anthropic proxy; URL fetches go through broker `/http/fetch`
 
-Runner's `ALLOWED_TOOLS` includes `WebFetch` and `WebSearch` (Claude SDK built-ins). These route HTTP traffic through Anthropic's servers, not through the broker — Anthropic fetches the URL and returns extracted content to the model via chat completion.
+Runner's `ALLOWED_TOOLS` includes `WebSearch` (Claude SDK built-in). WebSearch is server-side at Anthropic — search queries piggyback on the `/messages` API call (already broker-proxied through `/anthropic/v1/messages`), and results return inline. The runner never makes a separate outbound request for search.
 
-The broker's content classifier does **not** see this fetched content. The containment guarantee still holds: even if Anthropic returns malicious content and the agent follows the injection, the runner can't exfiltrate (no egress, no IAM) and the broker's artifact validator catches malformed outputs.
+`WebFetch` is **not** in `ALLOWED_TOOLS`. Claude SDK runs WebFetch client-side in the runner container and requires direct egress to `claude.ai` for URL safety pre-checks — egress the runner SG explicitly denies. All URL retrieval now goes through `pmf_runtime.http.get(url)` and `pmf_runtime.pdf.download(url)`, which call broker `/http/fetch` and `/pdf/fetch` respectively. The broker is the sole egress path; every URL fetch is auditable.
 
 Broker no longer exposes `research_fetch` or `research_search` endpoints.
 

--- a/broker/url_allowlist.py
+++ b/broker/url_allowlist.py
@@ -13,11 +13,12 @@ class AllowlistViolation(Exception):
 #
 # Rationale (same as PDF_ALLOWLIST below): response bodies flow to a runner
 # with no outbound egress, so they cannot be exfiltrated. URL-based side
-# channels (`evil.com/?d=SECRET`) are already possible via WebFetch today,
-# so restricting domains would not close any new risk class. Running agents
-# need to reach municipal platforms on arbitrary `.com` domains (Municode,
-# PrimeGov, eSCRIBE, CivicPlus, Granicus, BoardDocs, Azure blob packets),
-# and whitelisting each was a whack-a-mole blocker.
+# channels (`evil.com/?d=SECRET`) cannot be closed by a domain allowlist
+# either — running agents must reach municipal platforms on arbitrary `.com`
+# domains (Municode, PrimeGov, eSCRIBE, CivicPlus, Granicus, BoardDocs, Azure
+# blob packets), and whitelisting each was a whack-a-mole blocker. The
+# containment story relies on the runner's egress quarantine (no NAT, no
+# IAM credentials, broker as sole egress), not on URL filtering at this layer.
 #
 # SSRF into private / loopback / metadata IPs is still blocked by
 # http_fetch._validate_url (ported from pdf_fetch).
@@ -28,8 +29,9 @@ HTTP_ALLOWLIST: tuple[str, ...] = ()
 #
 # Rationale: PDF binary responses flow to a runner with no egress, so the
 # response cannot be exfiltrated. URL-based side channels (an injected agent
-# telling broker to fetch `evil.com/?d=SECRET`) are already possible today
-# via WebFetch, so restricting PDF domains would not close any new risk class.
+# telling broker to fetch `evil.com/?d=SECRET`) cannot be closed by a domain
+# allowlist — they require the same egress-quarantine containment as
+# HTTP_ALLOWLIST above.
 # The SSRF guards in pdf_fetch._validate_url (block RFC1918, link-local,
 # metadata, loopback) still apply.
 PDF_ALLOWLIST: tuple[str, ...] = ()

--- a/infrastructure/environments/prod/broker/.terraform.lock.hcl
+++ b/infrastructure/environments/prod/broker/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/environments/prod/broker/main.tf
+++ b/infrastructure/environments/prod/broker/main.tf
@@ -1,0 +1,127 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "broker/prod/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "bootstrap" {
+  type        = bool
+  default     = false
+  description = "First-pass apply: skip cross-stack remote_state lookups and the artifact bucket data source for stacks/resources that don't exist yet."
+}
+
+data "terraform_remote_state" "fargate" {
+  count = var.bootstrap ? 0 : 1
+
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "pmf-engine-fargate/prod/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
+data "terraform_remote_state" "control_plane" {
+  count = var.bootstrap ? 0 : 1
+
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "pmf-engine-control-plane/prod/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
+data "aws_s3_bucket" "artifacts" {
+  count  = var.bootstrap ? 0 : 1
+  bucket = "gp-agent-artifacts-prod"
+}
+
+data "aws_sqs_queue" "results" {
+  count = var.bootstrap ? 0 : 1
+  name  = "master-Queue.fifo"
+}
+
+resource "aws_secretsmanager_secret" "service_tokens" {
+  name        = "broker-service-tokens-prod"
+  description = "Plaintext SERVICE_TOKEN used by the dispatch Lambda to call broker /internal/mint-run-token. Hash lives in broker-prod."
+
+  tags = {
+    Environment = "prod"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "service_tokens_initial" {
+  secret_id     = aws_secretsmanager_secret.service_tokens.id
+  secret_string = jsonencode({})
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+module "broker" {
+  count  = var.bootstrap ? 0 : 1
+  source = "../../../modules/broker"
+
+  environment        = "prod"
+  vpc_id             = "vpc-0763fa52c32ebcf6a"
+  private_subnet_ids = ["subnet-053357b931f0524d4", "subnet-0bb591861f72dcb7f"]
+  ecr_repository_url = "333022194791.dkr.ecr.us-west-2.amazonaws.com/gp-ai-projects"
+  docker_image_tag   = "broker-prod"
+
+  agent_security_group_id           = try(data.terraform_remote_state.fargate[0].outputs.security_group_id, "")
+  dispatch_lambda_security_group_id = try(data.terraform_remote_state.control_plane[0].outputs.dispatch_lambda_sg_id, "")
+
+  artifact_bucket_arn  = data.aws_s3_bucket.artifacts[0].arn
+  artifact_bucket_name = data.aws_s3_bucket.artifacts[0].bucket
+
+  results_queue_arn = data.aws_sqs_queue.results[0].arn
+  results_queue_url = data.aws_sqs_queue.results[0].url
+
+  gp_api_sqs_queue_arn = data.aws_sqs_queue.results[0].arn
+
+  sns_topic_arn = try(data.terraform_remote_state.fargate[0].outputs.sns_topic_arn, "")
+}
+
+output "security_group_id" {
+  value       = var.bootstrap ? null : module.broker[0].security_group_id
+  description = "Broker security group ID (consumed by fargate + control-plane for egress rules)"
+}
+
+output "service_tokens_secret_arn" {
+  value       = aws_secretsmanager_secret.service_tokens.arn
+  description = "ARN of broker-service-tokens-prod (consumed by control-plane for dispatch Lambda env)"
+}
+
+output "broker_url" {
+  value       = var.bootstrap ? null : module.broker[0].broker_url
+  description = "Service Connect URL for the broker"
+}
+
+output "secrets_arn" {
+  value       = var.bootstrap ? null : module.broker[0].secrets_arn
+  description = "ARN of broker-prod (7 keys including SERVICE_TOKEN_HASH)"
+}
+
+output "dynamodb_table_name" {
+  value       = var.bootstrap ? null : module.broker[0].dynamodb_table_name
+  description = "DynamoDB scope tickets table name"
+}

--- a/infrastructure/environments/prod/pmf-engine-control-plane/.terraform.lock.hcl
+++ b/infrastructure/environments/prod/pmf-engine-control-plane/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.1"
+  hashes = [
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/environments/prod/pmf-engine-control-plane/main.tf
+++ b/infrastructure/environments/prod/pmf-engine-control-plane/main.tf
@@ -1,0 +1,96 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "pmf-engine-control-plane/prod/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "bootstrap" {
+  type        = bool
+  default     = false
+  description = "First-pass apply: skip the broker cross-stack remote_state lookup so control-plane can be applied before broker. Fargate state must already exist (apply order: fargate -> control-plane(bootstrap=true) -> broker -> control-plane re-apply)."
+}
+
+variable "gp_api_sqs_queue_url" {
+  type        = string
+  description = "URL of the gp-api SQS results queue that receives forwarded callbacks. Set per environment via terraform.tfvars; no default so dev values do not leak into qa/prod."
+}
+
+variable "gp_api_sqs_queue_arn" {
+  type        = string
+  description = "ARN of the gp-api SQS results queue. Set per environment via terraform.tfvars."
+}
+
+data "terraform_remote_state" "fargate" {
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "pmf-engine-fargate/prod/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
+data "terraform_remote_state" "broker" {
+  count = var.bootstrap ? 0 : 1
+
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "broker/prod/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
+# Direct lookup so control-plane can pass the secret ARN to its dispatch Lambda
+# without depending on broker remote_state existing (the secret is created by
+# broker/main.tf as a top-level resource, before any cross-stack wiring).
+data "aws_secretsmanager_secret" "service_tokens" {
+  name = "broker-service-tokens-prod"
+}
+
+module "pmf_engine_control_plane" {
+  source = "../../../modules/pmf-engine-control-plane"
+
+  environment = "prod"
+
+  ecs_cluster_arn             = data.terraform_remote_state.fargate.outputs.cluster_arn
+  ecs_task_definition_family  = data.terraform_remote_state.fargate.outputs.task_definition_family
+  ecs_subnet_ids              = ["subnet-053357b931f0524d4", "subnet-0bb591861f72dcb7f"]
+  ecs_security_group_id       = data.terraform_remote_state.fargate.outputs.security_group_id
+  ecs_task_execution_role_arn = data.terraform_remote_state.fargate.outputs.task_execution_role_arn
+  ecs_task_role_arn           = data.terraform_remote_state.fargate.outputs.task_role_arn
+
+  lambda_package_dir = "${path.module}/../../../../pmf_engine/.lambda_build"
+
+  gp_api_sqs_queue_url = var.gp_api_sqs_queue_url
+  gp_api_sqs_queue_arn = var.gp_api_sqs_queue_arn
+
+  broker_url                = var.bootstrap ? "https://broker-bootstrap.placeholder" : try(data.terraform_remote_state.broker[0].outputs.broker_url, "https://broker-bootstrap.placeholder")
+  service_tokens_secret_arn = data.aws_secretsmanager_secret.service_tokens.arn
+
+  vpc_id                   = "vpc-0763fa52c32ebcf6a"
+  broker_security_group_id = var.bootstrap ? "" : try(data.terraform_remote_state.broker[0].outputs.security_group_id, "")
+
+  sns_topic_arn = try(data.terraform_remote_state.fargate.outputs.sns_topic_arn, "")
+}
+
+output "dispatch_lambda_sg_id" {
+  value       = module.pmf_engine_control_plane.dispatch_lambda_sg_id
+  description = "Security group ID of the dispatch Lambda (consumed by broker for ingress rule in Step 4)"
+}

--- a/infrastructure/environments/prod/pmf-engine-fargate/.terraform.lock.hcl
+++ b/infrastructure/environments/prod/pmf-engine-fargate/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/environments/prod/pmf-engine-fargate/main.tf
+++ b/infrastructure/environments/prod/pmf-engine-fargate/main.tf
@@ -1,0 +1,91 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "pmf-engine-fargate/prod/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "bootstrap" {
+  type        = bool
+  default     = false
+  description = "First-pass apply: skip cross-stack remote_state lookups for stacks that don't exist yet."
+}
+
+data "terraform_remote_state" "broker" {
+  count = var.bootstrap ? 0 : 1
+
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "broker/prod/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
+data "terraform_remote_state" "vpc_endpoints" {
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "pmf-vpc-endpoints/dev/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
+module "pmf_engine_fargate" {
+  source = "../../../modules/pmf-engine-fargate"
+
+  environment        = "prod"
+  vpc_id             = "vpc-0763fa52c32ebcf6a"
+  private_subnet_ids = ["subnet-053357b931f0524d4", "subnet-0bb591861f72dcb7f"]
+  ecr_repository_url = "333022194791.dkr.ecr.us-west-2.amazonaws.com/gp-ai-projects"
+  docker_image_tag   = "pmf-engine-prod"
+  task_cpu           = "1024"
+  task_memory        = "2048"
+
+  artifact_bucket_arn      = "arn:aws:s3:::gp-agent-artifacts-prod"
+  broker_security_group_id = var.bootstrap ? "" : try(data.terraform_remote_state.broker[0].outputs.security_group_id, "")
+  broker_url               = var.bootstrap ? "https://broker-bootstrap.placeholder" : try(data.terraform_remote_state.broker[0].outputs.broker_url, "https://broker-bootstrap.placeholder")
+  vpce_security_group_id   = try(data.terraform_remote_state.vpc_endpoints.outputs.vpce_security_group_id, "")
+
+  shared_slack_notifier_lambda_arn = "arn:aws:lambda:us-west-2:333022194791:function:shared-slack-notifier"
+}
+
+output "cluster_arn" {
+  value = module.pmf_engine_fargate.cluster_arn
+}
+
+output "task_definition_family" {
+  value = module.pmf_engine_fargate.task_definition_family
+}
+
+output "security_group_id" {
+  value = module.pmf_engine_fargate.security_group_id
+}
+
+output "task_execution_role_arn" {
+  value = module.pmf_engine_fargate.task_execution_role_arn
+}
+
+output "task_role_arn" {
+  value = module.pmf_engine_fargate.task_role_arn
+}
+
+output "sns_topic_arn" {
+  value = module.pmf_engine_fargate.sns_topic_arn
+}

--- a/infrastructure/environments/qa/broker/.terraform.lock.hcl
+++ b/infrastructure/environments/qa/broker/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/environments/qa/broker/main.tf
+++ b/infrastructure/environments/qa/broker/main.tf
@@ -1,0 +1,127 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "broker/qa/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "bootstrap" {
+  type        = bool
+  default     = false
+  description = "First-pass apply: skip cross-stack remote_state lookups and the artifact bucket data source for stacks/resources that don't exist yet."
+}
+
+data "terraform_remote_state" "fargate" {
+  count = var.bootstrap ? 0 : 1
+
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "pmf-engine-fargate/qa/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
+data "terraform_remote_state" "control_plane" {
+  count = var.bootstrap ? 0 : 1
+
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "pmf-engine-control-plane/qa/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
+data "aws_s3_bucket" "artifacts" {
+  count  = var.bootstrap ? 0 : 1
+  bucket = "gp-agent-artifacts-qa"
+}
+
+data "aws_sqs_queue" "results" {
+  count = var.bootstrap ? 0 : 1
+  name  = "qa-Queue.fifo"
+}
+
+resource "aws_secretsmanager_secret" "service_tokens" {
+  name        = "broker-service-tokens-qa"
+  description = "Plaintext SERVICE_TOKEN used by the dispatch Lambda to call broker /internal/mint-run-token. Hash lives in broker-qa."
+
+  tags = {
+    Environment = "qa"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "service_tokens_initial" {
+  secret_id     = aws_secretsmanager_secret.service_tokens.id
+  secret_string = jsonencode({})
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+module "broker" {
+  count  = var.bootstrap ? 0 : 1
+  source = "../../../modules/broker"
+
+  environment        = "qa"
+  vpc_id             = "vpc-0763fa52c32ebcf6a"
+  private_subnet_ids = ["subnet-053357b931f0524d4", "subnet-0bb591861f72dcb7f"]
+  ecr_repository_url = "333022194791.dkr.ecr.us-west-2.amazonaws.com/gp-ai-projects"
+  docker_image_tag   = "broker-qa"
+
+  agent_security_group_id           = try(data.terraform_remote_state.fargate[0].outputs.security_group_id, "")
+  dispatch_lambda_security_group_id = try(data.terraform_remote_state.control_plane[0].outputs.dispatch_lambda_sg_id, "")
+
+  artifact_bucket_arn  = data.aws_s3_bucket.artifacts[0].arn
+  artifact_bucket_name = data.aws_s3_bucket.artifacts[0].bucket
+
+  results_queue_arn = data.aws_sqs_queue.results[0].arn
+  results_queue_url = data.aws_sqs_queue.results[0].url
+
+  gp_api_sqs_queue_arn = data.aws_sqs_queue.results[0].arn
+
+  sns_topic_arn = try(data.terraform_remote_state.fargate[0].outputs.sns_topic_arn, "")
+}
+
+output "security_group_id" {
+  value       = var.bootstrap ? null : module.broker[0].security_group_id
+  description = "Broker security group ID (consumed by fargate + control-plane for egress rules)"
+}
+
+output "service_tokens_secret_arn" {
+  value       = aws_secretsmanager_secret.service_tokens.arn
+  description = "ARN of broker-service-tokens-qa (consumed by control-plane for dispatch Lambda env)"
+}
+
+output "broker_url" {
+  value       = var.bootstrap ? null : module.broker[0].broker_url
+  description = "Service Connect URL for the broker"
+}
+
+output "secrets_arn" {
+  value       = var.bootstrap ? null : module.broker[0].secrets_arn
+  description = "ARN of broker-qa (7 keys including SERVICE_TOKEN_HASH)"
+}
+
+output "dynamodb_table_name" {
+  value       = var.bootstrap ? null : module.broker[0].dynamodb_table_name
+  description = "DynamoDB scope tickets table name"
+}

--- a/infrastructure/environments/qa/pmf-engine-control-plane/.terraform.lock.hcl
+++ b/infrastructure/environments/qa/pmf-engine-control-plane/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.1"
+  hashes = [
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/environments/qa/pmf-engine-control-plane/main.tf
+++ b/infrastructure/environments/qa/pmf-engine-control-plane/main.tf
@@ -1,0 +1,96 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "pmf-engine-control-plane/qa/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "bootstrap" {
+  type        = bool
+  default     = false
+  description = "First-pass apply: skip the broker cross-stack remote_state lookup so control-plane can be applied before broker. Fargate state must already exist (apply order: fargate -> control-plane(bootstrap=true) -> broker -> control-plane re-apply)."
+}
+
+variable "gp_api_sqs_queue_url" {
+  type        = string
+  description = "URL of the gp-api SQS results queue that receives forwarded callbacks. Set per environment via terraform.tfvars; no default so dev values do not leak into qa/prod."
+}
+
+variable "gp_api_sqs_queue_arn" {
+  type        = string
+  description = "ARN of the gp-api SQS results queue. Set per environment via terraform.tfvars."
+}
+
+data "terraform_remote_state" "fargate" {
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "pmf-engine-fargate/qa/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
+data "terraform_remote_state" "broker" {
+  count = var.bootstrap ? 0 : 1
+
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "broker/qa/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
+# Direct lookup so control-plane can pass the secret ARN to its dispatch Lambda
+# without depending on broker remote_state existing (the secret is created by
+# broker/main.tf as a top-level resource, before any cross-stack wiring).
+data "aws_secretsmanager_secret" "service_tokens" {
+  name = "broker-service-tokens-qa"
+}
+
+module "pmf_engine_control_plane" {
+  source = "../../../modules/pmf-engine-control-plane"
+
+  environment = "qa"
+
+  ecs_cluster_arn             = data.terraform_remote_state.fargate.outputs.cluster_arn
+  ecs_task_definition_family  = data.terraform_remote_state.fargate.outputs.task_definition_family
+  ecs_subnet_ids              = ["subnet-053357b931f0524d4", "subnet-0bb591861f72dcb7f"]
+  ecs_security_group_id       = data.terraform_remote_state.fargate.outputs.security_group_id
+  ecs_task_execution_role_arn = data.terraform_remote_state.fargate.outputs.task_execution_role_arn
+  ecs_task_role_arn           = data.terraform_remote_state.fargate.outputs.task_role_arn
+
+  lambda_package_dir = "${path.module}/../../../../pmf_engine/.lambda_build"
+
+  gp_api_sqs_queue_url = var.gp_api_sqs_queue_url
+  gp_api_sqs_queue_arn = var.gp_api_sqs_queue_arn
+
+  broker_url                = var.bootstrap ? "https://broker-bootstrap.placeholder" : try(data.terraform_remote_state.broker[0].outputs.broker_url, "https://broker-bootstrap.placeholder")
+  service_tokens_secret_arn = data.aws_secretsmanager_secret.service_tokens.arn
+
+  vpc_id                   = "vpc-0763fa52c32ebcf6a"
+  broker_security_group_id = var.bootstrap ? "" : try(data.terraform_remote_state.broker[0].outputs.security_group_id, "")
+
+  sns_topic_arn = try(data.terraform_remote_state.fargate.outputs.sns_topic_arn, "")
+}
+
+output "dispatch_lambda_sg_id" {
+  value       = module.pmf_engine_control_plane.dispatch_lambda_sg_id
+  description = "Security group ID of the dispatch Lambda (consumed by broker for ingress rule in Step 4)"
+}

--- a/infrastructure/environments/qa/pmf-engine-fargate/.terraform.lock.hcl
+++ b/infrastructure/environments/qa/pmf-engine-fargate/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/environments/qa/pmf-engine-fargate/main.tf
+++ b/infrastructure/environments/qa/pmf-engine-fargate/main.tf
@@ -1,0 +1,91 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "pmf-engine-fargate/qa/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+variable "bootstrap" {
+  type        = bool
+  default     = false
+  description = "First-pass apply: skip cross-stack remote_state lookups for stacks that don't exist yet."
+}
+
+data "terraform_remote_state" "broker" {
+  count = var.bootstrap ? 0 : 1
+
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "broker/qa/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
+data "terraform_remote_state" "vpc_endpoints" {
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "pmf-vpc-endpoints/dev/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
+module "pmf_engine_fargate" {
+  source = "../../../modules/pmf-engine-fargate"
+
+  environment        = "qa"
+  vpc_id             = "vpc-0763fa52c32ebcf6a"
+  private_subnet_ids = ["subnet-053357b931f0524d4", "subnet-0bb591861f72dcb7f"]
+  ecr_repository_url = "333022194791.dkr.ecr.us-west-2.amazonaws.com/gp-ai-projects"
+  docker_image_tag   = "pmf-engine-qa"
+  task_cpu           = "1024"
+  task_memory        = "2048"
+
+  artifact_bucket_arn      = "arn:aws:s3:::gp-agent-artifacts-qa"
+  broker_security_group_id = var.bootstrap ? "" : try(data.terraform_remote_state.broker[0].outputs.security_group_id, "")
+  broker_url               = var.bootstrap ? "https://broker-bootstrap.placeholder" : try(data.terraform_remote_state.broker[0].outputs.broker_url, "https://broker-bootstrap.placeholder")
+  vpce_security_group_id   = try(data.terraform_remote_state.vpc_endpoints.outputs.vpce_security_group_id, "")
+
+  shared_slack_notifier_lambda_arn = "arn:aws:lambda:us-west-2:333022194791:function:shared-slack-notifier"
+}
+
+output "cluster_arn" {
+  value = module.pmf_engine_fargate.cluster_arn
+}
+
+output "task_definition_family" {
+  value = module.pmf_engine_fargate.task_definition_family
+}
+
+output "security_group_id" {
+  value = module.pmf_engine_fargate.security_group_id
+}
+
+output "task_execution_role_arn" {
+  value = module.pmf_engine_fargate.task_execution_role_arn
+}
+
+output "task_role_arn" {
+  value = module.pmf_engine_fargate.task_role_arn
+}
+
+output "sns_topic_arn" {
+  value = module.pmf_engine_fargate.sns_topic_arn
+}

--- a/infrastructure/modules/pmf-engine-fargate/main.tf
+++ b/infrastructure/modules/pmf-engine-fargate/main.tf
@@ -399,7 +399,7 @@ resource "aws_sns_topic_subscription" "shared_slack_notifier" {
 
 resource "aws_lambda_permission" "allow_sns_invoke_slack" {
   count         = var.shared_slack_notifier_lambda_arn != "" ? 1 : 0
-  statement_id  = "AllowSNSInvokeFromPmfEngineFailures"
+  statement_id  = "AllowSNSInvokeFromPmfEngineFailures-${var.environment}"
   action        = "lambda:InvokeFunction"
   function_name = var.shared_slack_notifier_lambda_arn
   principal     = "sns.amazonaws.com"

--- a/pmf_engine/runner/experiments/instructions/district_intel.md
+++ b/pmf_engine/runner/experiments/instructions/district_intel.md
@@ -63,11 +63,9 @@ print(f"L2 district: {l2_district_type} = {l2_district_name}")
 
 ## STEP 2: Research the governing body
 
-Use the **`WebSearch`** and **`WebFetch`** tools (Claude SDK built-ins) for web research. Follow this strategy:
+Use **`WebSearch`** (Claude SDK built-in) to discover URLs and **`pmf_runtime.http.get`** (broker proxy) to retrieve them. The runner has no direct internet egress — all URL fetches go through the broker. `WebFetch` is not available.
 
-### CRITICAL: WebFetch domain-verification failures
-
-If `WebFetch` returns an error like `Unable to verify if domain {host} is safe to fetch. This may be due to network restrictions or enterprise security policies blocking claude.ai` — **do NOT retry `WebFetch` on the same or sibling domains** (each attempt burns ~2 minutes). Fall back immediately to `pmf_runtime.http.get`, which routes through the broker's allowlist-enforced proxy and bypasses Claude SDK's domain verification:
+### URL retrieval — use `pmf_runtime.http.get`
 
 ```python
 from pmf_runtime import http
@@ -76,15 +74,15 @@ r = http.get("https://city.gov/council-minutes")
 print(r["body"][:2000])
 ```
 
-Most `.gov` and municipal portal domains are already allowlisted. Use `pmf_runtime.http.get` whenever `WebFetch` errors, not as a second fallback after more `WebFetch` retries.
+`.gov` and municipal portal domains pass through the broker without an explicit allowlist (broker enforces SSRF guards instead).
 
 **2a. Find the municipality website**
 - `WebSearch({city} {state} city council)` — find the homepage
-- `WebFetch(homepage_url, prompt="find meeting minutes and agendas page")` — locate the minutes section
+- `pmf_runtime.http.get(homepage_url)` — locate the minutes section by scanning the returned HTML
 
 **2b. Pull recent meeting minutes/agendas**
 - Look for the last 3-6 months of meeting minutes or agendas
-- Meeting minutes are often PDFs or HTML pages. For PDFs, try `WebFetch` first (returns extracted text). If it fails or the PDF is large, use `pmf_runtime.pdf.download(url)` to pull raw bytes through the broker, then `pdftotext -layout /workspace/downloads/file.pdf -` to extract.
+- Meeting minutes are often PDFs or HTML pages. For HTML, use `pmf_runtime.http.get(url)`. For PDFs, use `pmf_runtime.pdf.download(url)` to pull raw bytes through the broker, then `pdftotext -layout /workspace/downloads/file.pdf -` to extract.
 - If the official site has a "meetings" or "agendas" section, start there
 
 **2c. Search for local news**

--- a/pmf_engine/runner/experiments/instructions/meeting_briefing.md
+++ b/pmf_engine/runner/experiments/instructions/meeting_briefing.md
@@ -42,17 +42,15 @@ touch /workspace/conversation.log
 - `/workspace/api_responses/` — saved API responses (Legistar events, agenda items, fiscal data)
 - `/workspace/conversation.log` — turn-by-turn log of every action taken
 
-**Save the content you extract.** The runner has narrow network egress and cannot `curl` arbitrary hosts. Three retrieval paths:
+**Save the content you extract.** The runner has no direct internet egress and cannot `curl` arbitrary hosts. Two retrieval paths through the broker, plus search:
 
-- **`WebFetch` (Claude SDK)** — HTML pages and short PDFs. Returns extracted text to your context. No disk write.
-- **`pmf_runtime.http.get(url)`** — HTTP GET through the broker. Returns `{"status", "headers", "body"}`. **Use this whenever `WebFetch` errors.**
-- **`pmf_runtime.pdf.download(url)`** — pulls PDFs through the broker and writes the raw bytes to `/workspace/downloads/`. Use this for staff reports, budget books, and any PDF too large or auth-walled for `WebFetch`.
+- **`WebSearch(query)`** (Claude SDK) — discover URLs and topical hits. Server-side at Anthropic, returns search results inline.
+- **`pmf_runtime.http.get(url)`** — HTTP GET through the broker. Returns `{"status", "headers", "body"}`. Use for HTML pages, JSON REST APIs (Legistar, LINC, etc.).
+- **`pmf_runtime.pdf.download(url)`** — pulls PDFs through the broker and writes raw bytes to `/workspace/downloads/`. Use for staff reports, budget books, attachment PDFs.
 
-### CRITICAL: WebFetch domain-verification failures
+`WebFetch` is **not** available — the runner SG denies direct egress to `claude.ai` (the SDK's safety pre-check endpoint). All URL retrieval goes through `pmf_runtime`.
 
-If `WebFetch` returns an error like `Unable to verify if domain {host} is safe to fetch. This may be due to network restrictions or enterprise security policies blocking claude.ai` — **do NOT retry `WebFetch` on the same or sibling domains** (it will fail the same way after ~2 minutes per attempt, burning your turn budget).
-
-Fall back immediately to `pmf_runtime.http.get`:
+### URL retrieval example
 
 ```python
 from pmf_runtime import http
@@ -61,7 +59,7 @@ r = http.get("https://hendersonvillenc.gov/council-meeting-agendas")
 print(r["body"][:2000])
 ```
 
-This routes through the broker's allowlist-enforced proxy and bypasses Claude SDK's domain verification entirely. Most `.gov` and municipal portal domains are already allowlisted.
+`.gov` and municipal portal domains pass through the broker without an explicit allowlist (broker enforces SSRF guards instead).
 
 Example — download a staff report and extract the sections you need:
 
@@ -210,7 +208,7 @@ Do NOT guess the Legistar client name. Discover it.
    - `cityoffayetteville.legistar.com` → client = `cityoffayetteville`
    - `durhamnc.legistar.com` → client = `durhamnc`
    - `austintx.legistar.com` → client = `austintx`
-4. Verify the client works. Runner has no direct internet egress — use the broker's `pmf_runtime.http.get` for Legistar REST API calls (Claude's WebFetch refuses `webapi.legistar.com`):
+4. Verify the client works. Use the broker's `pmf_runtime.http.get` for Legistar REST API calls (the runner has no direct internet egress; all HTTP fetches go through the broker):
 
 ```python
 from pmf_runtime import http
@@ -311,11 +309,11 @@ if text:
 | Everything else with `EventItemRollCallFlag > 0` | `business` |
 | Everything else | `informational` |
 
-**PrimeGov cities:** PrimeGov hosts agendas at `https://{client}.primegov.com/Portal/Meeting?meetingTemplateId=XXX`. To find meetings, use `WebFetch` on the portal page to list upcoming meetings, then `pmf_runtime.pdf.download(url)` to pull the compiled meeting PDF. Extract agenda items with `pdftotext`. PrimeGov PDFs typically have numbered items with section headers (Consent Agenda, Public Hearings, Action Items, etc.).
+**PrimeGov cities:** PrimeGov hosts agendas at `https://{client}.primegov.com/Portal/Meeting?meetingTemplateId=XXX`. To find meetings, use `pmf_runtime.http.get` on the portal page to list upcoming meetings, then `pmf_runtime.pdf.download(url)` to pull the compiled meeting PDF. Extract agenda items with `pdftotext`. PrimeGov PDFs typically have numbered items with section headers (Consent Agenda, Public Hearings, Action Items, etc.).
 
-**eSCRIBE cities:** Use `WebFetch` on the meetings endpoint, parse for item titles, numbers, attachments. Mark items under "Consent Agenda" header as consent.
+**eSCRIBE cities:** Use `pmf_runtime.http.get` on the meetings endpoint, parse for item titles, numbers, attachments. Mark items under "Consent Agenda" header as consent.
 
-**CivicPlus AgendaCenter:** Use `WebFetch` on the AgendaCenter page to locate the agenda PDF URL, then `pmf_runtime.pdf.download(url)` to retrieve it, then `pdftotext` to extract text. Parse by numbered items and section headers.
+**CivicPlus AgendaCenter:** Use `pmf_runtime.http.get` on the AgendaCenter page to locate the agenda PDF URL, then `pmf_runtime.pdf.download(url)` to retrieve it, then `pdftotext` to extract text. Parse by numbered items and section headers.
 
 **Fallback:** Search `"[city]" "[state]" city council agenda [meeting date]` and extract what you can. Record `agenda_source: "web_search"`.
 
@@ -329,11 +327,11 @@ After identifying agenda items, look for downloadable PDF attachments — especi
 
 **Municode/CivicPlus cities:**
 
-The `adaHtmlDocument` HTML page links to PDFs on Azure blob storage (`mccmeetingspublic.blob.core.usgovcloudapi.net`). Pull the agenda HTML with `WebFetch`, scan the returned text for PDF URLs on that blob domain, and save the list to `/workspace/api_responses/attachments.txt`.
+The `adaHtmlDocument` HTML page links to PDFs on Azure blob storage (`mccmeetingspublic.blob.core.usgovcloudapi.net`). Pull the agenda HTML with `pmf_runtime.http.get`, scan the returned text for PDF URLs on that blob domain, and save the list to `/workspace/api_responses/attachments.txt`.
 
 **Legistar cities:**
 
-Legistar matter attachments are available via `WebFetch` on:
+Legistar matter attachments are available via `pmf_runtime.http.get` on:
 ```
 https://webapi.legistar.com/v1/{client}/matters/{matterId}/attachments
 ```

--- a/pmf_engine/runner/experiments/instructions/peer_city_benchmarking.md
+++ b/pmf_engine/runner/experiments/instructions/peer_city_benchmarking.md
@@ -119,9 +119,9 @@ For each peer city, note: name, state, approximate population, and why it's comp
 
 ## STEP 4: Research peer city approaches to each issue
 
-### CRITICAL: WebFetch domain-verification failures
+### URL retrieval — use `pmf_runtime.http.get`
 
-If `WebFetch` returns an error like `Unable to verify if domain {host} is safe to fetch. This may be due to network restrictions or enterprise security policies blocking claude.ai` — **do NOT retry `WebFetch` on the same or sibling domains** (each attempt burns ~2 minutes). Fall back immediately to `pmf_runtime.http.get`, which routes through the broker's allowlist-enforced proxy and bypasses Claude SDK's domain verification:
+The runner has no direct internet egress. All URL retrieval (HTML pages, news articles, REST APIs) goes through the broker via `pmf_runtime.http.get`:
 
 ```python
 from pmf_runtime import http
@@ -130,7 +130,7 @@ r = http.get("https://peercity.gov/council-minutes")
 print(r["body"][:2000])
 ```
 
-Most `.gov` and municipal portal domains are already allowlisted. Use `pmf_runtime.http.get` whenever `WebFetch` errors, not as a second fallback after more `WebFetch` retries.
+For PDFs, use `pmf_runtime.pdf.download(url)` then `pdftotext` (see step 4c below). Use `WebSearch(...)` to discover URLs; never use `WebFetch` (it is not in the runner's tool set).
 
 For each issue from the district intel, and each peer city:
 
@@ -149,7 +149,7 @@ For each issue from the district intel, and each peer city:
 - City budget documents or reports
 - Policy implementation reports
 
-For HTML pages and short PDFs use `WebFetch(url, prompt="what did PEER_CITY do about ISSUE_TOPIC")`. For large budget books or staff reports, download through the broker:
+For HTML pages, use `pmf_runtime.http.get(url)`. For PDFs (budget books, staff reports), download through the broker:
 ```python
 from pmf_runtime import pdf
 result = pdf.download("https://peercity.gov/fy2026_budget.pdf", purpose="public safety line items")

--- a/pmf_engine/runner/harness/claude_sdk.py
+++ b/pmf_engine/runner/harness/claude_sdk.py
@@ -22,7 +22,7 @@ from pmf_engine.runner.contract import format_contract_for_prompt
 
 logger = get_logger(__name__)
 
-ALLOWED_TOOLS = ["Bash", "Write", "Edit", "Glob", "Grep", "WebFetch", "WebSearch"]
+ALLOWED_TOOLS = ["Bash", "Write", "Edit", "Glob", "Grep", "WebSearch"]
 
 DEFAULT_PERMISSION_MODE = "bypassPermissions"
 
@@ -50,8 +50,8 @@ You have **{max_turns} tool-use turns** to complete this task. Each tool call (B
 **CLI**: python, aws, pdftotext (poppler-utils). You can `pip install` additional Python packages if needed.
 
 **Network egress**: The container has NO direct internet access. `curl`, `wget`, and raw `httpx` calls to external hosts will fail. All external access goes through either:
-- `WebFetch(url, prompt=...)` / `WebSearch(query)` (Claude SDK) — for HTML pages and web search. Returns extracted text. Note: some domains (e.g. `webapi.legistar.com` REST API) are blocked by Anthropic's fetch allowlist — use `pmf_runtime.http.get` for those.
-- `pmf_runtime.http.get(url)` (via broker) — for JSON REST APIs (Legistar, LINC, etc.). Broker's domain allowlist covers `.gov`, `.us`, Legistar, Granicus, PrimeGov, CivicPlus, BoardDocs, eSCRIBE, Municode.
+- `WebSearch(query)` (Claude SDK) — for discovering URLs and topical results. Returns search hits.
+- `pmf_runtime.http.get(url)` (via broker) — for HTML pages, JSON REST APIs (Legistar, LINC, etc.), and any URL retrieval. Broker's domain allowlist covers `.gov`, `.us`, Legistar, Granicus, PrimeGov, CivicPlus, BoardDocs, eSCRIBE, Municode. **This is the only sanctioned way to fetch a URL — `WebFetch` is not available.**
 - `pmf_runtime.pdf.download(url)` (via broker) — for PDFs. Same allowlist.
 - `pmf_runtime` (Databricks, priors, publish, Anthropic proxy) — structured data + artifact I/O.
 

--- a/pmf_engine/tests/test_harness_claude_sdk.py
+++ b/pmf_engine/tests/test_harness_claude_sdk.py
@@ -430,14 +430,21 @@ async def test_tool_spans_paired_by_tool_use_id_not_fifo():
 
 
 def test_allowed_tools_contains_expected_tools():
-    assert ALLOWED_TOOLS == ["Bash", "Write", "Edit", "Glob", "Grep", "WebFetch", "WebSearch"]
+    assert ALLOWED_TOOLS == ["Bash", "Write", "Edit", "Glob", "Grep", "WebSearch"]
 
 
-def test_allowed_tools_includes_web_retrieval():
-    # WebFetch + WebSearch go through Anthropic's servers (not the broker).
-    # The quarantine's containment guarantee still holds — runner has no egress
-    # and no IAM, so a compromised agent acting on fetched content can't exfiltrate.
-    assert "WebFetch" in ALLOWED_TOOLS
+def test_allowed_tools_excludes_webfetch():
+    # WebFetch is excluded: the Claude SDK's WebFetch tool calls claude.ai for
+    # URL safety pre-check from inside the runner container. The runner SG only
+    # permits egress to broker / VPC endpoints / S3 — it cannot reach claude.ai,
+    # so WebFetch always errors with "Unable to verify domain ... claude.ai".
+    # Agents must use pmf_runtime.http.get (broker /http/fetch) for URL retrieval.
+    assert "WebFetch" not in ALLOWED_TOOLS
+
+
+def test_allowed_tools_includes_web_search():
+    # WebSearch routes through api.anthropic.com (which the runner reaches via
+    # broker's anthropic proxy), so it functions inside the egress quarantine.
     assert "WebSearch" in ALLOWED_TOOLS
 
 


### PR DESCRIPTION
## Summary

- Adds qa+prod terraform for `broker`, `pmf-engine-control-plane`, and `pmf-engine-fargate`. Uses a `bootstrap` variable + count-guarded data sources to handle the first-apply chicken-and-egg between the three stacks.
- Module fix: env-suffixes the lambda permission `statement_id` on `shared-slack-notifier` so dev/qa/prod don't collide on `lambda:AddPermission`.
- Runner harness drops `WebFetch` from `ALLOWED_TOOLS`. The Claude SDK calls `claude.ai` for URL safety pre-checks from inside the runner container, but the runner SG only permits egress to broker / VPC endpoints / S3 — `claude.ai` is denied, so `WebFetch` always errored. Agents now use `pmf_runtime.http.get` (broker `/http/fetch`) for URL retrieval. `WebSearch` (server-side at Anthropic, broker-proxied through `/anthropic/v1/messages`) stays.
- Updated 3 experiment instruction files (`district_intel.md`, `meeting_briefing.md`, `peer_city_benchmarking.md`), `broker/ARCHITECTURE.md`, and `broker/url_allowlist.py` rationale comments to match the new tool set.

## Test plan

- [x] qa terraform applied successfully (5 passes: fargate → broker secret target → control-plane → broker → re-apply x2)
- [x] prod terraform applied successfully (same 5-pass shape; ALB + ACM cert validated for `broker.ai.goodparty.org`)
- [x] dev fargate re-applied to clear the unsuffixed `statement_id` drift
- [x] district_intel smoke-tested end-to-end on dev/qa/prod (artifact lands in `gp-agent-artifacts-{env}`, broker `/artifact/publish` 200, gp-api consumed forwarded result on each env)
- [x] dev re-run with WebFetch-removed image: 0 WebFetch tool invocations, agent used WebSearch (10x) + `pmf_runtime.http.get` via broker, artifact richer than baseline (16 sources vs 8, 5 issues vs 4) and ~3 min faster (no claude.ai timeouts)
- [x] 29/29 harness unit tests pass (test changes encode WebFetch absence + WebSearch presence as separate behavioral assertions)

## Open follow-ups (not blocking)

- **SERVICE_TOKEN plaintext in Lambda env / TF state** (pre-existing dev pattern, security finding C1) — should be moved to runtime fetch via `secretsmanager:GetSecretValue` in the dispatch handler.
- **`agent-results-{env}.fifo` orphan queue** — control-plane creates it but broker writes directly to gp-api's queue instead. Decide whether to wire the callback path or remove the queue + DLQ + alarm.
- **prod resource deletion safety** — add `prevent_destroy` lifecycle blocks on `broker-scope-tickets-prod` DDB, broker log group, and broker-prod secret before next destructive operation; document a drain procedure.
- **S3 artifact bucket retention** — `gp-agent-artifacts-prod` has no expiration rule for untagged objects. Pick a per-env retention (suggested: dev 30d, qa 90d, prod 730d).
- **qa/prod live smoke harness** — `pmf_engine/tests/live/test_live_smoke.py` is dev-only (`@pytest.mark.live_dev`); extend to support `LIVE_SMOKE_ENV=qa|prod` with separate enable flags so contract drift can be regression-tested in each env.
- **Bootstrap apply runbook** — capture the 5-pass apply order in `pmf_engine/tests/live/RUNBOOK.md` so future env stand-ups don't have to reverse-engineer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces new QA/Prod infrastructure and cross-stack wiring (Secrets Manager, network/security-group dependencies), so misconfiguration can break deployments or egress controls. Also changes the agent’s web retrieval path, which can impact run behavior and reliability if any workflows still assume `WebFetch`.
> 
> **Overview**
> Adds first-class **QA and Prod Terraform stacks** for `broker`, `pmf-engine-fargate`, and `pmf-engine-control-plane`, including per-env state backends, cross-stack `remote_state` wiring, and a `bootstrap` flag to break initial apply dependency cycles; also provisions per-env `broker-service-tokens-*` Secrets Manager secrets and exports key outputs (SG IDs, broker URL, secret ARNs).
> 
> Updates the runner harness to **drop `WebFetch` from `ALLOWED_TOOLS`**, keeping `WebSearch` and directing all URL retrieval through `pmf_runtime.http.get`/`pmf_runtime.pdf.download` (broker `/http/fetch` + `/pdf/fetch`), with corresponding documentation/instruction updates and test adjustments.
> 
> Fixes an env-collision issue in `pmf-engine-fargate` by suffixing the Slack notifier Lambda permission `statement_id` with `${var.environment}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 910cfaffcb5d8ab0b71d3643ec14bd63cac6e59c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->