### PR TITLE
ENG-7317 Set up evals via Braintrust's beta sandbox feature.

### DIFF
--- a/campaign_plan_lambda/README.md
+++ b/campaign_plan_lambda/README.md
@@ -135,6 +135,63 @@ aws logs tail /aws/lambda/campaign-plan-dev --follow --region us-west-2 --profil
 aws s3 ls s3://campaign-plan-results-dev/results/99999/ --region us-west-2 --profile gp-readonly
 ```
 
+## Iterating on prompts via Braintrust evals
+
+The pipeline ships with a Braintrust sandbox eval (`evals.py`) so PMs can iterate on prompts in the Braintrust playground without engineer involvement. Each eval run executes the same `search → filter → cleanup` flow the Lambda runs in prod, against a curated dataset, with the PM-edited prompts substituted in via the playground form.
+
+### One-time setup (per Braintrust project)
+
+In Braintrust UI → `campaign-plan` project → Settings → Environment Variables:
+
+- `GEMINI_API_KEY` — for the sandbox to call Gemini.
+- `ENVIRONMENT=eval` — stamps `metadata.environment="eval"` on every span emitted from sandbox runs so they're filterable in Logs separately from prod runs (`DEV` / `QA` / `PROD` come from the Lambda's AWS env config).
+
+You also need a dataset under the same project with rows shaped like `{electionDate, state, city, officeName, officeLevel, primaryElectionDate}`. Drag-to-dataset from the parent `generate_event_tasks` span in any prod trace produces correctly-shaped rows.
+
+### Engineer workflow — push eval changes
+
+After modifying `evals.py`, `event_generator.py`, or anything in `shared/braintrust.py`:
+
+```bash
+./campaign_plan_lambda/push_eval_to_braintrust.sh
+```
+
+This bundles the eval and uploads it to Braintrust's hosted Lambda sandbox. The script is a Python wrapper around `braintrust push` that works around two SDK quirks (sys.path pollution from uv, and the lazy-load short-circuit when scanning local imports). See the comments in the script for details.
+
+`evals.requirements.txt` is the pip-style manifest the sandbox installs into its venv. Keep it in sync with `pyproject.toml`'s `campaign-plan-lambda` group when bumping versions.
+
+### PM workflow — run the eval
+
+In Braintrust UI:
+
+1. Navigate to `campaign-plan` project → Playground.
+2. **+ Task** → **Remote eval** submenu → pick the registered eval.
+3. Edit `search_prompt` and/or `filter_prompt` in the form (mustache `{{var}}` placeholders).
+4. Pick a dataset, hit **Run**.
+
+Results land as a Braintrust experiment with per-row scores (`count_in_range`, `dates_in_range`, `urls_valid`, `title_overlap`). Compare experiments side-by-side in the UI to evaluate prompt changes.
+
+### Promotion to prod
+
+Once a prompt looks good via eval, save the content into the Braintrust prompt registry under slugs `search-community-events` and `filter-and-structure-events`. The Lambda picks up the latest version on the next invocation via `load_prompt_from_braintrust`.
+
+⚠️ **Prompt updates take effect immediately** on the next Lambda call — there's no environment-pinning yet. Treat the prompt registry as a production-affecting surface and coordinate prompt changes with deploys. Future ticket: wire up Braintrust's deploy-to-environment feature for prompt-version pinning.
+
+### Reading traces
+
+Every Lambda invocation produces a parent `generate_event_tasks` span (type `task`) with two child LLM spans (type `llm`) nested under it:
+
+```
+generate_event_tasks                  input = {electionDate, city, state, ...}
+                                      output = {tasks: [...]}
+                                      metadata.environment = DEV/QA/PROD/eval
+                                      metadata.model = gemini-3-flash-preview
+├── generate_with_search              input = {prompt: "..."}, output = {text, search_queries, sources}
+└── generate_structured_content       input = {prompt: "..."}, output = {events: [...]}
+```
+
+Filter the Logs view by `metadata.environment` to isolate prod vs eval runs, or by `metadata.model` to compare model performance. Click into any parent span to drill into the two LLM children for prompt-and-response detail.
+
 ## SQS message format
 
 ### Input (from gp-api)

--- a/campaign_plan_lambda/evals.py
+++ b/campaign_plan_lambda/evals.py
@@ -1,0 +1,326 @@
+"""
+Braintrust Sandbox Eval for the campaign plan pipeline.
+
+Runs end-to-end (search → filter → cleanup). The PM edits the two prompt
+templates directly in the playground form (UI prompt editor), runs against
+a curated dataset, sees scored results. No prompt-version management
+required — eval changes never touch the prod prompts in the Braintrust
+prompt registry.
+
+Push (engineer, after code changes):
+    ./campaign_plan_lambda/push_eval_to_braintrust.sh
+
+PM workflow (in Braintrust UI):
+    Project → Playground → + Task → Remote eval submenu → pick this eval →
+    edit search_prompt and/or filter_prompt → pick dataset → Run.
+
+Promotion to prod is a deliberate engineer step:
+    Once a prompt is proven via eval, save the content into the Braintrust
+    prompt registry under the slugs `search-community-events` and
+    `filter-and-structure-events`. The Lambda picks up the latest version
+    via load_prompt_from_braintrust on the next invocation.
+
+    Caveat: prompt updates take effect immediately on the next Lambda call.
+    Environment-pinned prompt deployment is a future ticket — until then,
+    treat the prompt registry as a "production-affecting" surface.
+
+Environment configuration:
+    Set `ENVIRONMENT=eval` in Braintrust → Project Settings → Environment
+    Variables (alongside GEMINI_API_KEY). This stamps `environment=eval`
+    on every span emitted from sandbox runs so they're filterable in Logs
+    separately from prod runs (which set ENVIRONMENT via the Lambda's
+    AWS Lambda env config). For local `bt eval --dev` invocations, export
+    ENVIRONMENT=eval in your shell or .env.
+"""
+
+import os
+import re
+from datetime import date
+from typing import Any, Optional
+
+from braintrust import Eval, init_dataset
+
+from shared.braintrust import (
+    flatten_prompt_messages,
+    init_braintrust,
+    trace_pipeline,
+)
+from shared.llm_gemini_3 import Gemini3Client
+from campaign_plan_lambda.event_generator import (
+    FILTER_PROMPT_FALLBACK,
+    SEARCH_PROMPT_FALLBACK,
+    _build_prompt_variables,
+    _filter_and_structure_events,
+    _search_community_events,
+)
+
+PROJECT = "campaign-plan"
+DATASET_NAME = "campaign-plan-pipeline"
+
+
+def _to_mustache(template: str) -> str:
+    """Convert Python `{var}` placeholders to Mustache `{{var}}` so the
+    Lambda's fallback prompts (rendered via `.format(**vars)`) can serve
+    as the eval-form defaults (rendered via Braintrust's Mustache engine)
+    without manual duplication. Already-doubled braces are preserved."""
+    return re.sub(
+        r"(?<!\{)\{([a-zA-Z_][a-zA-Z0-9_]*)\}(?!\})",
+        r"{{\1}}",
+        template,
+    )
+
+
+# Default prompt content for the playground form, derived from the
+# Lambda's runtime fallback prompts. Edit `SEARCH_PROMPT_FALLBACK` /
+# `FILTER_PROMPT_FALLBACK` in event_generator.py and these defaults
+# track automatically — no manual sync. The PM can still override per-
+# run via the form.
+SEARCH_PROMPT_DEFAULT = _to_mustache(SEARCH_PROMPT_FALLBACK)
+FILTER_PROMPT_DEFAULT = _to_mustache(FILTER_PROMPT_FALLBACK)
+
+
+def _coerce_optional_str(v: Any) -> Optional[str]:
+    if v is None:
+        return None
+    if isinstance(v, str):
+        return v if v.strip() else None
+    return str(v)
+
+
+async def pipeline_task(input: dict, hooks: Any) -> dict:
+    """Run the full search → filter pipeline against one dataset row, using
+    prompts supplied by the PM via the playground form.
+
+    Wraps the work in a `generate_event_tasks` span (same name and input
+    shape as the Lambda's parent span) so the project Logs view shows the
+    variable-dict input + cleaned-tasks output at the top, with the inner
+    LLM calls nested underneath. Eval-vs-prod distinguishability comes
+    from `metadata.environment="eval"` (set in Braintrust project env
+    vars) — no separate tag is needed."""
+    # Initialise the BraintrustClient singleton so _traced_call inside
+    # Gemini3Client emits child spans under the experiment row.
+    # Idempotent — the singleton no-ops on repeat calls — and intentionally
+    # placed here rather than at module import to keep eval imports side-
+    # effect-free (the bundler imports this file with no API key set).
+    init_braintrust(project=PROJECT)
+
+    params = hooks.parameters
+
+    # Some prod campaigns lack details.electionDate. Curated dataset rows
+    # may inherit that gap. Skip the LLM work and return an empty result so
+    # one bad row doesn't crash the whole eval. Scorers treat empty `tasks`
+    # as a 0 score, which is the right signal here.
+    raw_election_date = input.get("electionDate")
+    if not raw_election_date:
+        return {"tasks": []}
+    try:
+        election_date = date.fromisoformat(raw_election_date)
+    except (ValueError, TypeError):
+        return {"tasks": []}
+    today = date.today()
+    variables = _build_prompt_variables(
+        today=today,
+        election_date=election_date,
+        state=_coerce_optional_str(input.get("state")),
+        city=_coerce_optional_str(input.get("city")),
+        office_name=_coerce_optional_str(input.get("officeName")),
+        office_level=_coerce_optional_str(input.get("officeLevel")),
+        primary_election_date=_coerce_optional_str(input.get("primaryElectionDate")),
+    )
+
+    # Match the Lambda's parent-span input dict so eval and prod traces
+    # have identical shapes in the Logs view.
+    pipeline_input = {
+        "electionDate": str(election_date),
+        "state": _coerce_optional_str(input.get("state")),
+        "city": _coerce_optional_str(input.get("city")),
+        "officeName": _coerce_optional_str(input.get("officeName")),
+        "officeLevel": _coerce_optional_str(input.get("officeLevel")),
+        "primaryElectionDate": _coerce_optional_str(input.get("primaryElectionDate")),
+    }
+
+    llm_client = Gemini3Client()
+
+    with trace_pipeline(
+        "generate_event_tasks",
+        metadata={
+            "model": llm_client.default_model.value,
+            "environment": os.getenv("ENVIRONMENT", "eval"),
+        },
+    ) as span:
+        span.log(input=pipeline_input)
+
+        search_built = params["search_prompt"].build(**variables)
+        search_text = flatten_prompt_messages(search_built)
+        # hooks.span.start_span attaches to the experiment row so the eval
+        # drill-down shows the per-step breakdown. The LLM call inside
+        # routes via `_traced_call` into the project Logs view (under
+        # generate_event_tasks), so both views stay populated.
+        with hooks.span.start_span(name="search") as search_span:
+            search_span.log(input={"prompt": search_text})
+            raw_events = await _search_community_events(
+                llm_client, variables, rendered_prompt=search_text,
+            )
+            search_span.log(output={"raw_events": raw_events})
+
+        filter_built = params["filter_prompt"].build(**variables, raw_events=raw_events)
+        filter_text = flatten_prompt_messages(filter_built)
+        with hooks.span.start_span(name="filter") as filter_span:
+            filter_span.log(input={"prompt": filter_text})
+            tasks = await _filter_and_structure_events(
+                llm_client, variables, election_date, today, raw_events,
+                rendered_prompt=filter_text,
+            )
+            filter_span.log(output={"tasks": [t.model_dump() for t in tasks]})
+
+        output = {"tasks": [t.model_dump() for t in tasks]}
+        span.log(output=output)
+
+    return output
+
+
+# --- Scorers --------------------------------------------------------------
+# Each scorer returns a float in [0, 1]. Braintrust uses the function name
+# as the metric name in experiment summaries. Signature follows Braintrust's
+# canonical scorer contract: (input, output, expected, **kwargs).
+
+
+def count_in_range(input: dict, output: dict, expected: Optional[dict] = None, **_: Any) -> float:
+    """Prompt asks for 5–8 events. Score 1 if in range, otherwise scaled by
+    distance from the band."""
+    n = len(output.get("tasks") or [])
+    if 5 <= n <= 8:
+        return 1.0
+    if n == 0:
+        return 0.0
+    if n < 5:
+        return n / 5
+    return max(0.0, 1.0 - (n - 8) / 8)
+
+
+def dates_in_range(input: dict, output: dict, expected: Optional[dict] = None, **_: Any) -> float:
+    """Every task date must fall between today and the election date. The
+    upper bound comes from the dataset row's electionDate; the lower bound
+    is today (the day the eval runs) — events in the past don't help the
+    candidate even if the model produced them."""
+    try:
+        election = date.fromisoformat(input["electionDate"])
+    except (KeyError, ValueError, TypeError):
+        # Dataset row missing / malformed electionDate — skip with a 0
+        # score rather than crash the whole row.
+        return 0.0
+    today = date.today()
+    tasks = output.get("tasks") or []
+    if not tasks:
+        return 0.0
+    ok = 0
+    for t in tasks:
+        if not isinstance(t, dict):
+            continue
+        try:
+            d = date.fromisoformat(t["date"])
+        except (ValueError, KeyError, TypeError):
+            continue
+        if today <= d <= election:
+            ok += 1
+    return ok / len(tasks)
+
+
+def urls_valid(input: dict, output: dict, expected: Optional[dict] = None, **_: Any) -> float:
+    """Non-null URLs must be http/https. Null URLs are fine."""
+    tasks = output.get("tasks") or []
+    if not tasks:
+        return 0.0
+    ok = 0
+    for t in tasks:
+        if not isinstance(t, dict):
+            continue
+        url = t.get("url")
+        if url is None or (isinstance(url, str) and url.startswith(("http://", "https://"))):
+            ok += 1
+    return ok / len(tasks)
+
+
+def title_overlap(input: dict, output: dict, expected: Optional[dict] = None, **_: Any) -> float:
+    """Jaccard of task titles (case-insensitive) vs expected. Skip if no
+    expected (PM may curate inputs without writing gold outputs)."""
+    if not expected or not expected.get("tasks"):
+        return 0.0
+    out_titles = {
+        (t.get("title") or "").strip().lower()
+        for t in (output.get("tasks") or [])
+        if isinstance(t, dict)
+    }
+    exp_titles = {
+        (t.get("title") or "").strip().lower()
+        for t in expected["tasks"]
+        if isinstance(t, dict)
+    }
+    out_titles.discard("")
+    exp_titles.discard("")
+    if not out_titles or not exp_titles:
+        return 0.0
+    return len(out_titles & exp_titles) / len(out_titles | exp_titles)
+
+
+# --- Eval -----------------------------------------------------------------
+# `data=` is ignored when the eval runs from the playground (PM picks the
+# dataset there), but it must still be valid Python so offline runs work.
+#
+# Use plain dict literals for `EVAL_PARAMETERS` rather than Braintrust's
+# typed constructors (PromptParameter / PromptData / PromptChatBlock /
+# PromptMessage). Those constructors emit every field — including unset
+# Optional ones — as JSON `null`s (e.g. `tools: null`, `name: null`,
+# `tool_calls: null`), which the playground UI's parameter validator
+# rejects: a sandbox registered with the typed-constructor shape silently
+# disappears from the playground "+ Task → Remote eval" picker even
+# though the function is queryable via the API. Dict literals omit the
+# unset keys, matching what the UI expects.
+#
+# Pulled out as a module-level constant so `tests/test_evals.py` can
+# import it and assert the no-null shape directly (regression check).
+EVAL_PARAMETERS: dict[str, Any] = {
+    "search_prompt": {
+        "type": "prompt",
+        "name": "Search prompt",
+        "description": (
+            "Prompt for the Gemini grounded-search step. Variables "
+            "available: today, election_date, state, city, office_name, "
+            "office_level, primary_election_date."
+        ),
+        "default": {
+            "prompt": {
+                "type": "chat",
+                "messages": [{"role": "system", "content": SEARCH_PROMPT_DEFAULT}],
+            },
+            "options": {"model": "gemini-3-flash-preview"},
+        },
+    },
+    "filter_prompt": {
+        "type": "prompt",
+        "name": "Filter prompt",
+        "description": (
+            "Prompt for the structured-output filter step. Variables "
+            "available: today, election_date, state, city, office_name, "
+            "office_level, primary_election_date, raw_events (the search "
+            "step's output)."
+        ),
+        "default": {
+            "prompt": {
+                "type": "chat",
+                "messages": [{"role": "system", "content": FILTER_PROMPT_DEFAULT}],
+            },
+            "options": {"model": "gemini-3-flash-preview"},
+        },
+    },
+}
+
+
+Eval(
+    PROJECT,
+    experiment_name="campaign-plan-pipeline",
+    data=init_dataset(PROJECT, DATASET_NAME),
+    task=pipeline_task,
+    scores=[count_in_range, dates_in_range, urls_valid, title_overlap],
+    parameters=EVAL_PARAMETERS,
+)

--- a/campaign_plan_lambda/evals.requirements.txt
+++ b/campaign_plan_lambda/evals.requirements.txt
@@ -1,0 +1,20 @@
+# Dependency manifest for the Braintrust sandbox eval bundle.
+#
+# The rest of this project uses uv + pyproject.toml as the source of truth
+# for dependencies. This file exists because `braintrust push --requirements`
+# expects a plain pip-style requirements.txt to ship into the hosted sandbox
+# runtime. It does NOT understand uv lockfiles or pyproject groups.
+#
+# Keep this list minimal: only the runtime deps `evals.py` (and the
+# campaign_plan_lambda / shared modules it imports) actually need inside
+# the sandbox. The bundler installs these into an isolated venv that gets
+# uploaded to Braintrust's Lambda runtime.
+#
+# When updating: bump versions here AND in pyproject.toml's
+# `campaign-plan-lambda` group so local runs and sandbox runs resolve to
+# compatible versions.
+
+braintrust>=0.12.1
+google-genai>=1.56.0
+pydantic>=2.0.0
+python-dotenv>=1.1.1

--- a/campaign_plan_lambda/event_generator.py
+++ b/campaign_plan_lambda/event_generator.py
@@ -8,13 +8,14 @@ Generates community event tasks using Gemini Google Search grounding.
 Prompts are loaded from Braintrust (with hardcoded fallbacks if unavailable).
 """
 
+import os
 from datetime import date
 from typing import List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
 from shared.llm_gemini_3 import Gemini3Client
-from shared.braintrust import load_prompt_from_braintrust
+from shared.braintrust import load_prompt_from_braintrust, trace_pipeline
 from shared.logger import get_logger
 
 logger = get_logger(__name__)
@@ -95,6 +96,20 @@ class LlmEventResultList(BaseModel):
     events: List[LlmEventResult]
 
 
+class CampaignContext(BaseModel):
+    """Per-campaign context for the event-generation pipeline. Field names
+    match the camelCase shape that flows from gp-api → SQS → Braintrust
+    span input, so `model_dump()` produces the dict we log directly.
+    `electionDate` is required; everything else is optional and the prompt
+    builder substitutes a "not available" sentinel for missing values."""
+    electionDate: str
+    state: Optional[str] = None
+    city: Optional[str] = None
+    officeName: Optional[str] = None
+    officeLevel: Optional[str] = None
+    primaryElectionDate: Optional[str] = None
+
+
 class CampaignEventTask(BaseModel):
     """Final task shape matching gp-api's CampaignTask schema."""
     title: str
@@ -142,25 +157,21 @@ def _build_prompt_variables(
 
 
 async def generate_event_tasks(
-    election_date: date,
-    state: Optional[str] = None,
-    city: Optional[str] = None,
-    office_name: Optional[str] = None,
-    office_level: Optional[str] = None,
-    primary_election_date: Optional[str] = None,
+    ctx: CampaignContext,
     llm_client: Optional[Gemini3Client] = None,
 ) -> List[CampaignEventTask]:
     llm_client = llm_client or Gemini3Client()
 
     today = date.today()
+    election_date = date.fromisoformat(ctx.electionDate)
     variables = _build_prompt_variables(
         today=today,
         election_date=election_date,
-        state=state,
-        city=city,
-        office_name=office_name,
-        office_level=office_level,
-        primary_election_date=primary_election_date,
+        state=ctx.state,
+        city=ctx.city,
+        office_name=ctx.officeName,
+        office_level=ctx.officeLevel,
+        primary_election_date=ctx.primaryElectionDate,
     )
     logger.info(
         f"Generating events for {variables['city']}, {variables['state']} "
@@ -168,26 +179,51 @@ async def generate_event_tasks(
         f"election: {election_date})"
     )
 
-    raw_events = await _search_community_events(llm_client, variables)
-    event_tasks = await _filter_and_structure_events(
-        llm_client, variables, election_date, today, raw_events
-    )
+    with trace_pipeline(
+        "generate_event_tasks",
+        metadata={
+            "model": llm_client.default_model.value,
+            "environment": os.getenv("ENVIRONMENT", "local"),
+        },
+    ) as span:
+        # Log the highest level input to the pipeline (the CampaignContext) so it's visible in the trace.
+        span.log(input=ctx.model_dump())
+
+        raw_events = await _search_community_events(llm_client, variables)
+        event_tasks = await _filter_and_structure_events(
+            llm_client, variables, election_date, today, raw_events,
+        )
+
+        span.log(output={"tasks": [t.model_dump() for t in event_tasks]})
 
     stats = llm_client.get_usage_stats()
     logger.info(f"Generated {len(event_tasks)} event tasks | Gemini: {stats['api_calls']} calls, ${stats['total_cost']:.4f}")
     return event_tasks
 
 
-async def _search_community_events(llm_client: Gemini3Client, variables: dict) -> str:
+async def _search_community_events(
+    llm_client: Gemini3Client,
+    variables: dict,
+    rendered_prompt: Optional[str] = None,
+) -> str:
+    """Run the grounded-search step.
+
+    `rendered_prompt` is for eval/test use only — when supplied, it bypasses
+    Braintrust prompt loading and uses the given string directly. The prod
+    Lambda never passes it; handler.py calls generate_event_tasks with
+    explicit named kwargs that don't include rendered_prompt, so untrusted
+    SQS input cannot reach this parameter.
+    """
     logger.info(f"Searching for community events in {variables['city']}, {variables['state']}")
 
-    prompt = load_prompt_from_braintrust(
-        prompt_name="search-community-events",
-        fallback_prompt=SEARCH_PROMPT_FALLBACK,
-        variables=variables,
-    )
+    if rendered_prompt is None:
+        rendered_prompt = load_prompt_from_braintrust(
+            prompt_name="search-community-events",
+            fallback_prompt=SEARCH_PROMPT_FALLBACK,
+            variables=variables,
+        )
 
-    response = llm_client.generate_with_search(prompt)
+    response = llm_client.generate_with_search(rendered_prompt)
     return response.text
 
 
@@ -197,17 +233,25 @@ async def _filter_and_structure_events(
     election_date: date,
     today: date,
     raw_events: str,
+    rendered_prompt: Optional[str] = None,
 ) -> List[CampaignEventTask]:
+    """Run the filter/structure step.
+
+    `rendered_prompt` is for eval/test use only — when supplied, it bypasses
+    Braintrust prompt loading and uses the given string directly. Same
+    safety reasoning as _search_community_events.
+    """
     logger.info("Filtering and structuring events as tasks")
 
-    prompt = load_prompt_from_braintrust(
-        prompt_name="filter-and-structure-events",
-        fallback_prompt=FILTER_PROMPT_FALLBACK,
-        variables={**variables, "raw_events": raw_events},
-    )
+    if rendered_prompt is None:
+        rendered_prompt = load_prompt_from_braintrust(
+            prompt_name="filter-and-structure-events",
+            fallback_prompt=FILTER_PROMPT_FALLBACK,
+            variables={**variables, "raw_events": raw_events},
+        )
 
     raw_response = llm_client.generate_structured_content(
-        prompt=prompt,
+        prompt=rendered_prompt,
         response_schema=LlmEventResultList,
         system_instruction="Select community events and return them as structured data. Dates must be YYYY-MM-DD format.",
         temperature=0.0,

--- a/campaign_plan_lambda/handler.py
+++ b/campaign_plan_lambda/handler.py
@@ -168,17 +168,18 @@ def handler(event: LambdaEvent, context=None) -> None:
 
 
 async def _generate(campaign_id: int, msg: SqsMessageBody) -> CampaignPlanResult:
-    from campaign_plan_lambda.event_generator import generate_event_tasks
+    from campaign_plan_lambda.event_generator import CampaignContext, generate_event_tasks
     from campaign_plan_lambda.output import write_result_to_s3, send_completion_message
 
-    event_tasks = await generate_event_tasks(
-        election_date=date.fromisoformat(msg.electionDate),
+    ctx = CampaignContext(
+        electionDate=msg.electionDate,
         state=msg.state,
         city=msg.city,
-        office_name=msg.officeName,
-        office_level=msg.officeLevel,
-        primary_election_date=msg.primaryElectionDate,
+        officeName=msg.officeName,
+        officeLevel=msg.officeLevel,
+        primaryElectionDate=msg.primaryElectionDate,
     )
+    event_tasks = await generate_event_tasks(ctx)
     logger.info(f"Generated {len(event_tasks)} event tasks")
 
     generation_timestamp = datetime.now(timezone.utc).isoformat()

--- a/campaign_plan_lambda/push_eval_to_braintrust.sh
+++ b/campaign_plan_lambda/push_eval_to_braintrust.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Push campaign_plan_lambda/evals.py to Braintrust as a sandbox eval.
+#
+# Why the Python wrapper? The vanilla `braintrust push` CLI walks the import
+# graph of the eval file to decide which local source files to ship. Two
+# things break that walker for us:
+#   1. uv adds the project root to sys.path[1:] (in addition to leaving an
+#      empty string at [0]), so the bundler's `_under_rest` check defers
+#      every submodule.
+#   2. The push CLI imports the eval with _set_lazy_load(True), which
+#      short-circuits Eval() so the task body (and thus its transitive
+#      imports) never runs — only the eval module's top-level imports are
+#      observed, and even those get filtered out by problem #1.
+# Net effect: only `campaign_plan_lambda/__init__.py` and `shared/__init__.py`
+# end up in the zip, the sandbox crashes with `No module named
+# 'campaign_plan_lambda.evals'`, and we lose hours figuring it out.
+#
+# Workaround: sanitize sys.path AND explicitly enumerate every .py file
+# under our two top-level packages so the bundler ships them regardless of
+# what the auto-walker missed.
+#
+# Run from project root:
+#   ./campaign_plan_lambda/push_eval_to_braintrust.sh
+#
+# Requires BRAINTRUST_API_KEY in env. The dev dep `braintrust[cli]` must be
+# installed (uv sync handles this).
+#
+# Sandbox runtime configuration (one-time, in Braintrust UI):
+#   - GEMINI_API_KEY: set in Project Settings → Environment Variables.
+#   - ENVIRONMENT=eval: also in Environment Variables. Stamps every span
+#     emitted from sandbox runs with `metadata.environment="eval"` so the
+#     Logs view can filter eval rows separately from prod
+#     (DEV / QA / PROD comes from the Lambda's AWS env config).
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+uv run python -c "
+import sys, os
+print('[push_eval] wrapper starting', file=sys.stderr, flush=True)
+# Load .env so BRAINTRUST_API_KEY (and friends) are available to the push CLI.
+# shared/braintrust.py loads .env when imported, but the braintrust CLI doesn't
+# go through that module, so we have to do it explicitly here.
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+cwd = os.path.abspath(os.getcwd())
+sys.path[:] = [cwd] + [p for p in sys.path if p and os.path.abspath(p) != cwd]
+print(f'[push_eval] cleaned sys.path[0]={sys.path[0]!r}', file=sys.stderr, flush=True)
+print(f'[push_eval] sys.path[1:]={sys.path[1:]!r}', file=sys.stderr, flush=True)
+
+# Explicit list of local source files the eval depends on. Add an entry when
+# evals.py or its callees gain a new local import. We use an allow-list (not
+# os.walk) so build artifacts under .build/, tests/, and unrelated shared
+# modules don't get sucked into the bundle.
+EVAL_SOURCE_FILES = [
+    'campaign_plan_lambda/__init__.py',
+    'campaign_plan_lambda/evals.py',
+    'campaign_plan_lambda/event_generator.py',
+    'shared/__init__.py',
+    'shared/braintrust.py',
+    'shared/llm_gemini_3.py',
+    'shared/logger.py',
+]
+
+import braintrust.cli.push as _push_mod
+print(f'[push_eval] patching {_push_mod.__file__}', file=sys.stderr, flush=True)
+_orig_import = _push_mod._import_module
+def _augmented_import(name, path):
+    sources = _orig_import(name, path)
+    seen = {os.path.abspath(s) for s in sources}
+    for rel in EVAL_SOURCE_FILES:
+        abs_path = os.path.abspath(rel)
+        if not os.path.exists(abs_path):
+            raise FileNotFoundError(f'EVAL_SOURCE_FILES entry missing: {rel}')
+        if abs_path not in seen:
+            sources.append(abs_path)
+            seen.add(abs_path)
+    return sources
+_push_mod._import_module = _augmented_import
+
+_orig_upload = _push_mod._upload_bundle
+def _logged_upload(entry_module_name, sources, requirements):
+    print(f'[push_eval] entry: {entry_module_name}', file=sys.stderr, flush=True)
+    print(f'[push_eval] {len(sources)} sources in bundle:', file=sys.stderr, flush=True)
+    for s in sorted(sources):
+        try:
+            rel = os.path.relpath(s)
+        except ValueError:
+            rel = s
+        print(f'  {rel}', file=sys.stderr, flush=True)
+    return _orig_upload(entry_module_name, sources, requirements)
+_push_mod._upload_bundle = _logged_upload
+print('[push_eval] patches applied; invoking main()', file=sys.stderr, flush=True)
+
+from braintrust.cli.__main__ import main
+sys.argv = [
+    'braintrust', 'push',
+    'campaign_plan_lambda/evals.py',
+    '--requirements', 'campaign_plan_lambda/evals.requirements.txt',
+    '--if-exists', 'replace',
+]
+sys.exit(main())
+"

