### PR TITLE
Remove agent-experiment-metadata publish OIDC roles

### DIFF
--- a/infrastructure/environments/dev/agent-experiment-metadata/main.tf
+++ b/infrastructure/environments/dev/agent-experiment-metadata/main.tf
@@ -21,20 +21,10 @@ provider "aws" {
   region = "us-west-2"
 }
 
-# OIDC provider was created by shared/github-actions-iam. Look it up by URL
-# rather than via remote_state so this env doesn't depend on that state file
-# being readable from this stack.
-data "aws_iam_openid_connect_provider" "github" {
-  url = "https://token.actions.githubusercontent.com"
-}
-
 module "agent_experiment_metadata" {
   source = "../../../modules/agent-experiment-metadata"
 
-  environment              = "dev"
-  github_oidc_provider_arn = data.aws_iam_openid_connect_provider.github.arn
-  publishing_repo          = "thegoodparty/runbooks"
-  publish_branch           = "dev"
+  environment = "dev"
 }
 
 output "bucket_name" {
@@ -47,8 +37,4 @@ output "bucket_arn" {
 
 output "read_policy_arn" {
   value = module.agent_experiment_metadata.read_policy_arn
-}
-
-output "publish_role_arn" {
-  value = module.agent_experiment_metadata.publish_role_arn
 }

--- a/infrastructure/environments/prod/agent-experiment-metadata/main.tf
+++ b/infrastructure/environments/prod/agent-experiment-metadata/main.tf
@@ -21,20 +21,10 @@ provider "aws" {
   region = "us-west-2"
 }
 
-# OIDC provider was created by shared/github-actions-iam. Look it up by URL
-# rather than via remote_state so this env doesn't depend on that state file
-# being readable from this stack.
-data "aws_iam_openid_connect_provider" "github" {
-  url = "https://token.actions.githubusercontent.com"
-}
-
 module "agent_experiment_metadata" {
   source = "../../../modules/agent-experiment-metadata"
 
-  environment              = "prod"
-  github_oidc_provider_arn = data.aws_iam_openid_connect_provider.github.arn
-  publishing_repo          = "thegoodparty/runbooks"
-  publish_branch           = "main"
+  environment = "prod"
 }
 
 output "bucket_name" {
@@ -47,8 +37,4 @@ output "bucket_arn" {
 
 output "read_policy_arn" {
   value = module.agent_experiment_metadata.read_policy_arn
-}
-
-output "publish_role_arn" {
-  value = module.agent_experiment_metadata.publish_role_arn
 }

--- a/infrastructure/environments/qa/agent-experiment-metadata/main.tf
+++ b/infrastructure/environments/qa/agent-experiment-metadata/main.tf
@@ -21,20 +21,10 @@ provider "aws" {
   region = "us-west-2"
 }
 
-# OIDC provider was created by shared/github-actions-iam. Look it up by URL
-# rather than via remote_state so this env doesn't depend on that state file
-# being readable from this stack.
-data "aws_iam_openid_connect_provider" "github" {
-  url = "https://token.actions.githubusercontent.com"
-}
-
 module "agent_experiment_metadata" {
   source = "../../../modules/agent-experiment-metadata"
 
-  environment              = "qa"
-  github_oidc_provider_arn = data.aws_iam_openid_connect_provider.github.arn
-  publishing_repo          = "thegoodparty/runbooks"
-  publish_branch           = "qa"
+  environment = "qa"
 }
 
 output "bucket_name" {
@@ -47,8 +37,4 @@ output "bucket_arn" {
 
 output "read_policy_arn" {
   value = module.agent_experiment_metadata.read_policy_arn
-}
-
-output "publish_role_arn" {
-  value = module.agent_experiment_metadata.publish_role_arn
 }

--- a/infrastructure/modules/agent-experiment-metadata/main.tf
+++ b/infrastructure/modules/agent-experiment-metadata/main.tf
@@ -19,27 +19,10 @@ variable "environment" {
   }
 }
 
-variable "github_oidc_provider_arn" {
-  description = "ARN of the existing GitHub Actions OIDC provider (created in shared/github-actions-iam). Pass via remote_state lookup."
-  type        = string
-}
-
-variable "publishing_repo" {
-  description = "GitHub repo (org/name) allowed to assume the publish role. Subject claim restricts to this repo."
-  type        = string
-  default     = "thegoodparty/runbooks"
-}
-
-variable "publish_branch" {
-  description = "Git branch in publishing_repo allowed to assume the publish role. Branch-per-env model: dev branch publishes to dev bucket, qa to qa, main to prod."
-  type        = string
-}
-
 data "aws_caller_identity" "current" {}
 
 locals {
   bucket_name      = "agent-experiment-metadata-${var.environment}"
-  publish_role     = "agent-experiment-metadata-publish-${var.environment}"
   read_policy_name = "AgentExperimentMetadataRead-${var.environment}"
 }
 
@@ -135,81 +118,6 @@ resource "aws_iam_policy" "metadata_read" {
 }
 
 # ---------------------------------------------------------------------------
-# IAM: GitHub Actions OIDC role for the runbooks repo to publish manifests.
-# Trust narrowed to the publishing_repo via the `sub` claim.
-# ---------------------------------------------------------------------------
-
-resource "aws_iam_role" "publish" {
-  name = local.publish_role
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Federated = var.github_oidc_provider_arn
-        }
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Condition = {
-          # Pin trust to ONE branch per env: dev branch can only mint dev
-          # bucket creds; qa branch only qa; main branch only prod. AWS
-          # rejects an assume-role attempt from any other branch, so a
-          # workflow_dispatch from a feature branch or a misconfigured push
-          # cannot publish to the wrong env. Anyone with merge-to-<branch>
-          # rights can still trigger a publish to that env — that's a
-          # separate (social/branch-protection) gate.
-          StringEquals = {
-            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
-            "token.actions.githubusercontent.com:sub" = "repo:${var.publishing_repo}:ref:refs/heads/${var.publish_branch}"
-          }
-        }
-      }
-    ]
-  })
-
-  tags = {
-    Name        = "agent-experiment-metadata-publish-${var.environment}"
-    Environment = var.environment
-    Purpose     = "Allow runbooks GitHub Actions to publish PMF experiment manifests"
-  }
-}
-
-resource "aws_iam_role_policy" "publish_write" {
-  name = "publish-write"
-  role = aws_iam_role.publish.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid      = "ListBucket"
-        Effect   = "Allow"
-        Action   = ["s3:ListBucket"]
-        Resource = [aws_s3_bucket.metadata.arn]
-      },
-      {
-        # No DeleteObject by design. The bucket has versioning + 30-day
-        # noncurrent lifecycle; bad publishes are rolled back by publishing
-        # a new version, never by hard-deleting. Removing an experiment is
-        # done by deleting its directory in the runbooks repo and re-running
-        # publish (which omits it from index.json) — the orphan files in S3
-        # are harmless because the dispatcher routes off index.json. This
-        # blocks the `aws s3 rm --recursive` blast radius from a
-        # compromised branch.
-        Sid    = "ReadWriteObjects"
-        Effect = "Allow"
-        Action = [
-          "s3:PutObject",
-          "s3:GetObject"
-        ]
-        Resource = ["${aws_s3_bucket.metadata.arn}/*"]
-      }
-    ]
-  })
-}
-
-# ---------------------------------------------------------------------------
 # Outputs
 # ---------------------------------------------------------------------------
 
