### PR TITLE
feat(broker): proxy /agent/mcp with per-call Clerk session impersonation

### DIFF
--- a/broker/clerk_client.py
+++ b/broker/clerk_client.py
@@ -1,0 +1,140 @@
+import asyncio
+import base64
+import json
+import time
+from typing import TypedDict
+
+import httpx
+
+
+class ClerkSessionInfo(TypedDict):
+    session_id: str
+
+
+class ClerkClientError(Exception):
+    pass
+
+
+class ClerkClient:
+    def __init__(
+        self,
+        secret_key: str,
+        frontend_api_base: str,
+        agent_fleet_clerk_id: str,
+    ):
+        self._secret_key = secret_key
+        self._frontend_api_base = frontend_api_base.rstrip("/")
+        self._agent_fleet_clerk_id = agent_fleet_clerk_id
+        self._http = httpx.AsyncClient(timeout=15)
+        self._backend = httpx.AsyncClient(
+            base_url="https://api.clerk.com",
+            headers={"Authorization": f"Bearer {secret_key}"},
+            timeout=15,
+        )
+        self._jwt_cache: dict[str, tuple[str, int]] = {}
+        self._cache_lock = asyncio.Lock()
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
+        await self._backend.aclose()
+
+    async def create_actor_token(
+        self, user_id: str, expires_in_seconds: int = 600
+    ) -> dict:
+        """POST /v1/actor_tokens — mints a one-shot sign-in URL stamped with the
+        agent fleet as actor. The broker redeems this URL immediately afterward
+        via redeem_actor_token() to produce a real Clerk session."""
+        resp = await self._backend.post(
+            "/v1/actor_tokens",
+            json={
+                "user_id": user_id,
+                "actor": {"sub": self._agent_fleet_clerk_id},
+                "expires_in_seconds": expires_in_seconds,
+            },
+        )
+        if resp.status_code >= 400:
+            raise ClerkClientError(
+                f"actor token creation failed "
+                f"status={resp.status_code} body={resp.text[:500]}"
+            )
+        body = resp.json()
+        url = body.get("url")
+        if not url:
+            raise ClerkClientError(
+                f"actor token creation response missing 'url'; keys={list(body.keys())}"
+            )
+        return body
+
+    async def redeem_actor_token(self, actor_token_url: str) -> ClerkSessionInfo:
+        # The actor_token_url comes back from clerkClient.actorTokens.create,
+        # in the form https://<frontend-api>/v1/client/sign_in_tokens/<id>?token=<jwt>.
+        # Hitting it (POST, no body) creates a Client + Session and returns both;
+        # we only need the session id (we mint fresh JWTs per call via Backend API).
+        if not actor_token_url.startswith(f"{self._frontend_api_base}/"):
+            raise ClerkClientError(
+                f"actor token URL is not from the configured Clerk frontend API base "
+                f"(base={self._frontend_api_base}, got={actor_token_url[:64]}...)"
+            )
+        resp = await self._http.post(actor_token_url)
+        if resp.status_code >= 400:
+            raise ClerkClientError(
+                f"actor token redemption failed status={resp.status_code} body={resp.text[:500]}"
+            )
+        body = resp.json()
+        # The Clerk Frontend API response shape varies a bit across versions.
+        # Try the common keys; fail loudly if neither is present.
+        session_id = (
+            body.get("response", {}).get("created_session_id")
+            or body.get("client", {}).get("last_active_session_id")
+        )
+        if not session_id:
+            raise ClerkClientError(
+                f"actor token redemption response missing session id; keys={list(body.keys())}"
+            )
+        return {"session_id": session_id}
+
+    async def mint_session_jwt(
+        self, session_id: str, template: str = "agent-mcp"
+    ) -> str:
+        resp = await self._backend.post(
+            f"/v1/sessions/{session_id}/tokens",
+            json={"template": template},
+        )
+        if resp.status_code >= 400:
+            raise ClerkClientError(
+                f"session JWT mint failed status={resp.status_code} body={resp.text[:500]}"
+            )
+        jwt_value = resp.json().get("jwt")
+        if not jwt_value:
+            raise ClerkClientError("session JWT mint response missing 'jwt'")
+        return jwt_value
+
+    async def get_session_jwt(self, session_id: str) -> str:
+        """Cached: returns a JWT for the session, minting if absent or near expiry.
+        One Clerk mint per session per ~4.5 minutes regardless of request volume."""
+        now = int(time.time())
+        cached = self._jwt_cache.get(session_id)
+        if cached and cached[1] - now > 5:
+            return cached[0]
+        async with self._cache_lock:
+            cached = self._jwt_cache.get(session_id)
+            if cached and cached[1] - now > 5:
+                return cached[0]
+            jwt_value = await self.mint_session_jwt(session_id)
+            exp = self._extract_exp(jwt_value)
+            self._jwt_cache[session_id] = (jwt_value, exp)
+            return jwt_value
+
+    @staticmethod
+    def _extract_exp(jwt_value: str) -> int:
+        """Read the exp claim from a JWT without verifying (we just minted it,
+        don't need to re-verify our own credential)."""
+        parts = jwt_value.split(".")
+        if len(parts) != 3:
+            raise ClerkClientError("invalid JWT structure")
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        exp = payload.get("exp")
+        if not isinstance(exp, int):
+            raise ClerkClientError("JWT missing or non-numeric exp claim")
+        return exp

--- a/broker/dynamodb_client.py
+++ b/broker/dynamodb_client.py
@@ -28,6 +28,7 @@ class ScopeTicket(BaseModel):
     issued_at: int
     issued_by: str
     prior_artifact_versions: dict[str, str] | None = None
+    clerk_session_id: str | None = None
 
 
 class ScopeTicketStore:
@@ -49,6 +50,8 @@ class ScopeTicketStore:
         }
         if ticket.prior_artifact_versions is not None:
             item["prior_artifact_versions"] = {"S": json.dumps(ticket.prior_artifact_versions)}
+        if ticket.clerk_session_id is not None:
+            item["clerk_session_id"] = {"S": ticket.clerk_session_id}
 
         run_lock_item = {
             "pk": {"S": _run_lock_pk(ticket.run_id)},
@@ -106,6 +109,10 @@ class ScopeTicketStore:
         if "prior_artifact_versions" in item:
             prior = json.loads(item["prior_artifact_versions"]["S"])
 
+        clerk_session_id = None
+        if "clerk_session_id" in item:
+            clerk_session_id = item["clerk_session_id"]["S"]
+
         return ScopeTicket(
             pk=item["pk"]["S"],
             run_id=item["run_id"]["S"],
@@ -117,6 +124,7 @@ class ScopeTicketStore:
             issued_at=int(item["issued_at"]["N"]),
             issued_by=item["issued_by"]["S"],
             prior_artifact_versions=prior,
+            clerk_session_id=clerk_session_id,
         )
 
     def delete_ticket(self, broker_token: str) -> None:

--- a/broker/endpoints/agent_mcp_proxy.py
+++ b/broker/endpoints/agent_mcp_proxy.py
@@ -1,0 +1,69 @@
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+
+from broker.clerk_client import ClerkClient, ClerkClientError
+from broker.dynamodb_client import ScopeTicket
+
+router = APIRouter(prefix="/agent/mcp", tags=["agent_mcp"])
+
+
+def get_scope_ticket() -> ScopeTicket:  # pragma: no cover
+    raise NotImplementedError("Must be overridden via dependency_overrides")
+
+
+def get_clerk_client() -> ClerkClient:  # pragma: no cover
+    raise NotImplementedError("Must be overridden via dependency_overrides")
+
+
+def get_gp_api_base_url() -> str:  # pragma: no cover
+    raise NotImplementedError("Must be overridden via dependency_overrides")
+
+
+def get_http_client() -> httpx.AsyncClient:  # pragma: no cover
+    raise NotImplementedError("Must be overridden via dependency_overrides")
+
+
+@router.api_route(
+    "",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+    include_in_schema=False,
+)
+async def proxy_mcp_root(
+    request: Request,
+    ticket: ScopeTicket = Depends(get_scope_ticket),
+    clerk: ClerkClient = Depends(get_clerk_client),
+    base_url: str = Depends(get_gp_api_base_url),
+    http: httpx.AsyncClient = Depends(get_http_client),
+):
+    if not ticket.clerk_session_id:
+        raise HTTPException(
+            status_code=500,
+            detail={"reason": "ticket_missing_clerk_session_id"},
+        )
+
+    try:
+        jwt = await clerk.get_session_jwt(ticket.clerk_session_id)
+    except ClerkClientError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail={"reason": "clerk_session_jwt_mint_failed", "err": str(exc)},
+        )
+
+    body = await request.body()
+    upstream = await http.request(
+        method=request.method,
+        url=f"{base_url.rstrip('/')}/agent/mcp",
+        content=body,
+        headers={
+            "Content-Type": request.headers.get("content-type", "application/json"),
+            "Authorization": f"Bearer {jwt}",
+            "X-Organization-Slug": ticket.organization_slug,
+        },
+    )
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers={
+            "content-type": upstream.headers.get("content-type", "application/json")
+        },
+    )

