### PR TITLE
Prevent Braintrust logging during testing.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,27 @@
+"""Project-root pytest config.
+
+The autouse fixture below blocks every test in the repo from emitting
+real Braintrust telemetry. Several test suites (campaign_plan_lambda,
+pmf_engine smoke tests, hubspot_ddhq_match) call into application code
+that in turn calls `init_braintrust(...)` / `BraintrustClient.init(...)`
+without mocking. With `BRAINTRUST_API_KEY` present in the local `.env`,
+those tests would otherwise authenticate to Braintrust and pollute
+whichever project ended up first to grab the singleton.
+
+Clearing the API key keeps `BraintrustClient` in its disabled state for
+the duration of each test — `traced_span`, `traced_call`, and
+`load_prompt` all become no-ops. Resetting the singleton around each
+test prevents state leaking between tests if any of them set the key
+locally for their own assertions.
+"""
+import pytest
+
+from shared.braintrust import BraintrustClient
+
+
+@pytest.fixture(autouse=True)
+def disable_braintrust(monkeypatch):
+    monkeypatch.setenv("BRAINTRUST_API_KEY", "")
+    BraintrustClient.reset_instance()
+    yield
+    BraintrustClient.reset_instance()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1347,7 +1347,7 @@ dependencies = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.50" },
     { name = "faiss-cpu", specifier = ">=1.12.0" },
-    { name = "gp-shared", virtual = "shared" },
+    { name = "gp-shared", editable = "shared" },
     { name = "pyarrow", specifier = ">=21.0.0" },
 ]
 
@@ -1365,7 +1365,7 @@ dependencies = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.50" },
     { name = "claude-agent-sdk", specifier = ">=0.1.19" },
-    { name = "gp-shared", virtual = "shared" },
+    { name = "gp-shared", editable = "shared" },
 ]
 
 [[package]]
@@ -1392,7 +1392,7 @@ requires-dist = [
     { name = "claude-agent-sdk", specifier = ">=0.1.19" },
     { name = "fastapi", specifier = ">=0.116.0" },
     { name = "fpdf2", specifier = ">=2.8.7" },
-    { name = "gp-shared", virtual = "shared" },
+    { name = "gp-shared", editable = "shared" },
     { name = "kmapper", specifier = ">=2.0.0" },
     { name = "networkx", specifier = ">=3.0" },
     { name = "qrcode", specifier = ">=8.2" },
@@ -1404,7 +1404,7 @@ requires-dist = [
 [[package]]
 name = "gp-shared"
 version = "0.1.0"
-source = { virtual = "shared" }
+source = { editable = "shared" }
 dependencies = [
     { name = "braintrust" },
     { name = "databricks-sql-connector" },
@@ -1463,7 +1463,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.50" },
-    { name = "gp-shared", virtual = "shared" },
+    { name = "gp-shared", editable = "shared" },
     { name = "matplotlib", specifier = ">=3.10.0" },
     { name = "plotly", specifier = ">=5.27.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only environment isolation plus a lockfile metadata update; minimal impact outside local dev/test runs.
> 
> **Overview**
> Prevents tests from emitting real Braintrust telemetry by adding a repo-root `conftest.py` autouse fixture that clears `BRAINTRUST_API_KEY` and resets the `BraintrustClient` singleton before/after each test.
> 
> Updates `uv.lock` to revision 3 and switches `gp-shared` dependencies from `virtual = "shared"` to `editable = "shared"` for local package resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e44cc6ef380d398f498e5af61bc1028fc1c642c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->