@@ -226,9 +134,4 @@ output "bucket_arn" {
 output "read_policy_arn" {
   description = "Managed IAM policy ARN granting read access. Attach to: Fargate task role, dispatch Lambda role, gp-api ECS task role."
   value       = aws_iam_policy.metadata_read.arn
-}
-
-output "publish_role_arn" {
-  description = "IAM role ARN for runbooks GitHub Actions to assume via OIDC for publishing manifests."
-  value       = aws_iam_role.publish.arn
 }

--- a/infrastructure/modules/agent-experiment-metadata/main.tf
+++ b/infrastructure/modules/agent-experiment-metadata/main.tf
@@ -19,8 +19,6 @@ variable "environment" {
   }
 }
 
-data "aws_caller_identity" "current" {}
-
 locals {
   bucket_name      = "agent-experiment-metadata-${var.environment}"
   read_policy_name = "AgentExperimentMetadataRead-${var.environment}"


### PR DESCRIPTION
## Summary

- Removes the env-specific `agent-experiment-metadata-publish-{dev,qa,prod}` IAM roles and their inline write policies from the `agent-experiment-metadata` Terraform module + all three env wrappers.
- The runbooks `publish-experiments.yml` workflow moved to the shared `github-actions-pulumi-deploy` role in [thegoodparty/runbooks#19](https://github.com/thegoodparty/runbooks/pull/19), so these env-specific roles are no longer assumed by any consumer.
- Bucket, lifecycle, and read-side IAM policy (consumed by `broker` + `pmf_engine`) are untouched.

## Plan output (per env)

```
# module.agent_experiment_metadata.aws_iam_role.publish will be destroyed
# module.agent_experiment_metadata.aws_iam_role_policy.publish_write will be destroyed
Plan: 0 to add, 0 to change, 2 to destroy.
```

Same plan for `environments/{dev,qa,prod}/agent-experiment-metadata`. No incidental drift.

## Apply order

1. Merge this PR.
2. Apply `environments/dev/agent-experiment-metadata` (runbooks `develop` already moved off the dev role).
3. After the runbooks PR equivalent lands on the `qa` branch → apply qa.
4. After it lands on `main` (or confirm `main` never used this role — currently `publish-experiments.yml` is absent on `origin/main`) → apply prod.

## Test plan

- [ ] CI green on this branch.
- [ ] `terraform plan` for each env wrapper shows exactly `0 add / 0 change / 2 destroy`.
- [ ] After apply, confirm `aws iam get-role --role-name agent-experiment-metadata-publish-<env>` returns `NoSuchEntity`.
- [ ] Confirm runbooks `publish-experiments.yml` still succeeds on the matching branch (using the shared role).
- [ ] Confirm `broker` and `pmf_engine` continue to read manifests from the bucket (read-side policy unaffected).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes IAM roles/policies used for writing to the S3 metadata buckets; if any workflows or users still assume these roles, publishing will fail until they switch to the new shared role.
> 
> **Overview**
> Removes the GitHub Actions OIDC publishing path from `modules/agent-experiment-metadata` by deleting the `publish` IAM role, its write policy, and the `publish_role_arn` output.
> 
> Updates the `dev`/`qa`/`prod` environment wrappers to stop looking up the GitHub OIDC provider and to stop passing publish-related module inputs, leaving only `environment` and the read-side outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 496638e161cf1f10338d3dba52217d98a67db9c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->