--- a/broker/endpoints/mint_run_token.py
+++ b/broker/endpoints/mint_run_token.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from broker.auth import get_service_token, verify_service_token
+from broker.clerk_client import ClerkClient, ClerkClientError
 from broker.dynamodb_client import (
     ScopeTicket,
     ScopeTicketStore,
@@ -13,7 +14,10 @@ from broker.dynamodb_client import (
 
 router = APIRouter(prefix="/internal", tags=["internal"])
 
-MAX_TTL_SECONDS = 14400
+# 48h ceiling supports long-running campaign-plan and similar runs. The actual
+# ceiling is bounded by the Clerk session lifetime (default 7 days), not what
+# we set here — so 48h is comfortably within Clerk's bounds.
+MAX_TTL_SECONDS = 172800
 # The ticket must outlive the experiment's timeout so the agent's final
 # publish/report_status calls don't get 401'd mid-stride (which leaves the
 # DB row stuck RUNNING forever). Buffer covers validation + upload + callback.
@@ -29,6 +33,7 @@ class MintRequest(BaseModel):
     experiment_id: str = Field(..., pattern=IDENTIFIER_PATTERN)
     scope: dict
     params: dict
+    clerk_user_id: str = Field(...)
     exp_ttl_seconds: int = 3600
     # Optional — when provided, mint floors exp_ttl_seconds at
     # timeout_seconds + TTL_BUFFER_SECONDS so ticket survives the whole run.
@@ -54,12 +59,17 @@ def get_service_token_hash():
     raise NotImplementedError("must be overridden via dependency_overrides")  # pragma: no cover
 
 
+def get_clerk_client():
+    raise NotImplementedError("must be overridden via dependency_overrides")  # pragma: no cover
+
+
 @router.post("/mint-run-token", response_model=MintResponse)
 async def mint_run_token(
     request: MintRequest,
     service_token: str = Depends(get_service_token),
     token_hash: str = Depends(get_service_token_hash),
     store: ScopeTicketStore = Depends(get_ticket_store),
+    clerk_client: ClerkClient = Depends(get_clerk_client),
 ):
     if not verify_service_token(service_token, token_hash):
         raise HTTPException(status_code=401, detail="Invalid service token")
@@ -93,6 +103,28 @@ async def mint_run_token(
 
     exp = now + effective_ttl
 
+    try:
+        actor_token = await clerk_client.create_actor_token(request.clerk_user_id)
+    except ClerkClientError as e:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "reason": "clerk_actor_token_creation_failed",
+                "message": str(e),
+            },
+        ) from e
+
+    try:
+        session_info = await clerk_client.redeem_actor_token(actor_token["url"])
+    except ClerkClientError as e:
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "reason": "clerk_actor_token_redemption_failed",
+                "message": str(e),
+            },
+        ) from e
+
     ticket = ScopeTicket(
         pk=broker_token,
         run_id=request.run_id,
@@ -104,6 +136,7 @@ async def mint_run_token(
         issued_at=now,
         issued_by="dispatch_lambda",
         prior_artifact_versions=request.prior_artifact_versions,
+        clerk_session_id=session_info["session_id"],
     )
 
     try:

--- a/broker/main.py
+++ b/broker/main.py
@@ -8,8 +8,16 @@ from fastapi.responses import JSONResponse
 
 from broker.auth import AuthError, BrokerTokenAuth
 from broker.callback_sender import CallbackSender
+from broker.clerk_client import ClerkClient
 from broker.data_query_tracker import DataQueryTracker
 from broker.dynamodb_client import ScopeTicket, ScopeTicketStore
+from broker.endpoints.agent_mcp_proxy import (
+    get_clerk_client as agent_mcp_get_clerk_client,
+    get_gp_api_base_url as agent_mcp_get_gp_api_base_url,
+    get_http_client as agent_mcp_get_http_client,
+    get_scope_ticket as agent_mcp_get_scope_ticket,
+    router as agent_mcp_router,
+)
 from broker.endpoints.anthropic_proxy import (
     get_anthropic_api_key,
     get_broker_auth,
@@ -39,6 +47,7 @@ from broker.endpoints.databricks_query import (
     router as databricks_router,
 )
 from broker.endpoints.mint_run_token import (
+    get_clerk_client,
     get_service_token_hash,
     get_ticket_store,
     router as mint_router,
@@ -129,6 +138,11 @@ async def lifespan(app: FastAPI):
     # than accepting a synthetic artifact from an agent whose data calls
     # all failed).
     data_query_tracker = DataQueryTracker()
+    clerk_client = ClerkClient(
+        secret_key=secrets.clerk_secret_key,
+        frontend_api_base=secrets.clerk_frontend_api_base,
+        agent_fleet_clerk_id=secrets.agent_fleet_clerk_id,
+    )
     artifact_bucket = os.environ.get("ARTIFACT_BUCKET", "gp-agent-artifacts-dev")
     env = os.environ.get("ENVIRONMENT", "dev").strip().lower()
     experiment_metadata_bucket = os.environ.get(
@@ -150,6 +164,7 @@ async def lifespan(app: FastAPI):
 
     app.dependency_overrides[get_ticket_store] = lambda: store
     app.dependency_overrides[get_service_token_hash] = lambda: secrets.service_token_hash
+    app.dependency_overrides[get_clerk_client] = lambda: clerk_client
     app.dependency_overrides[delete_get_ticket_store] = lambda: store
     app.dependency_overrides[delete_get_service_token_hash] = lambda: secrets.service_token_hash
     app.dependency_overrides[get_broker_auth] = lambda: broker_auth
@@ -200,10 +215,16 @@ async def lifespan(app: FastAPI):
     app.dependency_overrides[http_get_scope_ticket] = _resolve_ticket_from_request
     app.dependency_overrides[http_get_httpx_client] = lambda: http_client
 
+    app.dependency_overrides[agent_mcp_get_scope_ticket] = _resolve_ticket_from_request
+    app.dependency_overrides[agent_mcp_get_clerk_client] = lambda: clerk_client
+    app.dependency_overrides[agent_mcp_get_gp_api_base_url] = lambda: secrets.gp_api_base_url
+    app.dependency_overrides[agent_mcp_get_http_client] = lambda: http_client
+
     yield
 
     await upstream_client.aclose()
     await http_client.aclose()
+    await clerk_client.aclose()
 
 
 app = FastAPI(lifespan=lifespan)
@@ -228,6 +249,7 @@ app.include_router(upload_router)
 app.include_router(pdf_router)
 app.include_router(http_router)
 app.include_router(experiment_manifest_router)
+app.include_router(agent_mcp_router)
 
 
 @app.get("/health")

--- a/broker/secrets.py
+++ b/broker/secrets.py
@@ -8,6 +8,10 @@ import boto3
 _REQUIRED_FIELDS = {
     "ANTHROPIC_API_KEY": "anthropic_api_key",
     "SERVICE_TOKEN_HASH": "service_token_hash",
+    "CLERK_SECRET_KEY": "clerk_secret_key",
+    "CLERK_FRONTEND_API_BASE": "clerk_frontend_api_base",
+    "GP_API_BASE_URL": "gp_api_base_url",
+    "AGENT_FLEET_CLERK_ID": "agent_fleet_clerk_id",
 }
 
 _OPTIONAL_FIELDS = {
@@ -25,6 +29,10 @@ _FIELD_MAP = {**_REQUIRED_FIELDS, **_OPTIONAL_FIELDS}
 class BrokerSecrets:
     anthropic_api_key: str
     service_token_hash: str
+    clerk_secret_key: str
+    clerk_frontend_api_base: str
+    gp_api_base_url: str
+    agent_fleet_clerk_id: str
     tavily_api_key: str = ""
     databricks_server_hostname: str = ""
     databricks_http_path: str = ""

--- a/broker/tests/conftest.py
+++ b/broker/tests/conftest.py
@@ -31,5 +31,9 @@ def fake_secrets() -> BrokerSecrets:
         databricks_http_path="/sql/1.0/warehouses/test123",
         databricks_api_key="dapi-fake-key-for-testing",
         service_token_hash="a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        clerk_secret_key="sk_test_fake_clerk_secret",
+        clerk_frontend_api_base="https://fake.clerk.app",
+        gp_api_base_url="https://gp-api-dev.goodparty.org",
+        agent_fleet_clerk_id="user_agent_fleet_test",
         results_queue_url="https://sqs.us-west-2.amazonaws.com/333022194791/agent-results-dev.fifo",
     )

--- a/broker/tests/test_agent_mcp_proxy.py
+++ b/broker/tests/test_agent_mcp_proxy.py
@@ -1,0 +1,230 @@
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from broker.clerk_client import ClerkClient, ClerkClientError
+from broker.dynamodb_client import ScopeTicket
+from broker.endpoints.agent_mcp_proxy import (
+    get_clerk_client,
+    get_gp_api_base_url,
+    get_http_client,
+    get_scope_ticket,
+    router,
+)
+
+BROKER_TOKEN = "broker-token-test-mcp"
+GP_API_BASE_URL = "https://gp-api-dev.goodparty.org"
+FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9.fake.jwt"
+
+
+def _make_ticket(clerk_session_id: str | None = "sess_abc123") -> ScopeTicket:
+    now = int(time.time())
+    return ScopeTicket(
+        pk=BROKER_TOKEN,
+        run_id="run-mcp-001",
+        organization_slug="org-42",
+        experiment_id="voter_targeting",
+        scope={"databricks": ["SELECT"]},
+        params={"state": "CA"},
+        exp=now + 3600,
+        issued_at=now,
+        issued_by="dispatch-lambda-dev",
+        clerk_session_id=clerk_session_id,
+    )
+
+
+def _create_app(
+    ticket: ScopeTicket | None = None,
+    upstream_status: int = 200,
+    upstream_body: bytes = b'{"jsonrpc":"2.0","result":{"ok":true}}',
+    upstream_content_type: str = "application/json",
+    mint_jwt_error: Exception | None = None,
+    mint_jwt_value: str = FAKE_JWT,
+) -> tuple[FastAPI, MagicMock, MagicMock]:
+    app = FastAPI()
+    app.include_router(router)
+
+    _ticket = ticket if ticket is not None else _make_ticket()
+    app.dependency_overrides[get_scope_ticket] = lambda: _ticket
+
+    mock_clerk = MagicMock(spec=ClerkClient)
+    if mint_jwt_error is not None:
+        mock_clerk.get_session_jwt = AsyncMock(side_effect=mint_jwt_error)
+    else:
+        mock_clerk.get_session_jwt = AsyncMock(return_value=mint_jwt_value)
+    app.dependency_overrides[get_clerk_client] = lambda: mock_clerk
+
+    app.dependency_overrides[get_gp_api_base_url] = lambda: GP_API_BASE_URL
+
+    mock_http = MagicMock(spec=httpx.AsyncClient)
+    upstream_response = httpx.Response(
+        status_code=upstream_status,
+        content=upstream_body,
+        headers={"content-type": upstream_content_type},
+    )
+    mock_http.request = AsyncMock(return_value=upstream_response)
+    app.dependency_overrides[get_http_client] = lambda: mock_http
+
+    return app, mock_clerk, mock_http
+
+
+class TestAgentMcpProxyHappyPath:
+    def test_forwards_body_with_bearer_jwt_and_returns_upstream_response(self):
+        app, mock_clerk, mock_http = _create_app(
+            upstream_status=200,
+            upstream_body=b'{"jsonrpc":"2.0","result":{"tools":[]}}',
+        )
+        client = TestClient(app)
+
+        request_body = b'{"jsonrpc":"2.0","method":"tools/list","id":1}'
+        resp = client.post(
+            "/agent/mcp",
+            content=request_body,
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.content == b'{"jsonrpc":"2.0","result":{"tools":[]}}'
+
+        mock_clerk.get_session_jwt.assert_awaited_once_with("sess_abc123")
+
+        mock_http.request.assert_awaited_once()
+        call_kwargs = mock_http.request.call_args.kwargs
+        assert call_kwargs["method"] == "POST"
+        assert call_kwargs["url"] == f"{GP_API_BASE_URL}/agent/mcp"
+        assert call_kwargs["content"] == request_body
+        assert call_kwargs["headers"]["Authorization"] == f"Bearer {FAKE_JWT}"
+        assert call_kwargs["headers"]["Content-Type"] == "application/json"
+        assert call_kwargs["headers"]["X-Organization-Slug"] == "org-42"
+
+    def test_get_method_also_proxied(self):
+        app, _, mock_http = _create_app()
+        client = TestClient(app)
+
+        resp = client.get(
+            "/agent/mcp",
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 200
+        assert mock_http.request.call_args.kwargs["method"] == "GET"
+
+
+class TestAgentMcpProxyMissingClerkSessionId:
+    def test_returns_500_when_ticket_lacks_clerk_session_id(self):
+        ticket = _make_ticket(clerk_session_id=None)
+        app, mock_clerk, mock_http = _create_app(ticket=ticket)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/agent/mcp",
+            content=b"{}",
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 500
+        assert resp.json()["detail"]["reason"] == "ticket_missing_clerk_session_id"
+        mock_clerk.get_session_jwt.assert_not_awaited()
+        mock_http.request.assert_not_awaited()
+
+
+class TestAgentMcpProxyClerkMintFailure:
+    def test_returns_502_when_clerk_mint_raises(self):
+        app, _, mock_http = _create_app(
+            mint_jwt_error=ClerkClientError("upstream 500"),
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/agent/mcp",
+            content=b"{}",
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 502
+        detail = resp.json()["detail"]
+        assert detail["reason"] == "clerk_session_jwt_mint_failed"
+        assert "upstream 500" in detail["err"]
+        mock_http.request.assert_not_awaited()
+
+
+class TestAgentMcpProxyUpstreamErrorPassthrough:
+    def test_upstream_401_passes_through(self):
+        app, _, _ = _create_app(
+            upstream_status=401,
+            upstream_body=b'{"error":"unauthorized"}',
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/agent/mcp",
+            content=b"{}",
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 401
+        assert resp.content == b'{"error":"unauthorized"}'
+
+    def test_upstream_500_passes_through(self):
+        app, _, _ = _create_app(
+            upstream_status=500,
+            upstream_body=b'{"error":"internal"}',
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/agent/mcp",
+            content=b"{}",
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 500
+        assert resp.content == b'{"error":"internal"}'
+
+
+class TestAgentMcpProxyHeaderHygiene:
+    """X-Broker-Token is the broker's internal auth — it must never appear on
+    the outbound request to gp-api. Only Content-Type and Authorization should
+    be forwarded."""
+
+    def test_x_broker_token_is_not_forwarded_to_gp_api(self):
+        app, _, mock_http = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/agent/mcp",
+            content=b'{"jsonrpc":"2.0"}',
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 200
+        outbound_headers = mock_http.request.call_args.kwargs["headers"]
+        # Case-insensitive guard: no broker token under any casing.
+        lowered = {k.lower(): v for k, v in outbound_headers.items()}
+        assert "x-broker-token" not in lowered, (
+            f"X-Broker-Token leaked to gp-api: {outbound_headers}"
+        )
+        # Sanity: only the three expected headers should be present.
+        assert set(lowered.keys()) == {"content-type", "authorization", "x-organization-slug"}

--- a/broker/tests/test_clerk_client.py
+++ b/broker/tests/test_clerk_client.py
@@ -1,0 +1,346 @@
+import asyncio
+import base64
+import json
+import time
+
+import httpx
+import pytest
+
+from broker.clerk_client import ClerkClient, ClerkClientError
+
+
+def _make_client_with_backend(transport: httpx.MockTransport) -> ClerkClient:
+    client = ClerkClient(
+        secret_key="sk_test",
+        frontend_api_base="https://x.clerk.app",
+        agent_fleet_clerk_id="user_agent_fleet_test",
+    )
+    client._backend = httpx.AsyncClient(
+        base_url="https://api.clerk.com",
+        headers={"Authorization": "Bearer sk_test"},
+        transport=transport,
+    )
+    return client
+
+
+def _make_client_with_http(transport: httpx.MockTransport) -> ClerkClient:
+    client = ClerkClient(
+        secret_key="sk_test",
+        frontend_api_base="https://x.clerk.app",
+        agent_fleet_clerk_id="user_agent_fleet_test",
+    )
+    client._http = httpx.AsyncClient(transport=transport)
+    return client
+
+
+def _fake_jwt(exp_offset_seconds: int = 300) -> str:
+    """Build a minimal JWT-shaped string with a real exp claim so
+    ClerkClient._extract_exp() can decode it. Signature is meaningless;
+    we never verify our own freshly-minted credential."""
+    header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=").decode()
+    payload = json.dumps({"exp": int(time.time()) + exp_offset_seconds}).encode()
+    payload_b64 = base64.urlsafe_b64encode(payload).rstrip(b"=").decode()
+    return f"{header}.{payload_b64}.sig"
+
+
+class TestMintSessionJwt:
+    async def test_returns_jwt_string_on_200(self):
+        jwt_value = _fake_jwt()
+        transport = httpx.MockTransport(
+            lambda req: httpx.Response(200, json={"jwt": jwt_value})
+        )
+        client = _make_client_with_backend(transport)
+
+        jwt = await client.mint_session_jwt("sess_123")
+
+        assert jwt == jwt_value
+        await client.aclose()
+
+    async def test_raises_on_non_2xx(self):
+        transport = httpx.MockTransport(
+            lambda req: httpx.Response(404, json={"errors": [{"code": "session_not_found"}]})
+        )
+        client = _make_client_with_backend(transport)
+
+        with pytest.raises(ClerkClientError, match="session JWT mint failed"):
+            await client.mint_session_jwt("sess_missing")
+        await client.aclose()
+
+    async def test_raises_when_jwt_missing_in_response(self):
+        transport = httpx.MockTransport(
+            lambda req: httpx.Response(200, json={"object": "token"})
+        )
+        client = _make_client_with_backend(transport)
+
+        with pytest.raises(ClerkClientError, match="missing 'jwt'"):
+            await client.mint_session_jwt("sess_123")
+        await client.aclose()
+
+    async def test_sends_template_name_in_request_body(self):
+        captured: dict = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(req.content)
+            captured["path"] = req.url.path
+            return httpx.Response(200, json={"jwt": _fake_jwt()})
+
+        transport = httpx.MockTransport(handler)
+        client = _make_client_with_backend(transport)
+
+        await client.mint_session_jwt("sess_123")
+
+        assert captured["body"] == {"template": "agent-mcp"}
+        assert captured["path"] == "/v1/sessions/sess_123/tokens"
+        await client.aclose()
+
+
+class TestRedeemActorToken:
+    async def test_returns_session_id_from_response_created_session_id(self):
+        transport = httpx.MockTransport(
+            lambda req: httpx.Response(
+                200,
+                json={"response": {"created_session_id": "sess_abc"}},
+            )
+        )
+        client = _make_client_with_http(transport)
+
+        info = await client.redeem_actor_token(
+            "https://x.clerk.app/v1/client/sign_in_tokens/tok_1?token=jwt"
+        )
+
+        assert info == {"session_id": "sess_abc"}
+        await client.aclose()
+
+    async def test_falls_back_to_client_last_active_session_id(self):
+        transport = httpx.MockTransport(
+            lambda req: httpx.Response(
+                200,
+                json={"client": {"last_active_session_id": "sess_xyz"}},
+            )
+        )
+        client = _make_client_with_http(transport)
+
+        info = await client.redeem_actor_token(
+            "https://x.clerk.app/v1/client/sign_in_tokens/tok_1?token=jwt"
+        )
+
+        assert info == {"session_id": "sess_xyz"}
+        await client.aclose()
+
+    async def test_raises_on_non_2xx(self):
+        transport = httpx.MockTransport(
+            lambda req: httpx.Response(410, text="actor_token_already_used")
+        )
+        client = _make_client_with_http(transport)
+
+        with pytest.raises(ClerkClientError, match="actor token redemption failed"):
+            await client.redeem_actor_token(
+                "https://x.clerk.app/v1/client/sign_in_tokens/tok_1?token=jwt"
+            )
+        await client.aclose()
+
+    async def test_raises_when_no_session_id_present(self):
+        transport = httpx.MockTransport(
+            lambda req: httpx.Response(200, json={"response": {}, "client": {}})
+        )
+        client = _make_client_with_http(transport)
+
+        with pytest.raises(ClerkClientError, match="missing session id"):
+            await client.redeem_actor_token(
+                "https://x.clerk.app/v1/client/sign_in_tokens/tok_1?token=jwt"
+            )
+        await client.aclose()
+
+    async def test_rejects_url_outside_frontend_api_base(self):
+        client = ClerkClient(
+            secret_key="sk_test",
+            frontend_api_base="https://expected.clerk.app",
+            agent_fleet_clerk_id="user_agent_fleet_test",
+        )
+        with pytest.raises(ClerkClientError, match="not from the configured"):
+            await client.redeem_actor_token(
+                "https://attacker.com/v1/sign_in_tokens/abc?token=xyz"
+            )
+        await client.aclose()
+
+
+class TestCreateActorToken:
+    async def test_returns_body_with_url(self):
+        transport = httpx.MockTransport(
+            lambda req: httpx.Response(
+                200,
+                json={
+                    "object": "actor_token",
+                    "id": "act_xyz",
+                    "url": "https://x.clerk.app/v1/client/sign_in_tokens/tok_1?token=jwt",
+                    "token": "jwt-string",
+                },
+            )
+        )
+        client = _make_client_with_backend(transport)
+
+        body = await client.create_actor_token("user_abc123")
+
+        assert body["url"] == "https://x.clerk.app/v1/client/sign_in_tokens/tok_1?token=jwt"
+        assert body["token"] == "jwt-string"
+        await client.aclose()
+
+    async def test_raises_on_non_2xx(self):
+        transport = httpx.MockTransport(
+            lambda req: httpx.Response(422, text='{"errors":[{"code":"user_not_found"}]}')
+        )
+        client = _make_client_with_backend(transport)
+
+        with pytest.raises(ClerkClientError, match="actor token creation failed"):
+            await client.create_actor_token("user_missing")
+        await client.aclose()
+
+    async def test_raises_when_url_missing_in_response(self):
+        transport = httpx.MockTransport(
+            lambda req: httpx.Response(200, json={"object": "actor_token", "id": "act_xyz"})
+        )
+        client = _make_client_with_backend(transport)
+
+        with pytest.raises(ClerkClientError, match="missing 'url'"):
+            await client.create_actor_token("user_abc123")
+        await client.aclose()
+
+    async def test_sends_correct_request_body_shape(self):
+        captured: dict = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(req.content)
+            captured["path"] = req.url.path
+            return httpx.Response(
+                200,
+                json={"url": "https://x.clerk.app/v1/client/sign_in_tokens/tok_1?token=jwt"},
+            )
+
+        transport = httpx.MockTransport(handler)
+        client = _make_client_with_backend(transport)
+
+        await client.create_actor_token("user_abc123", expires_in_seconds=900)
+
+        assert captured["path"] == "/v1/actor_tokens"
+        assert captured["body"] == {
+            "user_id": "user_abc123",
+            "actor": {"sub": "user_agent_fleet_test"},
+            "expires_in_seconds": 900,
+        }
+        await client.aclose()
+
+
+class TestGetSessionJwt:
+    """get_session_jwt is the cached entry point used by the proxy. It must mint
+    once and reuse, but re-mint when the cached JWT is near expiry."""
+
+    async def test_cache_miss_calls_clerk_and_returns_jwt(self):
+        call_count = {"n": 0}
+        jwt_value = _fake_jwt(exp_offset_seconds=300)
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            call_count["n"] += 1
+            return httpx.Response(200, json={"jwt": jwt_value})
+
+        transport = httpx.MockTransport(handler)
+        client = _make_client_with_backend(transport)
+
+        result = await client.get_session_jwt("sess_abc")
+
+        assert result == jwt_value
+        assert call_count["n"] == 1
+        await client.aclose()
+
+    async def test_cache_hit_does_not_call_clerk_again(self):
+        """Two sequential calls on the same session should hit Clerk exactly once."""
+        call_count = {"n": 0}
+        jwt_value = _fake_jwt(exp_offset_seconds=300)
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            call_count["n"] += 1
+            return httpx.Response(200, json={"jwt": jwt_value})
+
+        transport = httpx.MockTransport(handler)
+        client = _make_client_with_backend(transport)
+
+        first = await client.get_session_jwt("sess_abc")
+        second = await client.get_session_jwt("sess_abc")
+
+        assert first == second == jwt_value
+        assert call_count["n"] == 1
+        await client.aclose()
+
+    async def test_near_expiry_jwt_is_re_minted(self):
+        """A cached JWT with exp = now + 3 should be considered stale and re-minted."""
+        call_count = {"n": 0}
+        # First mint returns a JWT that's near expiry; second mint returns fresh.
+        responses = [
+            _fake_jwt(exp_offset_seconds=3),
+            _fake_jwt(exp_offset_seconds=300),
+        ]
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            jwt_value = responses[call_count["n"]]
+            call_count["n"] += 1
+            return httpx.Response(200, json={"jwt": jwt_value})
+
+        transport = httpx.MockTransport(handler)
+        client = _make_client_with_backend(transport)
+
+        first = await client.get_session_jwt("sess_abc")
+        second = await client.get_session_jwt("sess_abc")
+
+        assert call_count["n"] == 2
+        assert first != second
+        await client.aclose()
+
+    async def test_parallel_cache_miss_does_not_thundering_herd(self):
+        """Concurrent get_session_jwt calls on the same session should produce
+        exactly one Clerk mint, not N."""
+        call_count = {"n": 0}
+        jwt_value = _fake_jwt(exp_offset_seconds=300)
+
+        async def handler(req: httpx.Request) -> httpx.Response:
+            # Force interleaving so both tasks have a chance to enter the
+            # function before either acquires the lock.
+            await asyncio.sleep(0.01)
+            call_count["n"] += 1
+            return httpx.Response(200, json={"jwt": jwt_value})
+
+        transport = httpx.MockTransport(handler)
+        client = _make_client_with_backend(transport)
+
+        results = await asyncio.gather(
+            client.get_session_jwt("sess_abc"),
+            client.get_session_jwt("sess_abc"),
+            client.get_session_jwt("sess_abc"),
+        )
+
+        assert all(r == jwt_value for r in results)
+        assert call_count["n"] == 1
+        await client.aclose()
+
+    async def test_different_sessions_are_cached_independently(self):
+        call_count = {"n": 0}
+        jwts = {
+            "sess_a": _fake_jwt(exp_offset_seconds=300),
+            "sess_b": _fake_jwt(exp_offset_seconds=300),
+        }
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            call_count["n"] += 1
+            session_id = req.url.path.split("/")[3]
+            return httpx.Response(200, json={"jwt": jwts[session_id]})
+
+        transport = httpx.MockTransport(handler)
+        client = _make_client_with_backend(transport)
+
+        a1 = await client.get_session_jwt("sess_a")
+        b1 = await client.get_session_jwt("sess_b")
+        a2 = await client.get_session_jwt("sess_a")
+        b2 = await client.get_session_jwt("sess_b")
+
+        assert a1 == a2 == jwts["sess_a"]
+        assert b1 == b2 == jwts["sess_b"]
+        assert call_count["n"] == 2
+        await client.aclose()

--- a/broker/tests/test_delete_run_token.py
+++ b/broker/tests/test_delete_run_token.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock, MagicMock
+
 import boto3
 import pytest
 from fastapi import FastAPI
@@ -5,6 +7,7 @@ from fastapi.testclient import TestClient
 from moto import mock_aws
 
 from broker.auth import hash_service_token
+from broker.clerk_client import ClerkClient
 from broker.dynamodb_client import ScopeTicketStore
 from broker.endpoints.delete_run_token import (
     get_service_token_hash,
@@ -12,6 +15,7 @@ from broker.endpoints.delete_run_token import (
     router,
 )
 from broker.endpoints.mint_run_token import (
+    get_clerk_client as mint_get_clerk_client,
     get_service_token_hash as mint_get_service_token_hash,
     get_ticket_store as mint_get_ticket_store,
     router as mint_router,
@@ -42,8 +46,14 @@ def app_and_store(moto_env):
     app = FastAPI()
     app.include_router(mint_router)
     app.include_router(router)
+    fake_clerk = MagicMock(spec=ClerkClient)
+    fake_clerk.create_actor_token = AsyncMock(
+        return_value={"url": "https://test.clerk.app/v1/client/sign_in_tokens/tok?token=jwt"}
+    )
+    fake_clerk.redeem_actor_token = AsyncMock(return_value={"session_id": "sess_test"})
     app.dependency_overrides[mint_get_ticket_store] = lambda: store
     app.dependency_overrides[mint_get_service_token_hash] = lambda: SERVICE_TOKEN_HASH
+    app.dependency_overrides[mint_get_clerk_client] = lambda: fake_clerk
     app.dependency_overrides[get_ticket_store] = lambda: store
     app.dependency_overrides[get_service_token_hash] = lambda: SERVICE_TOKEN_HASH
     return app, store, moto_env
@@ -58,6 +68,7 @@ def _mint(client: TestClient, run_id: str) -> str:
             "experiment_id": "voter_targeting",
             "scope": {"databricks": ["SELECT"]},
             "params": {"state": "CA"},
+            "clerk_user_id": "user_test_delete",
         },
         headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
     )

--- a/broker/tests/test_main.py
+++ b/broker/tests/test_main.py
@@ -18,6 +18,10 @@ def _fake_secrets() -> BrokerSecrets:
         databricks_http_path="/sql/test",
         databricks_api_key="dapi-fake",
         service_token_hash="fakehash",
+        clerk_secret_key="sk_test_fake",
+        clerk_frontend_api_base="https://fake.clerk.app",
+        gp_api_base_url="https://gp-api-dev.goodparty.org",
+        agent_fleet_clerk_id="user_agent_fleet_test",
         results_queue_url="https://sqs.us-west-2.amazonaws.com/123/queue.fifo",
     )
 

--- a/broker/tests/test_mint_run_token.py
+++ b/broker/tests/test_mint_run_token.py
@@ -1,13 +1,14 @@
 import hashlib
 import time
 import uuid
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from broker.auth import hash_service_token
+from broker.clerk_client import ClerkClient, ClerkClientError
 from broker.dynamodb_client import (
     ScopeTicket,
     ScopeTicketStore,
@@ -16,6 +17,7 @@ from broker.dynamodb_client import (
 from broker.endpoints.mint_run_token import (
     MintRequest,
     MintResponse,
+    get_clerk_client,
     get_service_token_hash,
     get_ticket_store,
     router,
@@ -23,19 +25,34 @@ from broker.endpoints.mint_run_token import (
 
 SERVICE_TOKEN = "test-dispatch-lambda-token"
 SERVICE_TOKEN_HASH = hash_service_token(SERVICE_TOKEN)
+DEFAULT_CLERK_USER_ID = "user_test_abc123"
+DEFAULT_ACTOR_TOKEN_URL = "https://test.clerk.app/v1/client/sign_in_tokens/tok_1?token=jwt"
+
+
+def _make_fake_clerk(
+    session_id: str = "sess_default",
+    actor_token_url: str = DEFAULT_ACTOR_TOKEN_URL,
+) -> MagicMock:
+    fake = MagicMock(spec=ClerkClient)
+    fake.create_actor_token = AsyncMock(return_value={"url": actor_token_url})
+    fake.redeem_actor_token = AsyncMock(return_value={"session_id": session_id})
+    return fake
 
 
 def _create_test_app(
     store: ScopeTicketStore | None = None,
     token_hash: str = SERVICE_TOKEN_HASH,
+    clerk_client: ClerkClient | None = None,
 ) -> FastAPI:
     app = FastAPI()
     app.include_router(router)
 
     _store = store or MagicMock(spec=ScopeTicketStore)
+    _clerk = clerk_client or _make_fake_clerk()
 
     app.dependency_overrides[get_ticket_store] = lambda: _store
     app.dependency_overrides[get_service_token_hash] = lambda: token_hash
+    app.dependency_overrides[get_clerk_client] = lambda: _clerk
 
     return app
 
@@ -47,6 +64,7 @@ def _mint_payload(**overrides) -> dict:
         "experiment_id": "voter_targeting",
         "scope": {"databricks": ["SELECT"], "tavily": True},
         "params": {"state": "CA", "district": "SD-15"},
+        "clerk_user_id": DEFAULT_CLERK_USER_ID,
     }
     base.update(overrides)
     return base
@@ -121,8 +139,8 @@ class TestMintRunTokenTTLCap:
     def test_ttl_above_max_is_rejected(self):
         """Caller asks for a TTL beyond MAX_TTL_SECONDS — reject loudly so a
         misconfigured dispatch (e.g., experiment with absurd timeout) is
-        visible as a 400 instead of silently clamping to 4h. Silent clamp
-        means agent thinks it has 24h and 401s mid-run; row sticks RUNNING
+        visible as a 400 instead of silently clamping. Silent clamp means
+        agent thinks it has more time and 401s mid-run; row sticks RUNNING
         forever in gp-api.
         """
         store = MagicMock(spec=ScopeTicketStore)
@@ -131,7 +149,7 @@ class TestMintRunTokenTTLCap:
 
         resp = client.post(
             "/internal/mint-run-token",
-            json=_mint_payload(exp_ttl_seconds=99999),
+            json=_mint_payload(exp_ttl_seconds=999999),
             headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
         )
         assert resp.status_code == 400
@@ -212,7 +230,7 @@ class TestMintRunTokenTTLVsTimeout:
 
         resp = client.post(
             "/internal/mint-run-token",
-            json=_mint_payload(exp_ttl_seconds=3600, timeout_seconds=15000),
+            json=_mint_payload(exp_ttl_seconds=3600, timeout_seconds=200000),
             headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
         )
         assert resp.status_code == 400
@@ -365,3 +383,89 @@ class TestMintRunTokenPriorArtifactVersions:
         assert resp.status_code == 200
         ticket: ScopeTicket = store.put_ticket.call_args[0][0]
         assert ticket.prior_artifact_versions is None
+
+
+class TestMintRunTokenActorTokenRedemption:
+    """The mint endpoint mints a Clerk actor token directly (broker-side, no
+    gp-api hop), redeems it for a session id, and persists the session id on
+    the ticket. The broker later uses this session id to mint fresh JWTs
+    (cached) for each outbound MCP/HTTP call.
+    """
+
+    def test_clerk_user_id_required(self):
+        store = MagicMock(spec=ScopeTicketStore)
+        app = _create_test_app(store=store)
+        client = TestClient(app)
+
+        payload = _mint_payload()
+        del payload["clerk_user_id"]
+
+        resp = client.post(
+            "/internal/mint-run-token",
+            json=payload,
+            headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
+        )
+        assert resp.status_code == 422
+
+    def test_session_id_persisted_on_ticket(self):
+        store = MagicMock(spec=ScopeTicketStore)
+        clerk = _make_fake_clerk(session_id="sess_abc123")
+        app = _create_test_app(store=store, clerk_client=clerk)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/internal/mint-run-token",
+            json=_mint_payload(),
+            headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
+        )
+
+        assert resp.status_code == 200
+        clerk.create_actor_token.assert_awaited_once_with(DEFAULT_CLERK_USER_ID)
+        clerk.redeem_actor_token.assert_awaited_once_with(DEFAULT_ACTOR_TOKEN_URL)
+        ticket: ScopeTicket = store.put_ticket.call_args[0][0]
+        assert ticket.clerk_session_id == "sess_abc123"
+
+    def test_creation_failure_returns_502_with_reason(self):
+        store = MagicMock(spec=ScopeTicketStore)
+        clerk = MagicMock(spec=ClerkClient)
+        clerk.create_actor_token = AsyncMock(
+            side_effect=ClerkClientError("upstream 422 user_not_found")
+        )
+        clerk.redeem_actor_token = AsyncMock()
+        app = _create_test_app(store=store, clerk_client=clerk)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/internal/mint-run-token",
+            json=_mint_payload(),
+            headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
+        )
+
+        assert resp.status_code == 502
+        body = resp.json()
+        assert body["detail"]["reason"] == "clerk_actor_token_creation_failed"
+        clerk.redeem_actor_token.assert_not_awaited()
+        store.put_ticket.assert_not_called()
+
+    def test_redemption_failure_returns_502_with_reason(self):
+        store = MagicMock(spec=ScopeTicketStore)
+        clerk = MagicMock(spec=ClerkClient)
+        clerk.create_actor_token = AsyncMock(
+            return_value={"url": DEFAULT_ACTOR_TOKEN_URL}
+        )
+        clerk.redeem_actor_token = AsyncMock(
+            side_effect=ClerkClientError("upstream 410 actor_token_already_used")
+        )
+        app = _create_test_app(store=store, clerk_client=clerk)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/internal/mint-run-token",
+            json=_mint_payload(),
+            headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
+        )
+
+        assert resp.status_code == 502
+        body = resp.json()
+        assert body["detail"]["reason"] == "clerk_actor_token_redemption_failed"
+        store.put_ticket.assert_not_called()

--- a/broker/tests/test_secrets.py
+++ b/broker/tests/test_secrets.py
@@ -13,6 +13,10 @@ FULL_SECRET = {
     "DATABRICKS_HTTP_PATH": "/sql/1.0/warehouses/abc",
     "DATABRICKS_API_KEY": "dapi-test",
     "SERVICE_TOKEN_HASH": "abc123hash",
+    "CLERK_SECRET_KEY": "sk_test_clerk",
+    "CLERK_FRONTEND_API_BASE": "https://test.clerk.app",
+    "GP_API_BASE_URL": "https://gp-api-dev.goodparty.org",
+    "AGENT_FLEET_CLERK_ID": "user_agent_fleet_test",
     "RESULTS_QUEUE_URL": "https://sqs.us-west-2.amazonaws.com/123/results.fifo",
 }
 
@@ -36,6 +40,9 @@ class TestLoadSecrets:
         assert result.databricks_http_path == "/sql/1.0/warehouses/abc"
         assert result.databricks_api_key == "dapi-test"
         assert result.service_token_hash == "abc123hash"
+        assert result.clerk_secret_key == "sk_test_clerk"
+        assert result.clerk_frontend_api_base == "https://test.clerk.app"
+        assert result.agent_fleet_clerk_id == "user_agent_fleet_test"
         assert result.results_queue_url == "https://sqs.us-west-2.amazonaws.com/123/results.fifo"
 
     def test_missing_required_field_raises_valueerror(self):

--- a/infrastructure/modules/broker/main.tf
+++ b/infrastructure/modules/broker/main.tf
@@ -674,6 +674,22 @@ resource "aws_ecs_task_definition" "broker" {
         {
           name      = "SERVICE_TOKEN_HASH"
           valueFrom = "${aws_secretsmanager_secret.broker.arn}:SERVICE_TOKEN_HASH::"
+        },
+        {
+          name      = "CLERK_SECRET_KEY"
+          valueFrom = "${aws_secretsmanager_secret.broker.arn}:CLERK_SECRET_KEY::"
+        },
+        {
+          name      = "CLERK_FRONTEND_API_BASE"
+          valueFrom = "${aws_secretsmanager_secret.broker.arn}:CLERK_FRONTEND_API_BASE::"
+        },
+        {
+          name      = "GP_API_BASE_URL"
+          valueFrom = "${aws_secretsmanager_secret.broker.arn}:GP_API_BASE_URL::"
+        },
+        {
+          name      = "AGENT_FLEET_CLERK_ID"
+          valueFrom = "${aws_secretsmanager_secret.broker.arn}:AGENT_FLEET_CLERK_ID::"
         }
       ]
     }

--- a/infrastructure/modules/broker/main.tf
+++ b/infrastructure/modules/broker/main.tf
@@ -123,7 +123,7 @@ resource "aws_cloudwatch_log_group" "broker" {
 
 resource "aws_secretsmanager_secret" "broker" {
   name        = "broker-${var.environment}"
-  description = "Secrets for PMF broker service. Operator populates: ANTHROPIC_API_KEY, GEMINI_API_KEY, TAVILY_API_KEY, DATABRICKS_SERVER_HOSTNAME, DATABRICKS_HTTP_PATH, DATABRICKS_API_KEY, SERVICE_TOKEN_HASH"
+  description = "Secrets for PMF broker service. Operator populates: ANTHROPIC_API_KEY, GEMINI_API_KEY, TAVILY_API_KEY, DATABRICKS_SERVER_HOSTNAME, DATABRICKS_HTTP_PATH, DATABRICKS_API_KEY, SERVICE_TOKEN_HASH, CLERK_SECRET_KEY, CLERK_FRONTEND_API_BASE, GP_API_BASE_URL, AGENT_FLEET_CLERK_ID"
 
   tags = {
     Environment = var.environment

--- a/pmf_engine/control_plane/broker_client.py
+++ b/pmf_engine/control_plane/broker_client.py
@@ -23,6 +23,7 @@ class BrokerClient:
         experiment_id: str,
         scope: dict,
         params: dict,
+        clerk_user_id: str,
         exp_ttl_seconds: int = 3600,
         prior_artifact_versions: dict[str, str] | None = None,
     ) -> dict:
@@ -32,6 +33,7 @@ class BrokerClient:
             "experiment_id": experiment_id,
             "scope": scope,
             "params": params,
+            "clerk_user_id": clerk_user_id,
             "exp_ttl_seconds": exp_ttl_seconds,
             "prior_artifact_versions": prior_artifact_versions,
         }

--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -328,7 +328,7 @@ def parse_dispatch_message(body: str) -> dict:
     except (json.JSONDecodeError, TypeError) as e:
         raise ValueError(f"Invalid message body: {e}")
 
-    for field in ("experiment_type", "organization_slug", "run_id"):
+    for field in ("experiment_type", "organization_slug", "run_id", "clerk_user_id"):
         if not data.get(field):
             raise ValueError(f"Missing required field: {field}")
 
@@ -338,6 +338,8 @@ def parse_dispatch_message(body: str) -> dict:
         raise ValueError("run_id must match [a-zA-Z0-9_-]{1,64}")
     if not isinstance(data["organization_slug"], str) or not _IDENTIFIER_RE.match(data["organization_slug"]):
         raise ValueError("organization_slug must match [a-zA-Z0-9_-]{1,64}")
+    if not isinstance(data["clerk_user_id"], str):
+        raise ValueError("clerk_user_id must be a string")
 
     if data.get("params") is None:
         data["params"] = {}
@@ -537,6 +539,7 @@ def handler(event: dict, context) -> dict:
                 experiment_id=experiment_id,
                 scope=scope,
                 params=message["params"],
+                clerk_user_id=message["clerk_user_id"],
                 exp_ttl_seconds=experiment.get("timeout_seconds", 3600) + 300,
                 prior_artifact_versions=prior_artifact_versions,
             )

--- a/pmf_engine/tests/test_broker_client.py
+++ b/pmf_engine/tests/test_broker_client.py
@@ -63,6 +63,7 @@ class TestMintRunTokenSuccess:
                 experiment_id="smoke_test",
                 scope={"state": "NC", "cities": ["Hendersonville"]},
                 params={"city": "Hendersonville"},
+                clerk_user_id="user_test",
                 exp_ttl_seconds=3600,
             )
 
@@ -83,7 +84,7 @@ class TestMintRunTokenSuccess:
 
         with patch("pmf_engine.control_plane.broker_client.httpx.post", return_value=mock_response) as mock_post:
             client = BrokerClient("https://broker.example.com/", "token")
-            client.mint_run_token("run-1", "org-1", "exp-1", {}, {})
+            client.mint_run_token("run-1", "org-1", "exp-1", {}, {}, "user_test")
 
         url = mock_post.call_args.args[0]
         assert url == "https://broker.example.com/internal/mint-run-token"
@@ -99,7 +100,7 @@ class TestMintRunToken401:
             client = BrokerClient("https://broker.example.com", "bad-token")
 
             with pytest.raises(BrokerError) as exc_info:
-                client.mint_run_token("run-1", "org-1", "exp-1", {}, {})
+                client.mint_run_token("run-1", "org-1", "exp-1", {}, {}, "user_test")
 
             assert exc_info.value.status_code == 401
             assert "service token" in exc_info.value.detail.lower()
@@ -118,7 +119,7 @@ class TestMintRunToken400:
             client = BrokerClient("https://broker.example.com", "svc-token")
 
             with pytest.raises(BrokerError) as exc_info:
-                client.mint_run_token("run-1", "org-1", "exp-1", {}, {"bad": {"nested": True}})
+                client.mint_run_token("run-1", "org-1", "exp-1", {}, {"bad": {"nested": True}}, "user_test")
 
             assert exc_info.value.status_code == 400
             assert exc_info.value.user_safe_message == "Invalid experiment parameters"
@@ -135,7 +136,7 @@ class TestMintRunToken409:
             client = BrokerClient("https://broker.example.com", "svc-token")
 
             with pytest.raises(BrokerError) as exc_info:
-                client.mint_run_token("run-dup", "org-1", "exp-1", {}, {})
+                client.mint_run_token("run-dup", "org-1", "exp-1", {}, {}, "user_test")
 
             assert exc_info.value.status_code == 409
             assert "duplicate" in exc_info.value.detail.lower()
@@ -155,6 +156,7 @@ class TestMintRunTokenPriorArtifactVersions:
                 experiment_id="smoke_main",
                 scope={"state": "NC"},
                 params={"issues": ["housing"]},
+                clerk_user_id="user_test",
                 prior_artifact_versions={
                     "smoke_dep": "smoke_dep/org-1/run-a/artifact.json"
                 },
@@ -179,6 +181,7 @@ class TestMintRunTokenPriorArtifactVersions:
                 experiment_id="smoke_test",
                 scope={"state": "NC"},
                 params={"city": "Hendersonville"},
+                clerk_user_id="user_test",
             )
 
         body = mock_post.call_args.kwargs["json"]

--- a/pmf_engine/tests/test_dispatch_handler.py
+++ b/pmf_engine/tests/test_dispatch_handler.py
@@ -107,6 +107,7 @@ class TestParseDispatchMessage:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": {"topic": "education"},
         }
         result = parse_dispatch_message(json.dumps(body))
@@ -120,6 +121,7 @@ class TestParseDispatchMessage:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
         }
         result = parse_dispatch_message(json.dumps(body))
         assert result["params"] == {}
@@ -160,6 +162,7 @@ class TestParseDispatchMessage:
             "experiment_type": bad_experiment_type,
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
         }
         with pytest.raises(ValueError):
             parse_dispatch_message(json.dumps(body))
@@ -178,6 +181,7 @@ class TestParseDispatchMessage:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": bad_run_id,
+            "clerk_user_id": "user_test_dispatch",
         }
         with pytest.raises(ValueError, match="run_id"):
             parse_dispatch_message(json.dumps(body))
@@ -196,6 +200,7 @@ class TestParseDispatchMessage:
             "experiment_type": "smoke_test",
             "organization_slug": bad_org_slug,
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
         }
         with pytest.raises(ValueError, match="organization_slug"):
             parse_dispatch_message(json.dumps(body))