--- a/campaign_plan_lambda/tests/test_evals.py
+++ b/campaign_plan_lambda/tests/test_evals.py
@@ -1,0 +1,331 @@
+"""Unit tests for campaign_plan_lambda/evals.py.
+
+Three flavors of test:
+- Pure-function scorer tests: exhaustive boundary/edge coverage for the
+  four scorers (`count_in_range`, `dates_in_range`, `urls_valid`,
+  `title_overlap`).
+- `pipeline_task` short-circuit tests: locks the explicit branches that
+  return an empty result on missing/malformed electionDate. The rest of
+  pipeline_task is thin orchestration (assemble vars → render prompts →
+  call helpers) and is integration-tested by PMs running real evals.
+- `EVAL_PARAMETERS` shape tests: regression coverage for the
+  null-field-in-prompt-block bug that hid our sandbox from the playground
+  "+ Task → Remote eval" picker. See `TestEvalParametersShape` below."""
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import pytest
+
+
+def _import_scorers():
+    """Import the scorer functions without triggering the module-level
+    `Eval(...)` call (which connects to Braintrust). Done with a stub for
+    `braintrust.Eval` and `braintrust.init_dataset`."""
+    import importlib
+    import sys
+
+    # If evals was already imported elsewhere (e.g. via push_eval_to_braintrust.sh), get
+    # the existing module — Eval already ran but that's harmless for our
+    # function references.
+    if "campaign_plan_lambda.evals" in sys.modules:
+        return sys.modules["campaign_plan_lambda.evals"]
+
+    with patch("braintrust.Eval"), patch("braintrust.init_dataset"):
+        return importlib.import_module("campaign_plan_lambda.evals")
+
+
+evals = _import_scorers()
+
+
+class TestCountInRange:
+    def test_target_band_scores_one(self):
+        for n in (5, 6, 7, 8):
+            output = {"tasks": [{}] * n}
+            assert evals.count_in_range(None, output) == 1.0
+
+    def test_zero_scores_zero(self):
+        assert evals.count_in_range(None, {"tasks": []}) == 0.0
+
+    def test_below_band_scales_linearly(self):
+        # 4 events / target floor of 5 = 0.8
+        assert evals.count_in_range(None, {"tasks": [{}] * 4}) == 0.8
+
+    def test_far_below_band(self):
+        assert evals.count_in_range(None, {"tasks": [{}]}) == 0.2
+
+    def test_above_band_scales_linearly(self):
+        # n=12 → 1 - (12-8)/8 = 0.5
+        assert evals.count_in_range(None, {"tasks": [{}] * 12}) == 0.5
+
+    def test_far_above_band_clamps_to_zero(self):
+        assert evals.count_in_range(None, {"tasks": [{}] * 100}) == 0.0
+
+    def test_missing_tasks_field(self):
+        assert evals.count_in_range(None, {}) == 0.0
+
+
+class TestDatesInRange:
+    def setup_method(self):
+        # Election 60 days from today; today is "now" inside the scorer.
+        self.today = date.today()
+        self.election = self.today + timedelta(days=60)
+        self.input = {"electionDate": self.election.isoformat()}
+
+    def test_all_in_range_scores_one(self):
+        output = {"tasks": [
+            {"date": (self.today + timedelta(days=10)).isoformat()},
+            {"date": (self.today + timedelta(days=30)).isoformat()},
+        ]}
+        assert evals.dates_in_range(self.input, output) == 1.0
+
+    def test_past_event_excluded(self):
+        # Lower bound (today) was added in this branch — past events used
+        # to score as in-range.
+        output = {"tasks": [
+            {"date": (self.today - timedelta(days=1)).isoformat()},
+            {"date": (self.today + timedelta(days=10)).isoformat()},
+        ]}
+        assert evals.dates_in_range(self.input, output) == 0.5
+
+    def test_post_election_event_excluded(self):
+        output = {"tasks": [
+            {"date": (self.election + timedelta(days=1)).isoformat()},
+            {"date": (self.today + timedelta(days=10)).isoformat()},
+        ]}
+        assert evals.dates_in_range(self.input, output) == 0.5
+
+    def test_today_and_election_inclusive(self):
+        output = {"tasks": [
+            {"date": self.today.isoformat()},
+            {"date": self.election.isoformat()},
+        ]}
+        assert evals.dates_in_range(self.input, output) == 1.0
+
+    def test_invalid_date_string_dropped(self):
+        output = {"tasks": [
+            {"date": "not-a-date"},
+            {"date": (self.today + timedelta(days=10)).isoformat()},
+        ]}
+        # 1 valid out of 2 total
+        assert evals.dates_in_range(self.input, output) == 0.5
+
+    def test_non_dict_task_dropped(self):
+        output = {"tasks": [
+            None,
+            {"date": (self.today + timedelta(days=10)).isoformat()},
+        ]}
+        assert evals.dates_in_range(self.input, output) == 0.5
+
+    def test_no_tasks_scores_zero(self):
+        assert evals.dates_in_range(self.input, {"tasks": []}) == 0.0
+
+    def test_missing_election_date_returns_zero_not_raise(self):
+        # Hardened in this branch: a malformed dataset row no longer crashes
+        # the entire eval.
+        output = {"tasks": [{"date": (self.today + timedelta(days=10)).isoformat()}]}
+        assert evals.dates_in_range({}, output) == 0.0
+        assert evals.dates_in_range({"electionDate": "garbage"}, output) == 0.0
+
+
+class TestUrlsValid:
+    def test_https_is_valid(self):
+        output = {"tasks": [{"url": "https://example.com"}]}
+        assert evals.urls_valid(None, output) == 1.0
+
+    def test_http_is_valid(self):
+        output = {"tasks": [{"url": "http://example.com"}]}
+        assert evals.urls_valid(None, output) == 1.0
+
+    def test_null_url_is_valid(self):
+        # Per the prompt rules, missing URL is acceptable.
+        output = {"tasks": [{"url": None}]}
+        assert evals.urls_valid(None, output) == 1.0
+
+    def test_ftp_url_invalid(self):
+        output = {"tasks": [{"url": "ftp://example.com"}]}
+        assert evals.urls_valid(None, output) == 0.0
+
+    def test_mixed(self):
+        output = {"tasks": [
+            {"url": "https://valid.com"},
+            {"url": "javascript:alert(1)"},
+            {"url": None},
+            {"url": "https://another.com"},
+        ]}
+        assert evals.urls_valid(None, output) == 0.75
+
+    def test_non_dict_task_dropped(self):
+        output = {"tasks": [None, {"url": "https://valid.com"}]}
+        # 1 valid out of 2 total — non-dict still counts toward the
+        # denominator (effectively invalid) since the scorer divides
+        # ok by len(tasks), not by the count of dict-shaped tasks.
+        assert evals.urls_valid(None, output) == 0.5
+
+    def test_no_tasks_scores_zero(self):
+        assert evals.urls_valid(None, {"tasks": []}) == 0.0
+
+
+class TestTitleOverlap:
+    def test_returns_zero_when_no_expected(self):
+        output = {"tasks": [{"title": "X"}]}
+        assert evals.title_overlap(None, output, None) == 0.0
+        assert evals.title_overlap(None, output, {}) == 0.0
+        assert evals.title_overlap(None, output, {"tasks": []}) == 0.0
+
+    def test_full_overlap(self):
+        output = {"tasks": [{"title": "Pride"}, {"title": "BBQ"}]}
+        expected = {"tasks": [{"title": "Pride"}, {"title": "BBQ"}]}
+        assert evals.title_overlap(None, output, expected) == 1.0
+
+    def test_case_insensitive(self):
+        output = {"tasks": [{"title": "PRIDE"}]}
+        expected = {"tasks": [{"title": "pride"}]}
+        assert evals.title_overlap(None, output, expected) == 1.0
+
+    def test_partial_overlap_jaccard(self):
+        # Output: {a, b}, Expected: {b, c}. Intersection=1, Union=3 → 1/3.
+        output = {"tasks": [{"title": "A"}, {"title": "B"}]}
+        expected = {"tasks": [{"title": "B"}, {"title": "C"}]}
+        assert abs(evals.title_overlap(None, output, expected) - 1 / 3) < 1e-9
+
+    def test_no_overlap(self):
+        output = {"tasks": [{"title": "A"}]}
+        expected = {"tasks": [{"title": "B"}]}
+        assert evals.title_overlap(None, output, expected) == 0.0
+
+    def test_non_dict_tasks_skipped(self):
+        output = {"tasks": [None, {"title": "X"}]}
+        expected = {"tasks": [{"title": "X"}]}
+        assert evals.title_overlap(None, output, expected) == 1.0
+
+
+class FakePromptParam:
+    """Stand-in for a Braintrust playground `type: 'prompt'` parameter.
+    Records every `.build(**kwargs)` call so tests can assert which
+    variables flowed in. Returns a messages-shaped dict that
+    `flatten_prompt_messages` will collapse into the content string."""
+
+    def __init__(self, content: str):
+        self.content = content
+        self.build_calls: list[dict] = []
+
+    def build(self, **kwargs):
+        self.build_calls.append(kwargs)
+        return {"messages": [{"role": "system", "content": self.content}]}
+
+
+class FakeHooks:
+    def __init__(self):
+        self.parameters = {
+            "search_prompt": FakePromptParam("irrelevant"),
+            "filter_prompt": FakePromptParam("irrelevant"),
+        }
+
+
+class TestPipelineTask:
+    """`pipeline_task` short-circuits with an empty result when the
+    dataset row is missing or has a malformed `electionDate`. This is
+    deliberate handling for a known prod data gap (~80% of pro
+    campaigns lack `details.electionDate`) — without it, one bad row
+    crashes an entire eval run. Locked here so the branches don't get
+    refactored away as dead code."""
+
+    @pytest.mark.asyncio
+    async def test_short_circuits_on_missing_election_date(self):
+        hooks = FakeHooks()
+        result = await evals.pipeline_task({"city": "Boston"}, hooks)
+
+        assert result == {"tasks": []}
+        # Bailed before prompt rendering or any LLM work.
+        assert hooks.parameters["search_prompt"].build_calls == []
+
+    @pytest.mark.asyncio
+    async def test_short_circuits_on_malformed_election_date(self):
+        hooks = FakeHooks()
+        result = await evals.pipeline_task({"electionDate": "not-a-date"}, hooks)
+
+        assert result == {"tasks": []}
+        assert hooks.parameters["search_prompt"].build_calls == []
+
+
+def _walk(value, path=""):
+    """Yield (jsonpath, value) for every leaf and container node in a
+    nested structure. Used by the no-null assertion below to point at the
+    exact field that broke if the test ever fails."""
+    if isinstance(value, dict):
+        yield path or "$", value
+        for k, v in value.items():
+            yield from _walk(v, f"{path}.{k}" if path else f"$.{k}")
+    elif isinstance(value, list):
+        yield path or "$", value
+        for i, v in enumerate(value):
+            yield from _walk(v, f"{path}[{i}]")
+    else:
+        yield path or "$", value
+
+
+class TestEvalParametersShape:
+    """Regression coverage for the parameter-serialization bug that hid
+    the sandbox from the playground "+ Task → Remote eval" picker.
+
+    Background: a previous revision built `EVAL_PARAMETERS` with the
+    Braintrust SDK's typed constructors (PromptParameter / PromptData /
+    PromptChatBlock / PromptMessage) for static-type-check coverage.
+    Those dataclasses include Optional fields that default to `None`
+    (`tools`, `name`, `function_call`, `tool_calls`), and the SDK's
+    serializer emits them as JSON `null`. The Braintrust playground's
+    parameter validator silently rejects shapes containing those nulls —
+    the function still registers via the API, but it doesn't surface in
+    the playground task picker. We now use plain dict literals, which
+    omit unset keys entirely.
+
+    These tests lock both ends of the contract:
+      1. `test_no_null_anywhere` proves our dict has no null leaves at
+         any depth — catches anyone reverting to typed constructors or
+         introducing a `None` default in the dict.
+      2. `test_typed_constructors_still_emit_nulls` is documentary: it
+         shows what the SDK serializer produces for an unset
+         PromptMessage. If Braintrust ever fixes the serializer to omit
+         unset fields, this test fails — at which point we can
+         reconsider using the typed constructors for static type
+         coverage."""
+
+    def test_no_null_anywhere(self):
+        for path, value in _walk(evals.EVAL_PARAMETERS):
+            assert value is not None, (
+                f"EVAL_PARAMETERS contains None at {path}; the Braintrust "
+                f"playground will hide the sandbox from the '+ Task → "
+                f"Remote eval' picker. Omit the key entirely instead."
+            )
+
+    def test_top_level_has_both_prompt_params(self):
+        # Cheap sanity: if the dict gets refactored, make sure both
+        # prompts the PM iterates on are still wired through.
+        assert set(evals.EVAL_PARAMETERS) == {"search_prompt", "filter_prompt"}
+
+    def test_typed_constructors_still_emit_nulls(self):
+        """Documentary — locks in the SDK behavior we're working around.
+
+        If this test starts failing, the Braintrust SDK has changed how
+        it serializes Optional/None fields. At that point the typed
+        constructors might be safe to use again, and we should re-evaluate
+        whether to bring back the static-type coverage they provided."""
+        from dataclasses import asdict
+
+        from braintrust.prompt import PromptChatBlock, PromptMessage
+
+        block = PromptChatBlock(
+            messages=[PromptMessage(role="system", content="hello")],
+        )
+        serialized = asdict(block)
+
+        # The PromptMessage default-None fields all surface as keys with
+        # null values in the serialization — this is the shape that broke
+        # the playground.
+        msg = serialized["messages"][0]
+        assert "name" in msg and msg["name"] is None
+        assert "function_call" in msg and msg["function_call"] is None
+        assert "tool_calls" in msg and msg["tool_calls"] is None
+        # PromptChatBlock's own `tools` field too.
+        assert "tools" in serialized and serialized["tools"] is None