@@ -205,6 +210,7 @@ class TestParseDispatchMessage:
             "experiment_type": "smoke_test",
             "organization_slug": "Org-123_abc",
             "run_id": "run-ABC-001",
+            "clerk_user_id": "user_test_dispatch",
         }
         parsed = parse_dispatch_message(json.dumps(body))
         assert parsed["organization_slug"] == "Org-123_abc"
@@ -215,6 +221,7 @@ class TestParseDispatchMessage:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "prior_artifact_versions": {
                 f"k{i}": f"e/r/artifact.json" for i in range(11)
             },
@@ -238,6 +245,7 @@ class TestBuildContainerOverrides:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-abc",
+            "clerk_user_id": "user_test_dispatch",
             "params": {"district": "CA-12"},
         }
 
@@ -272,6 +280,7 @@ class TestBuildContainerOverrides:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-abc",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
         }
         overrides = build_container_overrides(
@@ -302,6 +311,7 @@ class TestHandler:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -333,6 +343,7 @@ class TestHandler:
             "experiment_type": "nonexistent",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
         })
 
@@ -354,6 +365,7 @@ class TestHandler:
             "experiment_type": "nonexistent",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
         })
 
@@ -383,6 +395,7 @@ class TestHandler:
                 "experiment_type": "nonexistent",
                 "organization_slug": "org-123",
                 "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
                 "params": {},
             })
             handler(event, None)
@@ -428,6 +441,7 @@ class TestHandler:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -473,6 +487,7 @@ class TestHandler:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -504,6 +519,7 @@ class TestHandler:
                 "experiment_type": "smoke_test",
                 "organization_slug": "org-123",
                 "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             }
             send_error_callback(message, "some error", "https://sqs.example.com/callback.fifo")
         finally:
@@ -530,6 +546,7 @@ class TestHandler:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -553,6 +570,7 @@ class TestHandler:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -576,6 +594,7 @@ class TestBrokerFlow:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -602,6 +621,7 @@ class TestBrokerFlow:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -624,6 +644,7 @@ class TestBrokerFlow:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -645,6 +666,7 @@ class TestBrokerFlow:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -664,6 +686,7 @@ class TestNonDictParamsGuard:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-xyz",
+            "clerk_user_id": "user_test_dispatch",
             "params": "not a dict",
         })
 
@@ -686,6 +709,7 @@ class TestNonDictParamsGuard:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": [1, 2, 3],
         })
 
@@ -711,6 +735,7 @@ class TestNonDictParamsGuard:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": None,
         })
 
@@ -739,6 +764,7 @@ class TestErrorCallbackStableDedup:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-abc",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -759,6 +785,7 @@ class TestErrorCallbackStableDedup:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-abc",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -781,6 +808,7 @@ class TestErrorCallbackStableDedup:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-abc",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -808,6 +836,7 @@ class TestMissingCriticalEnvVars:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-xyz",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
         })
 