--- a/campaign_plan_lambda/tests/test_event_generator.py
+++ b/campaign_plan_lambda/tests/test_event_generator.py
@@ -1,19 +1,24 @@
 """Tests for event_generator — date validation and task construction."""
 
+from contextlib import contextmanager
 from datetime import date
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from campaign_plan_lambda.event_generator import (
+    CampaignContext,
     NOT_AVAILABLE,
     _build_prompt_variables,
     _filter_and_structure_events,
     _or_not_available,
+    _search_community_events,
     FILTER_PROMPT_FALLBACK,
     LlmEventResult,
     LlmEventResultList,
+    generate_event_tasks,
 )
+from shared.braintrust import NoOpSpan
 
 
 def _sample_vars(**overrides):
@@ -311,3 +316,123 @@ class TestPromptInjectionDefense:
         assert "&lt;office_name&gt;fake" in poisoned
         assert poisoned.count("<office_name>") == benign.count("<office_name>")
         assert poisoned.count("</office_name>") == benign.count("</office_name>")
+
+
+class TestRenderedPromptBoundary:
+    """The `rendered_prompt` kwarg on the search/filter helpers is for
+    eval/test use only. Two invariants protect prod:
+
+    1. When `rendered_prompt=` is passed, the helpers must use that exact
+       string and bypass `load_prompt_from_braintrust`.
+    2. The prod entry point (`generate_event_tasks` called from handler.py)
+       must not accept `rendered_prompt` as a keyword, so untrusted SQS
+       input cannot reach the bypass path even if a future refactor splats
+       extra fields into the call.
+    """
+
+    @pytest.mark.asyncio
+    async def test_search_uses_rendered_prompt_verbatim(self):
+        # When the eval supplies rendered_prompt, _search_community_events
+        # must send that exact string to Gemini without consulting Braintrust.
+        mock_client = Mock()
+        mock_response = Mock()
+        mock_response.text = "search results"
+        mock_client.generate_with_search.return_value = mock_response
+
+        result = await _search_community_events(
+            mock_client,
+            _sample_vars(),
+            rendered_prompt="EXACT-SEARCH-PROMPT",
+        )
+
+        assert result == "search results"
+        mock_client.generate_with_search.assert_called_once_with("EXACT-SEARCH-PROMPT")
+
+    @pytest.mark.asyncio
+    async def test_filter_uses_rendered_prompt_verbatim(self):
+        mock_client = Mock()
+        mock_client.generate_structured_content.return_value = LlmEventResultList(
+            events=[]
+        )
+
+        await _filter_and_structure_events(
+            mock_client,
+            _sample_vars(),
+            date(2026, 11, 4),
+            date(2026, 1, 1),
+            "raw events text",
+            rendered_prompt="EXACT-FILTER-PROMPT",
+        )
+
+        # Gemini receives the supplied prompt unchanged.
+        kwargs = mock_client.generate_structured_content.call_args.kwargs
+        assert kwargs["prompt"] == "EXACT-FILTER-PROMPT"
+
+    def test_generate_event_tasks_rejects_rendered_prompt_kwarg(self):
+        # The public entry point used by handler.py must not accept the
+        # bypass kwarg — guards against accidental plumbing of untrusted
+        # SQS-supplied fields into the inner helpers.
+        import inspect
+
+        sig = inspect.signature(generate_event_tasks)
+        assert "rendered_prompt" not in sig.parameters, (
+            "generate_event_tasks must not accept rendered_prompt — that "
+            "kwarg is eval-only and reaching it from SQS would let untrusted "
+            "input replace the Braintrust-loaded prompt."
+        )
+
+
+class TestParentSpanMetadata:
+    """Locks in the contract that `generate_event_tasks` plumbs the active
+    LLM client's model and the current ENVIRONMENT into the parent span's
+    metadata. The Logs UI uses these to filter rows — if a future refactor
+    accidentally drops either field, every `trace_pipeline`-level test still
+    passes but the Logs filter goes silently empty."""
+
+    @pytest.mark.asyncio
+    async def test_model_and_environment_passed_to_trace_pipeline(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "DEV")
+        captured = {}
+
+        @contextmanager
+        def fake_trace_pipeline(name, metadata=None):
+            captured["name"] = name
+            captured["metadata"] = metadata
+            yield NoOpSpan()
+
+        # Patch where event_generator imported it from.
+        monkeypatch.setattr(
+            "campaign_plan_lambda.event_generator.trace_pipeline",
+            fake_trace_pipeline,
+        )
+        # Skip real LLM work — we're testing the call-site plumbing only.
+        monkeypatch.setattr(
+            "campaign_plan_lambda.event_generator._search_community_events",
+            AsyncMock(return_value="raw events"),
+        )
+        monkeypatch.setattr(
+            "campaign_plan_lambda.event_generator._filter_and_structure_events",
+            AsyncMock(return_value=[]),
+        )
+
+        fake_client = Mock()
+        fake_client.default_model = Mock(value="gemini-3-flash-preview")
+        fake_client.get_usage_stats.return_value = {
+            "api_calls": 2, "total_cost": 0.01,
+        }
+
+        ctx = CampaignContext(
+            electionDate="2026-11-04",
+            state="MA",
+            city="Boston",
+            officeName="Mayor",
+            officeLevel="LOCAL",
+            primaryElectionDate=None,
+        )
+        await generate_event_tasks(ctx, llm_client=fake_client)
+
+        assert captured["name"] == "generate_event_tasks"
+        assert captured["metadata"] == {
+            "model": "gemini-3-flash-preview",
+            "environment": "DEV",
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "boto3>=1.40.50",
     "spacy>=3.8.7",
     "pillow>=10.0.0",
-    "braintrust>=0.3.10",
+    "braintrust>=0.12.1",
     "claude-agent-sdk>=0.1.19",
     "slack-sdk>=3.39.0",
     "sqlglot>=30.4.3",
@@ -98,6 +98,7 @@ asyncio_mode = "auto"
 
 [dependency-groups]
 dev = [
+    "braintrust[cli]>=0.12.1",
     "pre-commit>=4.3.0",
     "pytest>=8.4.2",
     "pytest-asyncio>=0.24.0",
@@ -107,5 +108,9 @@ dev = [
 ]
 campaign-plan-lambda = [
     "google-genai>=1.56.0",
-    "braintrust>=0.3.10",
+    "braintrust>=0.12.1",
+    # Used by shared/braintrust.py for local dev .env loading; was a
+    # transitive of braintrust<0.12 and stopped being one after the 0.16
+    # bump, so we now declare it explicitly.
+    "python-dotenv>=1.1.1",
 ]

--- a/shared/braintrust.py
+++ b/shared/braintrust.py
@@ -4,7 +4,7 @@ import os
 import re
 import threading
 from contextlib import contextmanager
-from typing import Optional, Dict, Any, Callable, TypeVar
+from typing import Optional, Dict, Any, Callable, Iterator, TypeVar
 
 from dotenv import load_dotenv
 from shared.logger import get_logger
@@ -14,6 +14,42 @@ load_dotenv()
 logger = get_logger(__name__)
 
 T = TypeVar('T')
+
+
+def flatten_prompt_messages(rendered: Any) -> str:
+    """Collapse a Braintrust `prompt.build()` result into a single string.
+    Handles three shapes: a plain string, a dict with `messages`, or any
+    object exposing a `.messages` attribute. Returns "" for a recognized
+    but empty messages container (e.g. PM cleared the prompt textarea —
+    we'd rather send nothing to the LLM and fail loudly than ship a dict
+    repr as the prompt). Falls back to `str(rendered)` only when the input
+    has no recognizable shape at all."""
+    if isinstance(rendered, str):
+        return rendered
+
+    has_messages_shape = (
+        isinstance(rendered, dict) and "messages" in rendered
+    ) or (
+        not isinstance(rendered, dict) and hasattr(rendered, "messages")
+    )
+    if not has_messages_shape:
+        return str(rendered)
+
+    if isinstance(rendered, dict):
+        msgs = rendered.get("messages") or []
+    else:
+        msgs = rendered.messages or []
+
+    contents = []
+    for msg in msgs:
+        if isinstance(msg, dict):
+            contents.append(msg.get("content", "") or "")
+        elif hasattr(msg, "content"):
+            contents.append(str(msg.content) if msg.content else "")
+        else:
+            contents.append(str(msg))
+    return "\n".join(c for c in contents if c)
+
 
 
 class NoOpSpan:
@@ -125,8 +161,10 @@ class BraintrustClient:
         if not self._enabled or self._braintrust_logger is None:
             return llm_call_fn()
 
+        # `type="llm"` lets Braintrust's Logs UI group these under a parent
+        # task span instead of treating each call as a top-level row.
         try:
-            span = self._braintrust_logger.start_span(name=name)
+            span = self._braintrust_logger.start_span(name=name, type="llm")
             span.__enter__()
         except Exception as e:
             logger.warning(f"Braintrust span creation failed: {e}")
@@ -173,13 +211,25 @@ class BraintrustClient:
         input_data: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         tags: Optional[list] = None,
+        span_type: Optional[str] = None,
     ):
+        """Open a Braintrust span as a context manager.
+
+        `span_type` categorizes the span for Braintrust's UI: `task`
+        parents surface as list-level rows, `llm` children nest under
+        them and feed into per-call rollups (token counts, cost,
+        latency). Omit to let the SDK pick its default. (Named
+        `span_type` rather than `type` to avoid shadowing the builtin.)
+        """
         if not self._enabled or self._braintrust_logger is None:
             yield NoOpSpan()
             return
 
+        span_kwargs: Dict[str, Any] = {"name": name}
+        if span_type is not None:
+            span_kwargs["type"] = span_type
         try:
-            span = self._braintrust_logger.start_span(name=name)
+            span = self._braintrust_logger.start_span(**span_kwargs)
             span.__enter__()
         except Exception as e:
             logger.warning(f"Braintrust traced_span failed: {e}")
@@ -201,11 +251,17 @@ class BraintrustClient:
 
         try:
             yield span
-        finally:
+        except Exception as e:
+            try:
+                span.__exit__(type(e), e, e.__traceback__)
+            except Exception as exit_err:
+                logger.debug(f"Braintrust traced_span exit (error path) failed: {exit_err}")
+            raise
+        else:
             try:
                 span.__exit__(None, None, None)
             except Exception as exit_err:
-                logger.debug(f"Braintrust traced_span exit failed: {exit_err}")
+                logger.debug(f"Braintrust traced_span exit (success path) failed: {exit_err}")
 
     def _serialize_output(self, result: Any) -> Dict[str, Any]:
         if result is None:
@@ -232,15 +288,14 @@ class BraintrustClient:
         self,
         prompt_name: str,
         fallback_prompt: str,
-        variables: Optional[Dict[str, Any]] = None
+        variables: Optional[Dict[str, Any]] = None,
     ) -> str:
         if not self._enabled or self._braintrust_module is None:
             return self._render_prompt(fallback_prompt, variables)
 
         try:
             prompt = self._braintrust_module.load_prompt(
-                project=self._project,
-                slug=prompt_name
+                project=self._project, slug=prompt_name
             )
 
             if prompt is None:
@@ -248,22 +303,7 @@ class BraintrustClient:
                 return self._render_prompt(fallback_prompt, variables)
 
             rendered = prompt.build(**(variables or {}))
-
-            if isinstance(rendered, str):
-                return rendered
-
-            if hasattr(rendered, 'messages') and rendered.messages:
-                contents = []
-                for msg in rendered.messages:
-                    if isinstance(msg, dict):
-                        contents.append(msg.get('content', ''))
-                    elif hasattr(msg, 'content'):
-                        contents.append(str(msg.content))
-                    else:
-                        contents.append(str(msg))
-                return "\n".join(contents)
-
-            return str(rendered)
+            return flatten_prompt_messages(rendered)
 
         except Exception as e:
             logger.warning(f"Failed to load prompt '{prompt_name}' from Braintrust: {e}")
@@ -404,9 +444,11 @@ def traced_llm_call(
 def load_prompt_from_braintrust(
     prompt_name: str,
     fallback_prompt: str,
-    variables: Optional[Dict[str, Any]] = None
+    variables: Optional[Dict[str, Any]] = None,
 ) -> str:
-    return BraintrustClient.get_instance().load_prompt(prompt_name, fallback_prompt, variables)
+    return BraintrustClient.get_instance().load_prompt(
+        prompt_name, fallback_prompt, variables
+    )
 
 
 def flush_logs() -> None:
@@ -419,6 +461,22 @@ def is_enabled() -> bool:
 
 def get_client() -> BraintrustClient:
     return BraintrustClient.get_instance()
+
+
+@contextmanager
+def trace_pipeline(
+    name: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Iterator[Any]:
+    """Open a parent Braintrust span tagged `type="task"` so Braintrust's
+    Logs UI groups the LLM children under it instead of showing each one
+    as its own top-level row. Inner traced LLM calls automatically nest
+    via Braintrust's contextvar-based propagation. Yields a no-op span
+    when Braintrust is disabled (e.g. no API key in tests)."""
+    with BraintrustClient.get_instance().traced_span(
+        name, span_type="task", metadata=metadata
+    ) as span:
+        yield span
 
 
 def cache_prompt(

--- a/shared/tests/test_braintrust.py
+++ b/shared/tests/test_braintrust.py
@@ -6,12 +6,14 @@ from unittest.mock import MagicMock, patch, call
 from shared.braintrust import (
     BraintrustClient,
     NoOpSpan,
+    flatten_prompt_messages,
     init_braintrust,
     traced_llm_call,
     load_prompt_from_braintrust,
     flush_logs,
     is_enabled,
     get_client,
+    trace_pipeline,
 )
 
 
@@ -51,8 +53,9 @@ class FakeBraintrustLogger:
         self.spans: list[FakeSpan] = []
         self.flush_count = 0
 
-    def start_span(self, name):
+    def start_span(self, name, type=None):
         span = FakeSpan(name)
+        span.type = type
         self.spans.append(span)
         return span
 
@@ -806,3 +809,121 @@ class TestTracedCallExecutesInsideSpan:
 
             assert result == "ok"
             assert exit_calls == [(None, None, None)]
+
+
+def _enabled_client(monkeypatch):
+    """Return (BraintrustClient, FakeBraintrustModule) wired together so
+    `is_enabled()` returns True and span calls go to the fake logger."""
+    monkeypatch.setenv("BRAINTRUST_API_KEY", "test-key")
+    fake_module = FakeBraintrustModule()
+    with patch.dict("sys.modules", {"braintrust": fake_module}):
+        BraintrustClient.reset_instance()
+        init_braintrust(project="test")
+    return get_client(), fake_module
+
+
+class TestTracedCallSpanType:
+    """`traced_call` opens its span with `type="llm"` so Braintrust's Logs
+    UI groups LLM calls under the parent task span instead of treating each
+    one as a top-level row."""
+
+    def test_traced_call_uses_llm_span_type(self, monkeypatch):
+        client, fake_module = _enabled_client(monkeypatch)
+
+        client.traced_call(
+            name="test-call",
+            input_data={"q": "hello"},
+            llm_call_fn=lambda: "answer",
+        )
+
+        span = fake_module.logger.span_named("test-call")
+        assert span.type == "llm"
+
+
+class TestTracePipeline:
+    """`trace_pipeline` opens a parent span tagged `type="task"` so the
+    Logs UI groups inner LLM spans underneath it."""
+
+    def test_yields_noop_span_when_disabled(self, no_api_key):
+        with trace_pipeline("generate_event_tasks") as span:
+            assert isinstance(span, NoOpSpan)
+            # Body still runs, log calls are accepted as no-ops.
+            span.log(input={"city": "Boston"})
+
+    def test_opens_real_span_with_task_type(self, monkeypatch):
+        client, fake_module = _enabled_client(monkeypatch)
+
+        with trace_pipeline("generate_event_tasks") as span:
+            span.log(input={"city": "Boston"})
+            span.log(output={"tasks": []})
+
+        real = fake_module.logger.span_named("generate_event_tasks")
+        assert real.type == "task"
+        assert real.inputs == [{"city": "Boston"}]
+        assert real.outputs == [{"tasks": []}]
+        assert real.exit_count == 1
+
+    def test_caller_metadata_passed_through(self, monkeypatch):
+        # `trace_pipeline` is intentionally a thin wrapper — it forwards
+        # whatever metadata the caller supplies (no env-reading or other
+        # magic from inside shared library code).
+        client, fake_module = _enabled_client(monkeypatch)
+
+        with trace_pipeline(
+            "generate_event_tasks",
+            metadata={"environment": "DEV", "model": "gemini-3-flash-preview"},
+        ):
+            pass
+
+        real = fake_module.logger.span_named("generate_event_tasks")
+        assert real.metadatas == [
+            {"environment": "DEV", "model": "gemini-3-flash-preview"}
+        ]
+
+    def test_no_metadata_is_fine(self, monkeypatch):
+        client, fake_module = _enabled_client(monkeypatch)
+
+        with trace_pipeline("generate_event_tasks"):
+            pass
+
+        real = fake_module.logger.span_named("generate_event_tasks")
+        # No metadata supplied → no metadata logged.
+        assert real.metadatas == []
+
+
+class TestFlattenPromptMessages:
+    def test_string_input_returned_unchanged(self):
+        assert flatten_prompt_messages("hello world") == "hello world"
+
+    def test_dict_with_messages(self):
+        built = {"messages": [{"role": "system", "content": "hi"}]}
+        assert flatten_prompt_messages(built) == "hi"
+
+    def test_object_with_messages_attribute(self):
+        msg = MagicMock(content="from attr")
+        rendered = MagicMock(messages=[msg])
+        assert flatten_prompt_messages(rendered) == "from attr"
+
+    def test_multiple_messages_joined_with_newline(self):
+        built = {
+            "messages": [
+                {"role": "system", "content": "first"},
+                {"role": "user", "content": "second"},
+            ]
+        }
+        assert flatten_prompt_messages(built) == "first\nsecond"
+
+    def test_empty_messages_returns_empty_string(self):
+        # PM clearing the prompt textarea results in an empty messages
+        # list. We'd rather send "" to the LLM (and fail loudly) than ship
+        # the dict repr as the prompt.
+        assert flatten_prompt_messages({"messages": []}) == ""
+
+    def test_messages_key_present_but_none_returns_empty_string(self):
+        assert flatten_prompt_messages({"messages": None}) == ""
+
+    def test_no_messages_attribute_falls_back_to_str(self):
+        # Genuinely-unrecognized shape — last-resort str() is preserved
+        # so debugging traces stay informative instead of going silent.
+        rendered = object()
+        assert flatten_prompt_messages(rendered) == str(rendered)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -243,13 +243,14 @@ wheels = [
 
 [[package]]
 name = "braintrust"
-version = "0.3.14"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "chevron" },
     { name = "exceptiongroup" },
     { name = "gitpython" },
-    { name = "python-dotenv" },
+    { name = "jsonschema" },
+    { name = "packaging" },
     { name = "python-slugify" },
     { name = "requests" },
     { name = "sseclient-py" },
@@ -257,9 +258,18 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/77/ed9169d589909aa50b347908c5022e472242151aab6728062eee647ba2f8/braintrust-0.3.14.tar.gz", hash = "sha256:e3aed27a78309e4ba7c32c76c840839c0ec428c17d9beee3d93a0149d2727fb0", size = 249719, upload-time = "2025-12-18T21:27:01.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/20/f57a1035a129eabb756827378fd71056c07e72ac24b164e886e0d99dc21f/braintrust-0.17.0.tar.gz", hash = "sha256:49631b1185d7edd646639d0ba5443e56c1371b085873cbddcd2e9a45dfe4a62b", size = 569862, upload-time = "2026-04-27T18:24:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/c1/047c543849725d3ca96b32e73132b0d09636012b26f99b0c23456f4938ea/braintrust-0.3.14-py3-none-any.whl", hash = "sha256:bc168f6300a4ee4e98144d11a853ce56495b515e1616194d885e23c61a41998d", size = 295306, upload-time = "2025-12-18T21:26:59.992Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/6d/8a71d190fcc7665e12172224f4d7d7b368c94a13a94d74ebf228efd1f1b2/braintrust-0.17.0-py3-none-any.whl", hash = "sha256:6bf0411a507a87b331742018b840e8d89b0d4373047f74e5ca6423084d9c1577", size = 663505, upload-time = "2026-04-27T18:24:16.004Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "boto3" },
+    { name = "python-dotenv" },
+    { name = "starlette" },
+    { name = "uv" },
+    { name = "uvicorn" },
 ]
 
 [[package]]
@@ -1229,8 +1239,10 @@ dev = [
 campaign-plan-lambda = [
     { name = "braintrust" },
     { name = "google-genai" },
+    { name = "python-dotenv" },
 ]
 dev = [
+    { name = "braintrust", extra = ["cli"] },
     { name = "jsonschema" },
     { name = "moto", extra = ["s3"] },
     { name = "pre-commit" },
@@ -1243,7 +1255,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.11" },
     { name = "boto3", specifier = ">=1.40.50" },
-    { name = "braintrust", specifier = ">=0.3.10" },
+    { name = "braintrust", specifier = ">=0.12.1" },
     { name = "claude-agent-sdk", specifier = ">=0.1.19" },
     { name = "databricks-sql-connector", specifier = ">=4.0.5" },
     { name = "faiss-cpu", specifier = ">=1.12.0" },
@@ -1288,10 +1300,12 @@ provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 campaign-plan-lambda = [
-    { name = "braintrust", specifier = ">=0.3.10" },
+    { name = "braintrust", specifier = ">=0.12.1" },
     { name = "google-genai", specifier = ">=1.56.0" },
+    { name = "python-dotenv", specifier = ">=1.1.1" },
 ]
 dev = [
+    { name = "braintrust", extras = ["cli"], specifier = ">=0.12.1" },
     { name = "jsonschema", specifier = ">=4.20.0" },
     { name = "moto", extras = ["s3", "sqs"], specifier = ">=5.0.0" },
     { name = "pre-commit", specifier = ">=4.3.0" },
@@ -1347,7 +1361,7 @@ dependencies = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.50" },
     { name = "faiss-cpu", specifier = ">=1.12.0" },
-    { name = "gp-shared", virtual = "shared" },
+    { name = "gp-shared", editable = "shared" },
     { name = "pyarrow", specifier = ">=21.0.0" },
 ]
 
@@ -1365,7 +1379,7 @@ dependencies = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.50" },
     { name = "claude-agent-sdk", specifier = ">=0.1.19" },
-    { name = "gp-shared", virtual = "shared" },
+    { name = "gp-shared", editable = "shared" },
 ]
 
 [[package]]
@@ -1392,7 +1406,7 @@ requires-dist = [
     { name = "claude-agent-sdk", specifier = ">=0.1.19" },
     { name = "fastapi", specifier = ">=0.116.0" },
     { name = "fpdf2", specifier = ">=2.8.7" },
-    { name = "gp-shared", virtual = "shared" },
+    { name = "gp-shared", editable = "shared" },
     { name = "kmapper", specifier = ">=2.0.0" },
     { name = "networkx", specifier = ">=3.0" },
     { name = "qrcode", specifier = ">=8.2" },
@@ -1404,7 +1418,7 @@ requires-dist = [
 [[package]]
 name = "gp-shared"
 version = "0.1.0"
-source = { virtual = "shared" }
+source = { editable = "shared" }
 dependencies = [
     { name = "braintrust" },
     { name = "databricks-sql-connector" },
@@ -1463,7 +1477,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.40.50" },
-    { name = "gp-shared", virtual = "shared" },
+    { name = "gp-shared", editable = "shared" },
     { name = "matplotlib", specifier = ">=3.10.0" },
     { name = "plotly", specifier = ">=5.27.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
@@ -4301,6 +4315,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "uv"
+version = "0.11.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/cd/4393fecb083897e956f016d4e66d0b8a496a08fe2e03cbda32a1e91da7ee/uv-0.11.8.tar.gz", hash = "sha256:bb2cf302b8503629aab6f0090a05551e6f8cfc2d687ca059cad7ec9e11214335", size = 4098020, upload-time = "2026-04-27T13:15:31.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/84/dcb676a3e36a3a2b44dc2e4dfea471b8cd709025e27cce3e588b176fd899/uv-0.11.8-py3-none-linux_armv6l.whl", hash = "sha256:a53e704a780a9e78a50f5a880e99a690f84e6fb9e82610903ce26f47c271d74c", size = 23664296, upload-time = "2026-04-27T13:15:15.644Z" },
+    { url = "https://files.pythonhosted.org/packages/86/05/557aa070fda7b8460bbbe1e867e8e5b80602c5b30ed77d1d94fc5acae518/uv-0.11.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d414fc3795b6f56fb6b1fa359537930924fdfe857750a144d2aedf3077be3f1d", size = 23087321, upload-time = "2026-04-27T13:15:36.193Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/62/82953018801a250e16b091ef4b5e95e939b2f01224363d6fc80f600b7eff/uv-0.11.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f0d402e182ab581e934c159cc9edf25ec6e08d32f29aa797980e949afefc87cd", size = 21747142, upload-time = "2026-04-27T13:15:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4c/477f2abe16f9a3d3c73077f15615878a303eef3760115ec946be58ecb9b2/uv-0.11.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:877c9af3b3955a35ef739e5b2ba79c56dae5c4d50420a7ed908c0901e1c8c807", size = 23425861, upload-time = "2026-04-27T13:15:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/63/19f46193e49f0c9bf33346a4d726313871864db16e7cdd1c0a63bc112000/uv-0.11.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:8278144df8d80a83f770c264a5e79ea50791316d2a0dda869e53b3c1174142a8", size = 23215551, upload-time = "2026-04-27T13:15:38.706Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3e/5595b265df848a33cd060b10e8f763a46d67521ac9f6c314e8a4ad5329d7/uv-0.11.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3494ad32465f4e02259cfb104d24efe5bb8f7a782351f0354de9385415fb310", size = 23224170, upload-time = "2026-04-27T13:15:18.083Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b3/6ca95e690b52542caa1dae10ede57732f90c629946ab5f027ff746f87deb/uv-0.11.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4421e27e81f85bce3bdb75986c38b5f9bfab9cdccaf3d977cf124b3f0f0b989", size = 24730048, upload-time = "2026-04-27T13:15:13.254Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/49/71b7322067c85a3736a22a300072b0566991fe3f95b81bed793508ff5315/uv-0.11.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91943e77fc962752d4f64ad5739219858395981078051c740b28b52963b366aa", size = 25585906, upload-time = "2026-04-27T13:15:41.455Z" },
+    { url = "https://files.pythonhosted.org/packages/37/16/4e84cd5131327fe86d4784ebfc8a983149f4e6b811476ef271fc548b29e6/uv-0.11.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:41fbba287efcc9bc9505a60549b3a223220da720eacd03be8c23d9daaafa44f4", size = 24795740, upload-time = "2026-04-27T13:15:49.842Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/01/df175979018743cc5ba6e2fb9dcec916868271e8d88cf0b9df8fd805a0df/uv-0.11.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d97bb2920d6cddc07faa475013461294cc09b77ec8139278416c6e54b938d037", size = 24824980, upload-time = "2026-04-27T13:15:53.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/95/93c7f595f7136fb32807442860c55d0faed2cd3d7da4b7105ed3c2535d5f/uv-0.11.8-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:fb6a755305eb1e081dfe6a8bc007dbae2d26fe75e551656ca7c9cd08fba21d26", size = 23526790, upload-time = "2026-04-27T13:15:04.955Z" },
+    { url = "https://files.pythonhosted.org/packages/04/02/77430b89e172c20cc549b07a5b1dfda0c882c161b6d82781d3150a7063ac/uv-0.11.8-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:841ecbb38532698f73b14b49dc5f0c5e756194c7fcf6e5c6b7ed3859200fe91b", size = 24280498, upload-time = "2026-04-27T13:15:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e3/23e4a2bb91e3880e017e6116886e2d0bde14ba6aa95ddc458160ee630e7c/uv-0.11.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b3ff2b20c1897105ebe7ed7f9b1b331c7171da029bc1e35970ce31dc086141c1", size = 24375233, upload-time = "2026-04-27T13:15:25.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/67/fb7dc17cea816a667d1be2632525aa1687566bfafd17bdac561a7a6c9484/uv-0.11.8-py3-none-musllinux_1_1_i686.whl", hash = "sha256:ad381228b0170ef9646902c7e908d4a10a7ecc3da8139450506cf70c7e7f3e80", size = 23904818, upload-time = "2026-04-27T13:15:23.21Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/91/b920e35f54f8c6b51f2c639e8170bb80a47a739a1442fea33a479bc93a3d/uv-0.11.8-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:0172b5215544844cd3db0fa3c73a2eb74999b3f00cd2527dde578725076d7b65", size = 25015448, upload-time = "2026-04-27T13:15:46.666Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e8/3771956dc1c94b8484789bb8070d91872080d0af99332b8bdec7218c2bfd/uv-0.11.8-py3-none-win32.whl", hash = "sha256:e71c1dd23cbb480f3952c3a95b4fd00f96bd618e2a94583fc9388c500af3070d", size = 22823583, upload-time = "2026-04-27T13:15:33.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/9b/a91a9c60dcae0e1e3da06377d38f32118a523697d461fe41bc9f117ecf59/uv-0.11.8-py3-none-win_amd64.whl", hash = "sha256:306c624c68d95dd7ea3647675323d72c1abc25f91c3e92ae4cd6f0f11b508726", size = 25407438, upload-time = "2026-04-27T13:15:28.957Z" },
+    { url = "https://files.pythonhosted.org/packages/61/5d/defa29fe617e6f07d4e514089e9d36fd9f44ede869e597e39ff7d69f6917/uv-0.11.8-py3-none-win_arm64.whl", hash = "sha256:a9853456696d579f206135c9dda7227a6ed8311b8a9a0b9b2008c4ae81950efe", size = 23914243, upload-time = "2026-04-27T13:15:07.717Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the event-generation pipeline entry point and Braintrust logging/tracing behavior, which could affect production prompt loading and observability if miswired. Changes are largely additive with tests guarding the eval-only prompt bypass and new tracing metadata.
> 
> **Overview**
> Adds a Braintrust *sandbox eval* (`campaign_plan_lambda/evals.py`) to run the campaign-plan pipeline end-to-end from the Braintrust Playground with PM-editable `search_prompt`/`filter_prompt` parameters and built-in scoring (`count_in_range`, `dates_in_range`, `urls_valid`, `title_overlap`). Includes `push_eval.sh` plus `evals.requirements.txt` to bundle and upload the eval to Braintrust’s hosted runtime, and updates docs with the PM/engineer workflows and trace-reading guidance.
> 
> Enhances observability by introducing `trace_pipeline()` and span typing (`type="task"` parents, `type="llm"` children) and making prompt rendering more robust via `flatten_prompt_messages()`. Refactors `generate_event_tasks` to accept a `CampaignContext`, logs top-level pipeline input/output to Braintrust, and adds eval/test-only `rendered_prompt` overrides in the internal search/filter helpers (with tests to ensure prod cannot pass untrusted prompts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b9e6ca80da934cc3860f1128fd786a8633953d2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->