@@ -837,6 +866,7 @@ class TestMissingCriticalEnvVars:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-xyz",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
         })
 
@@ -861,6 +891,7 @@ class TestMissingCriticalEnvVars:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-xyz",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
         })
 
@@ -885,6 +916,7 @@ class TestParamsSizeLimit:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-big",
+            "clerk_user_id": "user_test_dispatch",
             "params": oversized,
         })
 
@@ -919,6 +951,7 @@ class TestParamsSizeLimit:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
             "params": small,
         })
 
@@ -947,6 +980,7 @@ class TestRequiredParamsValidation:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-missing-state",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
         })
 
@@ -976,6 +1010,7 @@ class TestRequiredParamsValidation:
             "experiment_type": "smoke_test",
             "organization_slug": "org-empty",
             "run_id": "run-empty-strings",
+            "clerk_user_id": "user_test_dispatch",
             "params": {"state": ""},
         })
 
@@ -999,6 +1034,7 @@ class TestRequiredParamsValidation:
             "experiment_type": "smoke_test",
             "organization_slug": "org-ok",
             "run_id": "run-ok",
+            "clerk_user_id": "user_test_dispatch",
             "params": {"state": "WI"},
         })
 
@@ -1022,6 +1058,7 @@ class TestTransientBrokerErrors:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-transient",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -1048,6 +1085,7 @@ class TestTransientBrokerErrors:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-terminal",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -1078,6 +1116,7 @@ class TestDispatchHandlerErrorPathResilience:
             "experiment_type": "smoke_test",
             "organization_slug": "org-x",
             "run_id": "run-prog-err",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -1102,6 +1141,7 @@ class TestDispatchHandlerErrorPathResilience:
             "experiment_type": "smoke_test",
             "organization_slug": "org-x",
             "run_id": "run-missing-params",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
         })
 
@@ -1125,6 +1165,7 @@ class TestDispatchHandlerErrorPathResilience:
             "experiment_type": "smoke_test",
             "organization_slug": "org-x",
             "run_id": "run-missing-params-ok",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
         })
 
@@ -1201,6 +1242,7 @@ class TestPriorArtifactVersionsValidation:
             "experiment_type": "smoke_test",
             "organization_slug": "acme",
             "run_id": "run-1",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
             "prior_artifact_versions": {
                 "smoke_dep": "../../etc/passwd",
@@ -1214,6 +1256,7 @@ class TestPriorArtifactVersionsValidation:
             "experiment_type": "smoke_test",
             "organization_slug": "acme",
             "run_id": "run-2",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
             "prior_artifact_versions": {
                 "smoke_dep": "smoke_dep/other-org-run-id/artifact.json/../secrets.txt",
@@ -1227,6 +1270,7 @@ class TestPriorArtifactVersionsValidation:
             "experiment_type": "smoke_test",
             "organization_slug": "acme",
             "run_id": "run-3",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
             "prior_artifact_versions": {
                 "smoke_dep": "smoke_dep/abc-123/latest.json",
@@ -1240,6 +1284,7 @@ class TestPriorArtifactVersionsValidation:
             "experiment_type": "smoke_test",
             "organization_slug": "acme",
             "run_id": "run-4",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
             "prior_artifact_versions": {
                 "smoke_dep": "/abc-123/artifact.json",
@@ -1253,6 +1298,7 @@ class TestPriorArtifactVersionsValidation:
             "experiment_type": "smoke_test",
             "organization_slug": "acme",
             "run_id": "run-5",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
             "prior_artifact_versions": {
                 "smoke_dep": "smoke_dep/d188bc17-87bd-4fe0-9b45-d34d3b301d98/artifact.json",
@@ -1266,6 +1312,7 @@ class TestPriorArtifactVersionsValidation:
             "experiment_type": "smoke_dep",
             "organization_slug": "acme",
             "run_id": "run-6",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
         }
         result = parse_dispatch_message(json.dumps(body))
@@ -1276,6 +1323,7 @@ class TestPriorArtifactVersionsValidation:
             "experiment_type": "smoke_dep",
             "organization_slug": "acme",
             "run_id": "run-7",
+            "clerk_user_id": "user_test_dispatch",
             "params": {},
             "prior_artifact_versions": "not-a-dict",
         }
@@ -1317,6 +1365,7 @@ class TestEcsErrorCallbackDoesNotLeakRawDetail:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-iam-leak",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -1357,6 +1406,7 @@ class TestEcsErrorCallbackDoesNotLeakRawDetail:
             "experiment_type": "smoke_test",
             "organization_slug": "org-123",
             "run_id": "run-iam-exc-leak",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -1406,6 +1456,7 @@ class TestEcsErrorCallbackDoesNotLeakRawDetail:
                 "experiment_type": "smoke_test",
                 "organization_slug": "org-123",
                 "run_id": "run-log-detail",
+            "clerk_user_id": "user_test_dispatch",
                 "params": dict(VALID_PARAMS),
             })
             handler(event, None)
@@ -1445,6 +1496,7 @@ class TestRunTaskFailureCleansUpMintedTicket:
             "experiment_type": "smoke_test",
             "organization_slug": "org-x",
             "run_id": "run-ecs-cap",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -1470,6 +1522,7 @@ class TestRunTaskFailureCleansUpMintedTicket:
             "experiment_type": "smoke_test",
             "organization_slug": "org-x",
             "run_id": "run-ecs-boom",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -1496,6 +1549,7 @@ class TestRunTaskFailureCleansUpMintedTicket:
             "experiment_type": "smoke_test",
             "organization_slug": "org-x",
             "run_id": "run-double-fail",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -1523,6 +1577,7 @@ class TestRunTaskFailureCleansUpMintedTicket:
             "experiment_type": "smoke_test",
             "organization_slug": "org-x",
             "run_id": "run-ok",
+            "clerk_user_id": "user_test_dispatch",
             "params": dict(VALID_PARAMS),
         })
 
@@ -1587,6 +1642,7 @@ class TestInputSchemaSortKeyMixedTypes:
             "experiment_type": "smoke_test",
             "organization_slug": "org-mixed",
             "run_id": "run-mixed-paths",
+            "clerk_user_id": "user_test_dispatch",
             # Errors fall on: items (wrong type), items[0].id (missing),
             # name (missing). Paths mix str and int.
             "params": {"items": [{}, {"id": 42}]},
@@ -1625,6 +1681,7 @@ class TestInputSchemaSortKeyMixedTypes:
             "experiment_type": "smoke_test",
             "organization_slug": "org-fmt",
             "run_id": "run-fmt-check",
+            "clerk_user_id": "user_test_dispatch",
             # items[1].id is the wrong type (int instead of string).
             "params": {"items": [{"id": "ok"}, {"id": 42}], "name": "alice"},
         })


### PR DESCRIPTION
## Why

The broker half of the agent platform's authenticated tool surface. The runner (Fargate, no internet egress, empty IAM) needs to talk to gp-api on behalf of its assigned user. The broker holds the Clerk session, mints fresh JWTs per outbound call, and proxies MCP traffic — so the runner never sees a credential it could exfiltrate, and gp-api just sees a normal user-acting request.

Design doc: https://goodparty.clickup.com/90132012119/v/dc/2ky4jq2q-20493/2ky4jq2q-69013
Companion PR (gp-api side): thegoodparty/gp-api#1548

## What it adds

- **`ClerkClient` wrapper** with two operations: redeem an actor-token URL into a Clerk session ID (Frontend API), and mint a fresh ~60s session JWT from a session ID (Backend API). The session is durable; JWTs are minted just-in-time per outbound request.
- **`POST /agent/mcp` proxy endpoint.** Runner sends MCP/Streamable-HTTP traffic here with `X-Broker-Token`. Broker resolves the scope ticket, mints a fresh JWT via `clerk.mint_session_jwt(session_id)`, forwards the body to `<GP_API_BASE_URL>/agent/mcp` with `Authorization: Bearer <jwt>`. `X-Broker-Token` is explicitly NOT forwarded.
- **`ScopeTicket.clerk_session_id`** — populated at mint time when the dispatch Lambda redeems the actor-token URL via `redeem_actor_token`. Round-trips through DynamoDB alongside the existing `prior_artifact_versions` field.
- **`MintRequest.actor_token_url`** — required field on the dispatch Lambda → `/internal/mint-run-token` payload. Broker calls Clerk Frontend API to redeem.
- **TTL ceiling raised to 48h** (`MAX_TTL_SECONDS = 172800`), comfortably within Clerk's default 7-day session lifetime.

## Key design choices

- **Broker is the JWT factory; runner never sees one.** Storing only the session ID (not a JWT) in DynamoDB means we don't have to handle JWT rotation inside a no-egress runner — broker mints fresh on every call.
- **Outbound headers are explicit allowlist**: only `Content-Type` and `Authorization`. Test asserts `X-Broker-Token` does not leak.
- **No JWT caching** for MVP — adds ~50ms Clerk roundtrip per call. Easy to add request-scoped cache later if it becomes a measurable bottleneck.

## Required env vars

- `CLERK_SECRET_KEY` — Clerk Backend API key (in `broker-{env}` secret).
- `CLERK_FRONTEND_API_BASE` — base URL for the Frontend API.
- `GP_API_BASE_URL` — per-env (e.g. `https://gp-api-dev.goodparty.org`).
- `AGENT_FLEET_CLERK_ID` — must match gp-api's value.

## Follow-ups (non-blocking)

- The Clerk Frontend API redemption response shape is parsed against two known key paths (`response.created_session_id`, `client.last_active_session_id`). A real dev probe will confirm; if a different shape surfaces, the parser fails cleanly with `missing session id` rather than silently breaking.
- Response passthrough only forwards `Content-Type`. If future MCP transport modes need to surface `mcp-session-id` or SSE headers, extend the response constructor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new user-impersonation flow (Clerk session/JWT minting) and a new proxy endpoint, plus persists a new auth-related field in DynamoDB and expands required secrets; failures could impact agent connectivity and authorization if misconfigured.
> 
> **Overview**
> Adds **Clerk integration for agent impersonation** via a new `ClerkClient` that redeems a gp-api-provided actor token URL into a durable `clerk_session_id`, and mints short-lived session JWTs on demand.
> 
> Updates `POST /internal/mint-run-token` to require `actor_token_url`, redeem it during mint, store `clerk_session_id` on the `ScopeTicket` (DynamoDB round-trip), and raises the max TTL ceiling to 48h.
> 
> Introduces a new `/agent/mcp` proxy endpoint that resolves the ticket via `X-Broker-Token`, mints a fresh Clerk JWT per request, forwards the request body to `<GP_API_BASE_URL>/agent/mcp` with an explicit header allowlist, and returns upstream status/body (with tests asserting `X-Broker-Token` never leaks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ae873dd8693253d51bcc90a5905dc9210d0d00c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->