### PR TITLE
feat(broker): Playwright + stealth for /http/fetch and /pdf/fetch

### DIFF
--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -16,6 +16,8 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
@@ -24,8 +26,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder /app/.venv /app/.venv
 COPY --from=builder /app/broker /app/broker
 
+# Install Chromium + its OS deps. `--with-deps` shells out to apt to install
+# the system libraries Chromium needs (libnss3, libatk-bridge2.0-0, fonts,
+# etc.). Run as root before switching to the broker user.
+RUN /app/.venv/bin/playwright install --with-deps chromium
+
 RUN useradd -m -s /bin/bash broker && \
-    chown -R broker:broker /app
+    chown -R broker:broker /app /ms-playwright
 
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH="/app"

--- a/broker/browser_fetcher.py
+++ b/broker/browser_fetcher.py
@@ -1,0 +1,225 @@
+"""Browser-rendered fetch with stealth. Drop-in replacement for the httpx
+fetch path that was previously used by `/http/fetch` and `/pdf/fetch`.
+
+Why: plain httpx is 403'd by Cloudflare's JS challenge on many municipal
+agenda sites (e.g. CivicEngage, alvin.gov). A real Chromium + stealth
+fingerprint patches gets through, then captures the response — including
+PDFs that arrive as Content-Disposition: attachment downloads, not as the
+navigation response.
+
+DI shape: endpoints depend on the `BrowserFetcher` protocol so tests can
+inject an in-memory fake. Production wiring constructs a single
+`PlaywrightBrowserFetcher` at app startup (browser kept warm across requests,
+fresh context per request) and registers it via FastAPI dependency_overrides.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from typing import Protocol
+
+from fastapi import HTTPException
+
+from broker.ssrf_guard import validate_url
+
+logger = logging.getLogger(__name__)
+
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+
+NAVIGATION_TIMEOUT_MS = 45_000
+DOWNLOAD_WAIT_MS = 30_000
+POST_NAV_SETTLE_MS = 1_500
+
+
+@dataclass(frozen=True)
+class BrowserFetchResult:
+    status: int
+    content_type: str
+    body: bytes
+    final_url: str
+
+
+class BrowserFetcher(Protocol):
+    async def fetch(
+        self,
+        url: str,
+        *,
+        capture_download: bool = False,
+    ) -> BrowserFetchResult: ...
+
+
+class PlaywrightBrowserFetcher:
+    """Persistent Chromium + stealth, one context per fetch.
+
+    Cold-launch is ~3s; we pay it once at app startup. Each fetch opens a
+    fresh `BrowserContext` (isolated cookies/storage), applies stealth to the
+    new page, and intercepts every outbound request through `context.route`
+    so we can reject SSRF attempts mid-flight (intermediate redirect hops,
+    sub-resources, etc.) — the same posture the previous httpx path enforced
+    via per-hop validation in `resolve_redirects`.
+
+    `capture_download=True` is for endpoints (like /pdf/fetch) that need to
+    grab the file when the upstream sends Content-Disposition: attachment.
+    page.goto() raises with "Download is starting" in that case and the bytes
+    arrive via the `download` event — see the working reference at
+    /tmp/fetch_alvin_stealth.py (Alvin TX agenda PDF).
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._playwright = None
+        self._browser = None
+
+    async def start(self) -> None:
+        from playwright.async_api import async_playwright
+
+        self._playwright = await async_playwright().start()
+        self._browser = await self._playwright.chromium.launch(
+            headless=True,
+            args=["--disable-blink-features=AutomationControlled", "--no-sandbox"],
+        )
+
+    async def aclose(self) -> None:
+        if self._browser is not None:
+            await self._browser.close()
+            self._browser = None
+        if self._playwright is not None:
+            await self._playwright.stop()
+            self._playwright = None
+
+    async def fetch(
+        self,
+        url: str,
+        *,
+        capture_download: bool = False,
+    ) -> BrowserFetchResult:
+        from playwright.async_api import Download, Route
+        from playwright.async_api import Error as PlaywrightError
+        from playwright_stealth import stealth_async  # type: ignore[import-untyped]
+
+        if self._browser is None:
+            raise RuntimeError(
+                "PlaywrightBrowserFetcher.start() must be awaited before fetch()"
+            )
+
+        violations: list[str] = []
+
+        async def _route_handler(route: Route) -> None:
+            req_url = route.request.url
+            try:
+                await validate_url(req_url)
+            except HTTPException as e:
+                violations.append(f"{req_url}: {e.detail}")
+                await route.abort()
+                return
+            await route.continue_()
+
+        context = await self._browser.new_context(
+            user_agent=USER_AGENT,
+            accept_downloads=True,
+            viewport={"width": 1280, "height": 800},
+        )
+        page = await context.new_page()
+        try:
+            await stealth_async(page)
+            await context.route("**/*", _route_handler)
+
+            downloads: list[Download] = []
+            page.on("download", lambda d: downloads.append(d))
+
+            response = None
+            nav_error: Exception | None = None
+            try:
+                response = await page.goto(url, timeout=NAVIGATION_TIMEOUT_MS)
+            except PlaywrightError as e:
+                nav_error = e
+
+            if violations:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"SSRF blocked mid-fetch: {violations[0]}",
+                )
+
+            if capture_download:
+                # The download path is normal here — page.goto raises when
+                # navigation becomes a download. Wait briefly for the event.
+                if not downloads:
+                    for _ in range(int(DOWNLOAD_WAIT_MS / 100)):
+                        if downloads:
+                            break
+                        await page.wait_for_timeout(100)
+
+                if downloads:
+                    dl = downloads[0]
+                    final_url = dl.url
+                    try:
+                        await validate_url(final_url)
+                    except HTTPException:
+                        raise
+                    tmp_path = tempfile.mktemp(suffix=".bin")
+                    try:
+                        await dl.save_as(tmp_path)
+                        with open(tmp_path, "rb") as f:
+                            body = f.read()
+                    finally:
+                        try:
+                            os.unlink(tmp_path)
+                        except OSError:
+                            pass
+                    return BrowserFetchResult(
+                        status=200,
+                        content_type="application/pdf",
+                        body=body,
+                        final_url=final_url,
+                    )
+
+                # No download fired — fall through to treat as a regular page
+                # response. If nav_error is set, the upstream actually failed.
+                if nav_error is not None:
+                    raise HTTPException(
+                        status_code=502,
+                        detail=f"upstream navigation failed: {nav_error}",
+                    )
+
+            if nav_error is not None:
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"upstream navigation failed: {nav_error}",
+                )
+
+            if response is None:
+                raise HTTPException(
+                    status_code=502,
+                    detail="upstream returned no response",
+                )
+
+            await page.wait_for_timeout(POST_NAV_SETTLE_MS)
+
+            status = response.status
+            content_type = (
+                (response.headers.get("content-type") or "")
+                .split(";")[0]
+                .strip()
+                or "application/octet-stream"
+            )
+            body = await response.body()
+            final_url = page.url
+
+            return BrowserFetchResult(
+                status=status,
+                content_type=content_type,
+                body=body,
+                final_url=final_url,
+            )
+        finally:
+            try:
+                await context.close()
+            except Exception:
+                logger.warning("failed to close browser context", exc_info=True)

--- a/broker/endpoints/http_fetch.py
+++ b/broker/endpoints/http_fetch.py
@@ -2,20 +2,18 @@ from __future__ import annotations
 
 import logging
 
-import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from broker.browser_fetcher import BrowserFetcher
 from broker.dynamodb_client import ScopeTicket
-from broker.ssrf_guard import resolve_redirects
+from broker.ssrf_guard import validate_url
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/http", tags=["http"])
 
 MAX_BYTES = 10 * 1024 * 1024  # 10 MB
-FETCH_TIMEOUT = 30.0
-MAX_REDIRECTS = 5
 
 
 class HttpFetchRequest(BaseModel):
@@ -35,7 +33,7 @@ def get_scope_ticket() -> ScopeTicket:  # pragma: no cover
     raise NotImplementedError("Must be overridden via dependency_overrides")
 
 
-def get_httpx_client() -> httpx.AsyncClient:  # pragma: no cover
+def get_browser_fetcher() -> BrowserFetcher:  # pragma: no cover
     raise NotImplementedError("Must be overridden via dependency_overrides")
 
 
@@ -43,48 +41,34 @@ def get_httpx_client() -> httpx.AsyncClient:  # pragma: no cover
 async def http_fetch(
     req: HttpFetchRequest,
     ticket: ScopeTicket = Depends(get_scope_ticket),
-    client: httpx.AsyncClient = Depends(get_httpx_client),
+    fetcher: BrowserFetcher = Depends(get_browser_fetcher),
 ):
-    try:
-        resp, current_url = await resolve_redirects(
-            client, "GET", req.url, FETCH_TIMEOUT, MAX_REDIRECTS
-        )
-    except httpx.HTTPError as e:
-        logger.warning(
-            "http_fetch upstream error run_id=%s url=%s: %s",
-            ticket.run_id, req.url, e,
-        )
-        raise HTTPException(status_code=502, detail=f"upstream request failed: {e}")
+    await validate_url(req.url)
 
-    content_length_header = resp.headers.get("content-length")
-    if content_length_header is not None:
-        try:
-            cl = int(content_length_header)
-        except ValueError:
-            cl = None
-        if cl is not None and cl > MAX_BYTES:
-            raise HTTPException(status_code=413, detail=f"response too large: {cl} > {MAX_BYTES}")
+    result = await fetcher.fetch(req.url, capture_download=False)
 
-    raw = resp.content or b""
-    if len(raw) > MAX_BYTES:
-        raise HTTPException(status_code=413, detail=f"response exceeded {MAX_BYTES} bytes")
+    await validate_url(result.final_url)
+
+    if len(result.body) > MAX_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"response exceeded {MAX_BYTES} bytes",
+        )
 
     try:
-        body_text = raw.decode("utf-8")
+        body_text = result.body.decode("utf-8")
     except UnicodeDecodeError:
-        body_text = raw.decode("utf-8", errors="replace")
+        body_text = result.body.decode("utf-8", errors="replace")
 
     logger.info(
         "http_fetch ok run_id=%s status=%d bytes=%d purpose=%s url=%s",
-        ticket.run_id, resp.status_code, len(raw), req.purpose or "", req.url,
+        ticket.run_id, result.status, len(result.body), req.purpose or "", req.url,
     )
 
-    content_type = (resp.headers.get("content-type") or "").split(";")[0].strip() or "application/octet-stream"
-
     return HttpFetchResponse(
-        status=resp.status_code,
-        content_type=content_type,
+        status=result.status,
+        content_type=result.content_type,
         body=body_text,
-        source_url=current_url,
-        byte_size=len(raw),
+        source_url=result.final_url,
+        byte_size=len(result.body),
     )

--- a/broker/endpoints/pdf_fetch.py
+++ b/broker/endpoints/pdf_fetch.py
@@ -2,23 +2,19 @@ from __future__ import annotations
 
 import logging
 
-import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
+from broker.browser_fetcher import BrowserFetcher
 from broker.dynamodb_client import ScopeTicket
-from broker.ssrf_guard import resolve_redirects
+from broker.ssrf_guard import validate_url
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/pdf", tags=["pdf"])
 
 MAX_BYTES = 250 * 1024 * 1024  # 250 MB
-STREAM_CHUNK = 64 * 1024
-HEAD_TIMEOUT = 10.0
-STREAM_TIMEOUT = 180.0
-MAX_REDIRECTS = 5
 
 
 class PdfFetchRequest(BaseModel):
@@ -30,7 +26,7 @@ def get_scope_ticket() -> ScopeTicket:  # pragma: no cover
     raise NotImplementedError("Must be overridden via dependency_overrides")
 
 
-def get_httpx_client() -> httpx.AsyncClient:  # pragma: no cover
+def get_browser_fetcher() -> BrowserFetcher:  # pragma: no cover
     raise NotImplementedError("Must be overridden via dependency_overrides")
 
 
@@ -38,98 +34,39 @@ def get_httpx_client() -> httpx.AsyncClient:  # pragma: no cover
 async def pdf_fetch(
     req: PdfFetchRequest,
     ticket: ScopeTicket = Depends(get_scope_ticket),
-    client: httpx.AsyncClient = Depends(get_httpx_client),
+    fetcher: BrowserFetcher = Depends(get_browser_fetcher),
 ):
-    try:
-        head, current_url = await resolve_redirects(
-            client, "HEAD", req.url, HEAD_TIMEOUT, MAX_REDIRECTS
-        )
-    except httpx.HTTPError as e:
-        raise HTTPException(status_code=502, detail=f"HEAD request failed: {e}")
+    await validate_url(req.url)
 
-    if head.status_code >= 400:
-        raise HTTPException(status_code=502, detail=f"Upstream HEAD returned {head.status_code}")
+    result = await fetcher.fetch(req.url, capture_download=True)
 
-    content_type = (head.headers.get("content-type") or "").split(";")[0].strip().lower()
-    if content_type != "application/pdf":
+    await validate_url(result.final_url)
+
+    if result.content_type != "application/pdf":
         raise HTTPException(
             status_code=415,
-            detail=f"Upstream content-type is {content_type!r}, expected application/pdf",
+            detail=f"Upstream content-type is {result.content_type!r}, expected application/pdf",
         )
 
-    content_length_header = head.headers.get("content-length")
-    content_length: int | None = None
-    if content_length_header is not None:
-        try:
-            content_length = int(content_length_header)
-        except ValueError:
-            content_length = None
-        if content_length is not None and content_length > MAX_BYTES:
-            raise HTTPException(
-                status_code=413,
-                detail=f"PDF too large: {content_length} bytes > {MAX_BYTES}",
-            )
+    if len(result.body) > MAX_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"PDF too large: {len(result.body)} bytes > {MAX_BYTES}",
+        )
 
-    # GET uses the already-validated final URL (current_url) — redirect chain
-    # was resolved by the HEAD loop above. follow_redirects=False prevents the
-    # GET from chasing any new redirects beyond what HEAD approved.
-    # Enter the stream context manually so we can inspect status + headers
-    # BEFORE constructing StreamingResponse. Once StreamingResponse is built
-    # and returned, Starlette has committed status 200 to the wire — any raise
-    # inside the generator becomes a truncated body with a 200 status.
-    stream_ctx = client.stream("GET", current_url, timeout=STREAM_TIMEOUT, follow_redirects=False)
-    try:
-        resp = await stream_ctx.__aenter__()
-    except httpx.HTTPError as e:
-        raise HTTPException(status_code=502, detail=f"GET request failed: {e}")
-
-    try:
-        if resp.status_code >= 400:
-            raise HTTPException(
-                status_code=502,
-                detail=f"Upstream GET returned {resp.status_code}",
-            )
-
-        get_content_length_header = resp.headers.get("content-length")
-        if get_content_length_header is not None:
-            try:
-                get_cl = int(get_content_length_header)
-            except ValueError:
-                get_cl = None
-            if get_cl is not None and get_cl > MAX_BYTES:
-                raise HTTPException(
-                    status_code=413,
-                    detail=f"PDF too large: {get_cl} bytes > {MAX_BYTES}",
-                )
-    except BaseException:
-        await stream_ctx.__aexit__(None, None, None)
-        raise
-
-    async def _iter():
-        bytes_seen = 0
-        try:
-            async for chunk in resp.aiter_bytes(STREAM_CHUNK):
-                bytes_seen += len(chunk)
-                if bytes_seen > MAX_BYTES:
-                    # Status 200 is already on the wire — can't 413 now.
-                    # Truncate cleanly and log; downstream will see a short PDF.
-                    logger.warning(
-                        "pdf_fetch truncated at byte cap run_id=%s url=%s bytes_seen=%d cap=%d",
-                        ticket.run_id, req.url, bytes_seen, MAX_BYTES,
-                    )
-                    return
-                yield chunk
-            logger.info(
-                "pdf_fetch ok run_id=%s purpose=%s bytes=%d url=%s",
-                ticket.run_id, req.purpose or "", bytes_seen, req.url,
-            )
-        finally:
-            await stream_ctx.__aexit__(None, None, None)
+    logger.info(
+        "pdf_fetch ok run_id=%s purpose=%s bytes=%d url=%s",
+        ticket.run_id, req.purpose or "", len(result.body), req.url,
+    )
 
     headers = {
         "X-Source-URL": req.url,
+        "X-Byte-Size": str(len(result.body)),
     }
-    if content_length is not None:
-        headers["X-Byte-Size"] = str(content_length)
+
+    body = result.body
+
+    async def _iter():
+        yield body
 
     return StreamingResponse(_iter(), media_type="application/pdf", headers=headers)

--- a/broker/main.py
+++ b/broker/main.py
@@ -58,15 +58,16 @@ from broker.endpoints.delete_run_token import (
     router as delete_router,
 )
 from broker.endpoints.pdf_fetch import (
-    get_httpx_client as pdf_get_httpx_client,
+    get_browser_fetcher as pdf_get_browser_fetcher,
     get_scope_ticket as pdf_get_scope_ticket,
     router as pdf_router,
 )
 from broker.endpoints.http_fetch import (
-    get_httpx_client as http_get_httpx_client,
+    get_browser_fetcher as http_get_browser_fetcher,
     get_scope_ticket as http_get_scope_ticket,
     router as http_router,
 )
+from broker.browser_fetcher import PlaywrightBrowserFetcher  # noqa: I001
 from broker.endpoints.run_status import (
     get_artifact_bucket as status_get_artifact_bucket,
     get_broker_token_raw as status_get_broker_token_raw,
@@ -129,9 +130,12 @@ async def lifespan(app: FastAPI):
     upstream_client = httpx.AsyncClient(base_url="https://api.anthropic.com", timeout=300)
     s3_client = boto3.client("s3")
     sqs_client = boto3.client("sqs")
-    # Shared async client for pdf_fetch and http_fetch. Both endpoints are
-    # `async def` and use httpx.AsyncClient's await/async-with APIs.
+    # Shared async client used by anthropic_proxy and agent_mcp_proxy. The
+    # pdf_fetch / http_fetch endpoints now route through PlaywrightBrowserFetcher
+    # below — plain httpx is 403'd by Cloudflare's JS challenge on muni sites.
     http_client = httpx.AsyncClient(timeout=30)
+    browser_fetcher = PlaywrightBrowserFetcher()
+    await browser_fetcher.start()
     callback_sender = CallbackSender(sqs_client=sqs_client, queue_url=secrets.results_queue_url)
     # Per-ticket counter feeding the artifact_publish anti-fabrication gate.
     # Process-local; broker restart mid-run rejects publish (strictly safer
@@ -210,10 +214,10 @@ async def lifespan(app: FastAPI):
     app.dependency_overrides[exp_get_experiment_metadata_bucket] = lambda: experiment_metadata_bucket
 
     app.dependency_overrides[pdf_get_scope_ticket] = _resolve_ticket_from_request
-    app.dependency_overrides[pdf_get_httpx_client] = lambda: http_client
+    app.dependency_overrides[pdf_get_browser_fetcher] = lambda: browser_fetcher
 
     app.dependency_overrides[http_get_scope_ticket] = _resolve_ticket_from_request
-    app.dependency_overrides[http_get_httpx_client] = lambda: http_client
+    app.dependency_overrides[http_get_browser_fetcher] = lambda: browser_fetcher
 
     app.dependency_overrides[agent_mcp_get_scope_ticket] = _resolve_ticket_from_request
     app.dependency_overrides[agent_mcp_get_clerk_client] = lambda: clerk_client
@@ -225,6 +229,7 @@ async def lifespan(app: FastAPI):
     await upstream_client.aclose()
     await http_client.aclose()
     await clerk_client.aclose()
+    await browser_fetcher.aclose()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/broker/pyproject.toml
+++ b/broker/pyproject.toml
@@ -12,4 +12,6 @@ dependencies = [
     "python-multipart>=0.0.20",
     "pydantic>=2.0.0",
     "databricks-sql-connector>=4.0.5",
+    "playwright>=1.59.0,<1.60.0",
+    "tf-playwright-stealth>=1.2.0,<2.0.0",
 ]

--- a/broker/tests/test_http_fetch.py
+++ b/broker/tests/test_http_fetch.py
@@ -1,14 +1,13 @@
 import time
-from unittest.mock import AsyncMock, MagicMock
+from dataclasses import dataclass, field
 
-import httpx
-import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
+from broker.browser_fetcher import BrowserFetchResult
 from broker.dynamodb_client import ScopeTicket
 from broker.endpoints.http_fetch import (
-    get_httpx_client,
+    get_browser_fetcher,
     get_scope_ticket,
     router,
 )
@@ -31,37 +30,34 @@ def _make_ticket() -> ScopeTicket:
     )
 
 
-def _create_app(
-    response_body: bytes = b'[{"EventId": 1, "EventBodyName": "City Council"}]',
-    response_status: int = 200,
-    content_type: str = "application/json",
-    content_length_override: str | None = None,
-    get_side_effect: Exception | None = None,
-) -> FastAPI:
+@dataclass
+class _FakeFetcher:
+    result: BrowserFetchResult | None = None
+    raise_exc: Exception | None = None
+    calls: list[tuple[str, bool]] = field(default_factory=list)
+
+    async def fetch(self, url: str, *, capture_download: bool = False) -> BrowserFetchResult:
+        self.calls.append((url, capture_download))
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        assert self.result is not None, "test must configure result or raise_exc"
+        return self.result
+
+
+def _create_app(fetcher: _FakeFetcher | None = None) -> FastAPI:
     app = FastAPI()
     app.include_router(router)
-
     app.dependency_overrides[get_scope_ticket] = _make_ticket
-
-    mock_client = MagicMock(spec=httpx.AsyncClient)
-    if get_side_effect:
-        mock_client.get = AsyncMock(side_effect=get_side_effect)
-    else:
-        headers = {"content-type": content_type}
-        if content_length_override is not None:
-            headers["content-length"] = content_length_override
-        else:
-            headers["content-length"] = str(len(response_body))
-        mock_client.get = AsyncMock(
-            return_value=httpx.Response(
-                status_code=response_status,
-                content=response_body,
-                headers=headers,
-                request=httpx.Request("GET", "https://example.com/x"),
+    if fetcher is None:
+        fetcher = _FakeFetcher(
+            result=BrowserFetchResult(
+                status=200,
+                content_type="application/json",
+                body=b'[{"EventId": 1, "EventBodyName": "City Council"}]',
+                final_url="https://hendersonville-nc.municodemeetings.com/",
             )
         )
-
-    app.dependency_overrides[get_httpx_client] = lambda: mock_client
+    app.dependency_overrides[get_browser_fetcher] = lambda: fetcher
     return app
 
 
@@ -72,8 +68,7 @@ class TestPublicDomainsAllowed:
     (see TestSSRFGuards below)."""
 
     def test_accepts_any_public_com_domain(self):
-        app = _create_app()
-        client = TestClient(app)
+        client = TestClient(_create_app())
         resp = client.post(
             "/http/fetch",
             json={"url": "https://hendersonville-nc.municodemeetings.com/"},
@@ -82,8 +77,15 @@ class TestPublicDomainsAllowed:
         assert resp.status_code == 200
 
     def test_accepts_gov_domain(self):
-        app = _create_app()
-        client = TestClient(app)
+        fetcher = _FakeFetcher(
+            result=BrowserFetchResult(
+                status=200,
+                content_type="application/json",
+                body=b'{"records": []}',
+                final_url="https://linc.osbm.nc.gov/api/records",
+            )
+        )
+        client = TestClient(_create_app(fetcher))
         resp = client.post(
             "/http/fetch",
             json={"url": "https://linc.osbm.nc.gov/api/records"},
@@ -93,11 +95,17 @@ class TestPublicDomainsAllowed:
 
 
 class TestSSRFGuards:
-    """Block SSRF into private / metadata / loopback IPs. Mirrors pdf_fetch."""
+    """Block SSRF into private / metadata / loopback IPs.
+
+    Post-Playwright migration: intra-fetch redirect SSRF is enforced inside
+    PlaywrightBrowserFetcher's route handler (see test_browser_fetcher). The
+    endpoint pre-validates the input URL and post-validates the final URL the
+    fetcher returns — both defense-in-depth even if the route handler also
+    aborted in flight.
+    """
 
     def test_rejects_rfc1918_private_ips(self):
-        app = _create_app()
-        client = TestClient(app)
+        client = TestClient(_create_app())
         for url in [
             "https://10.0.0.5/api",
             "https://192.168.1.1/api",
@@ -111,8 +119,7 @@ class TestSSRFGuards:
             assert resp.status_code == 400, f"expected 400 for {url}, got {resp.status_code}"
 
     def test_rejects_aws_and_ecs_metadata_endpoints(self):
-        app = _create_app()
-        client = TestClient(app)
+        client = TestClient(_create_app())
         for url in [
             "https://169.254.169.254/latest/meta-data/",
             "https://169.254.170.2/v2/credentials",
@@ -125,11 +132,7 @@ class TestSSRFGuards:
             assert resp.status_code == 400, f"expected 400 for {url}"
 
     def test_rejects_ipv4_mapped_ipv6_metadata(self):
-        """::ffff:169.254.169.254 is IPv4-mapped IPv6 pointing at IMDS.
-        Python's IPv6Address.is_private returns False for mapped v4 ranges,
-        so without explicit ipv4_mapped handling this bypasses the guard."""
-        app = _create_app()
-        client = TestClient(app)
+        client = TestClient(_create_app())
         for url in [
             "https://[::ffff:169.254.169.254]/latest/meta-data/",
             "https://[::ffff:10.0.0.1]/api",
@@ -140,12 +143,11 @@ class TestSSRFGuards:
                 json={"url": url},
                 headers={"X-Broker-Token": BROKER_TOKEN},
             )
-            assert resp.status_code == 400, f"expected 400 for {url}, got {resp.status_code}"
+            assert resp.status_code == 400, f"expected 400 for {url}"
             assert "blocked address range" in resp.json().get("detail", "")
 
     def test_rejects_loopback(self):
-        app = _create_app()
-        client = TestClient(app)
+        client = TestClient(_create_app())
         for url in ["https://127.0.0.1/api", "https://localhost/api"]:
             resp = client.post(
                 "/http/fetch",
@@ -154,260 +156,90 @@ class TestSSRFGuards:
             )
             assert resp.status_code == 400, f"expected 400 for {url}"
 
-
-class TestSSRFRedirectReValidation:
-    """Upstream redirects are attacker-controlled. If httpx follows redirects
-    transparently, an allowed public URL can 302 to http://169.254.169.254
-    (AWS IMDS) or http://10.x.x.x (internal services) and the broker's
-    pre-request _validate_url has been bypassed entirely. Each redirect hop
-    must pass validation or the request is rejected.
-    """
-
-    def _redirect_response(self, location: str) -> httpx.Response:
-        return httpx.Response(
-            status_code=302,
-            headers={"location": location, "content-length": "0"},
-            content=b"",
-            request=httpx.Request("GET", "https://example.com/x"),
+    def test_rejects_when_browser_lands_on_private_ip(self):
+        """If the browser's final URL resolves to a private IP (post-redirect),
+        the endpoint must reject the response before returning the body. This
+        is the second SSRF gate, after the input-URL check and the route
+        handler's per-request abort."""
+        fetcher = _FakeFetcher(
+            result=BrowserFetchResult(
+                status=200,
+                content_type="application/json",
+                body=b"{}",
+                final_url="https://10.0.0.5/internal",
+            )
         )
-
-    def _ok_response(self) -> httpx.Response:
-        body = b'{"ok": true}'
-        return httpx.Response(
-            status_code=200,
-            content=body,
-            headers={"content-type": "application/json", "content-length": str(len(body))},
-            request=httpx.Request("GET", "https://example.com/x"),
-        )
-
-    def _create_app_with_redirects(self, responses: list[httpx.Response]) -> FastAPI:
-        app = FastAPI()
-        app.include_router(router)
-        app.dependency_overrides[get_scope_ticket] = _make_ticket
-
-        mock_client = MagicMock(spec=httpx.AsyncClient)
-        mock_client.get = AsyncMock(side_effect=responses)
-        app.dependency_overrides[get_httpx_client] = lambda: mock_client
-        return app
-
-    def test_redirect_to_imds_is_rejected(self):
-        app = self._create_app_with_redirects([
-            self._redirect_response("https://169.254.169.254/latest/meta-data/"),
-        ])
-        client = TestClient(app)
-
+        client = TestClient(_create_app(fetcher))
         resp = client.post(
             "/http/fetch",
-            json={"url": "https://example.com/legitimate"},
-            headers={"X-Broker-Token": BROKER_TOKEN},
-        )
-        assert resp.status_code == 400
-        assert "169.254" in resp.json()["detail"] or "blocked" in resp.json()["detail"].lower()
-
-    def test_redirect_to_rfc1918_is_rejected(self):
-        app = self._create_app_with_redirects([
-            self._redirect_response("https://10.0.0.5/internal"),
-        ])
-        client = TestClient(app)
-
-        resp = client.post(
-            "/http/fetch",
-            json={"url": "https://example.com/legitimate"},
+            json={"url": "https://example.com/start"},
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
         assert resp.status_code == 400
 
-    def test_redirect_to_public_host_is_followed(self):
-        """Legitimate redirects to other public hosts still work."""
-        app = self._create_app_with_redirects([
-            self._redirect_response("https://example.com/final"),
-            self._ok_response(),
-        ])
-        client = TestClient(app)
 
+class TestResponseShape:
+    def test_returns_body_and_metadata(self):
+        body = b'{"hello": "world"}'
+        fetcher = _FakeFetcher(
+            result=BrowserFetchResult(
+                status=200,
+                content_type="application/json",
+                body=body,
+                final_url="https://example.com/final",
+            )
+        )
+        client = TestClient(_create_app(fetcher))
         resp = client.post(
             "/http/fetch",
-            json={"url": "https://example.com/initial"},
+            json={"url": "https://example.com/start"},
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
         assert resp.status_code == 200
-        assert resp.json()["source_url"] == "https://example.com/final"
+        payload = resp.json()
+        assert payload["status"] == 200
+        assert payload["content_type"] == "application/json"
+        assert payload["body"] == body.decode("utf-8")
+        assert payload["source_url"] == "https://example.com/final"
+        assert payload["byte_size"] == len(body)
 
-    def test_redirect_loop_cap(self):
-        """Cap redirects at a low count. An attacker can't hold the broker
-        in an endless redirect chain to burn resources."""
-        app = self._create_app_with_redirects([
-            self._redirect_response(f"https://example.com/hop-{i}") for i in range(10)
-        ])
-        client = TestClient(app)
-
+    def test_body_size_cap_rejects_oversized_response(self):
+        oversized = b"x" * (10 * 1024 * 1024 + 1)
+        fetcher = _FakeFetcher(
+            result=BrowserFetchResult(
+                status=200,
+                content_type="text/plain",
+                body=oversized,
+                final_url="https://example.com/big",
+            )
+        )
+        client = TestClient(_create_app(fetcher))
         resp = client.post(
             "/http/fetch",
-            json={"url": "https://example.com/initial"},
-            headers={"X-Broker-Token": BROKER_TOKEN},
-        )
-        assert resp.status_code == 400
-        assert "redirect" in resp.json()["detail"].lower()
-
-    def test_relative_location_header_follows_correctly(self):
-        """RFC 7231 permits relative Location values. Raw assignment treats
-        `/redirected/path` as a full URL, losing the scheme+host — the next
-        _validate_url call then 400s with 'URL must use https scheme'.
-        urljoin(current_url, location) resolves root-relative against the
-        current URL's scheme+host."""
-        app = self._create_app_with_redirects([
-            self._redirect_response("/redirected/path"),
-            self._ok_response(),
-        ])
-        client = TestClient(app)
-
-        resp = client.post(
-            "/http/fetch",
-            json={"url": "https://example.com/initial"},
-            headers={"X-Broker-Token": BROKER_TOKEN},
-        )
-        assert resp.status_code == 200, (
-            f"expected 200 following relative redirect, got {resp.status_code} "
-            f"detail={resp.json().get('detail')}"
-        )
-        assert resp.json()["source_url"] == "https://example.com/redirected/path"
-
-    def test_protocol_relative_location_header_follows_correctly(self):
-        """Protocol-relative Location (`//other.example.com/foo`) must inherit
-        the scheme of the current URL. urljoin handles this; raw assignment
-        produces a schemeless URL that the SSRF guard rejects."""
-        app = self._create_app_with_redirects([
-            self._redirect_response("//www.example.com/foo"),
-            self._ok_response(),
-        ])
-        client = TestClient(app)
-
-        resp = client.post(
-            "/http/fetch",
-            json={"url": "https://example.com/initial"},
-            headers={"X-Broker-Token": BROKER_TOKEN},
-        )
-        assert resp.status_code == 200, (
-            f"expected 200 following protocol-relative redirect, got {resp.status_code} "
-            f"detail={resp.json().get('detail')}"
-        )
-        assert resp.json()["source_url"] == "https://www.example.com/foo"
-
-    def test_validate_url_called_for_initial_url_and_every_redirect_hop(self, monkeypatch):
-        """Regression guard against a refactor that drops per-hop validation.
-        Without this assertion, a refactor that moves validate_url back out of
-        the loop (or sets follow_redirects=True) could pass the existing tests
-        because they only check the FINAL outcome — not that the SSRF guard
-        actually ran on each hop's URL.
-        """
-        from broker import ssrf_guard
-
-        validated: list[str] = []
-        real_validate = ssrf_guard.validate_url
-
-        async def spy_validate(url: str) -> None:
-            validated.append(url)
-            await real_validate(url)
-
-        monkeypatch.setattr(ssrf_guard, "validate_url", spy_validate)
-
-        app = self._create_app_with_redirects([
-            self._redirect_response("https://example.com/hop-1"),
-            self._redirect_response("https://example.com/hop-2"),
-            self._ok_response(),
-        ])
-        client = TestClient(app)
-
-        resp = client.post(
-            "/http/fetch",
-            json={"url": "https://example.com/initial"},
-            headers={"X-Broker-Token": BROKER_TOKEN},
-        )
-        assert resp.status_code == 200
-        # Initial URL + each redirect target = 3 validations.
-        assert validated == [
-            "https://example.com/initial",
-            "https://example.com/hop-1",
-            "https://example.com/hop-2",
-        ]
-
-
-class TestUrlValidation:
-    def test_rejects_http_scheme(self):
-        app = _create_app()
-        client = TestClient(app)
-        resp = client.post(
-            "/http/fetch",
-            json={"url": "http://webapi.legistar.com/v1/x"},
-            headers={"X-Broker-Token": BROKER_TOKEN},
-        )
-        assert resp.status_code == 400
-        assert "https" in resp.json()["detail"].lower()
-
-
-class TestSizeGuards:
-    def test_rejects_oversized_content_length(self):
-        app = _create_app(content_length_override=str(11 * 1024 * 1024))
-        client = TestClient(app)
-        resp = client.post(
-            "/http/fetch",
-            json={"url": "https://linc.osbm.nc.gov/big.json"},
+            json={"url": "https://example.com/big"},
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
         assert resp.status_code == 413
 
-
-class TestHappyPath:
-    def test_returns_body_and_metadata(self):
-        body = b'[{"EventId": 42, "EventBodyName": "City Council"}]'
-        app = _create_app(response_body=body, content_type="application/json")
-        client = TestClient(app)
-        resp = client.post(
-            "/http/fetch",
-            json={"url": "https://webapi.legistar.com/v1/cityoffayetteville/events"},
-            headers={"X-Broker-Token": BROKER_TOKEN},
+    def test_fetcher_upstream_error_returns_502(self):
+        fetcher = _FakeFetcher(
+            raise_exc=HTTPException(status_code=502, detail="upstream nav failed: timeout"),
         )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["status"] == 200
-        assert data["content_type"] == "application/json"
-        assert data["body"] == body.decode()
-        assert data["source_url"] == "https://webapi.legistar.com/v1/cityoffayetteville/events"
-
-    def test_passes_through_upstream_404(self):
-        app = _create_app(response_body=b"not found", response_status=404, content_type="text/plain")
-        client = TestClient(app)
+        client = TestClient(_create_app(fetcher))
         resp = client.post(
             "/http/fetch",
-            json={"url": "https://webapi.legistar.com/v1/missing"},
-            headers={"X-Broker-Token": BROKER_TOKEN},
-        )
-        # Proxy returns 200 with upstream status in body — lets agent decide how to handle
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["status"] == 404
-        assert data["body"] == "not found"
-
-
-class TestNetworkErrorHandling:
-    def test_upstream_connection_error_returns_502(self):
-        app = _create_app(get_side_effect=httpx.ConnectError("connection refused"))
-        client = TestClient(app)
-        resp = client.post(
-            "/http/fetch",
-            json={"url": "https://webapi.legistar.com/v1/x"},
+            json={"url": "https://example.com/x"},
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
         assert resp.status_code == 502
 
 
 class TestAuth:
-    def test_rejects_unauthenticated(self):
+    def test_rejects_unauthenticated_request(self):
         app = FastAPI()
         app.include_router(router)
 
         def _raise():
-            from fastapi import HTTPException
             raise HTTPException(status_code=401, detail="missing broker token")
 
         app.dependency_overrides[get_scope_ticket] = _raise

--- a/broker/tests/test_pdf_fetch.py
+++ b/broker/tests/test_pdf_fetch.py
@@ -1,19 +1,19 @@
 import time
-from unittest.mock import AsyncMock, MagicMock
+from dataclasses import dataclass, field
 
-import httpx
-import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
+from broker.browser_fetcher import BrowserFetchResult
 from broker.dynamodb_client import ScopeTicket
 from broker.endpoints.pdf_fetch import (
-    get_httpx_client,
+    get_browser_fetcher,
     get_scope_ticket,
     router,
 )
 
 BROKER_TOKEN = "broker-token-pdf-test"
+SOURCE_URL = "https://legistar.granicus.com/cityoffayetteville/x.pdf"
 
 
 def _make_ticket() -> ScopeTicket:
@@ -31,112 +31,104 @@ def _make_ticket() -> ScopeTicket:
     )
 
 
-def _build_head(status: int = 200, content_type: str = "application/pdf", content_length: str = "1024") -> httpx.Response:
-    return httpx.Response(
-        status_code=status,
-        headers={"content-type": content_type, "content-length": content_length},
-        request=httpx.Request("HEAD", "https://legistar.granicus.com/cityoffayetteville/x.pdf"),
-    )
+@dataclass
+class _FakeFetcher:
+    result: BrowserFetchResult | None = None
+    raise_exc: Exception | None = None
+    calls: list[tuple[str, bool]] = field(default_factory=list)
+
+    async def fetch(self, url: str, *, capture_download: bool = False) -> BrowserFetchResult:
+        self.calls.append((url, capture_download))
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        assert self.result is not None, "test must configure result or raise_exc"
+        return self.result
 
 
-def _build_get(bytes_payload: bytes, content_type: str = "application/pdf") -> httpx.Response:
-    return httpx.Response(
-        status_code=200,
-        headers={"content-type": content_type, "content-length": str(len(bytes_payload))},
-        content=bytes_payload,
-        request=httpx.Request("GET", "https://legistar.granicus.com/cityoffayetteville/x.pdf"),
-    )
-
-
-def _create_app(
-    ticket: ScopeTicket | None = None,
-    head: httpx.Response | None = None,
-    get: httpx.Response | None = None,
-    get_side_effect: Exception | None = None,
-    get_status: int = 200,
-    get_content_length: int | None = None,
-) -> FastAPI:
+def _create_app(fetcher: _FakeFetcher | None = None) -> FastAPI:
     app = FastAPI()
     app.include_router(router)
-
-    app.dependency_overrides[get_scope_ticket] = lambda: ticket or _make_ticket()
-
-    mock_client = MagicMock(spec=httpx.AsyncClient)
-    mock_client.head = AsyncMock(return_value=head or _build_head())
-    if get_side_effect:
-        mock_client.stream = MagicMock(side_effect=get_side_effect)
-    else:
-        body = get.content if get else b"%PDF-1.4 fake bytes"
-        cl = get_content_length if get_content_length is not None else len(body)
-        status = get_status
-        def _stream(method, url, **kw):
-            class _Ctx:
-                async def __aenter__(self_):
-                    resp = MagicMock()
-                    resp.status_code = status
-                    resp.headers = {
-                        "content-type": "application/pdf",
-                        "content-length": str(cl),
-                    }
-                    resp.aclose = AsyncMock(return_value=None)
-                    async def _iter(chunk_size=8192):
-                        for i in range(0, len(body), chunk_size):
-                            yield body[i:i + chunk_size]
-                    resp.aiter_bytes = _iter
-                    resp.raise_for_status = lambda: None
-                    return resp
-                async def __aexit__(self_, *a):
-                    return False
-            return _Ctx()
-        mock_client.stream = _stream
-
-    app.dependency_overrides[get_httpx_client] = lambda: mock_client
+    app.dependency_overrides[get_scope_ticket] = _make_ticket
+    if fetcher is None:
+        fetcher = _FakeFetcher(
+            result=BrowserFetchResult(
+                status=200,
+                content_type="application/pdf",
+                body=b"%PDF-1.4 fake bytes",
+                final_url=SOURCE_URL,
+            )
+        )
+    app.dependency_overrides[get_browser_fetcher] = lambda: fetcher
     return app
 
 
 class TestUrlValidation:
     def test_https_only_rejects_http(self):
-        app = _create_app()
-        client = TestClient(app)
-        resp = client.post("/pdf/fetch", json={"url": "http://legistar.granicus.com/cityoffayetteville/x.pdf"}, headers={"X-Broker-Token": BROKER_TOKEN})
+        client = TestClient(_create_app())
+        resp = client.post(
+            "/pdf/fetch",
+            json={"url": "http://legistar.granicus.com/cityoffayetteville/x.pdf"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
         assert resp.status_code == 400
         assert "https" in resp.json()["detail"].lower()
 
     def test_rejects_private_rfc1918(self):
-        app = _create_app()
-        client = TestClient(app)
+        client = TestClient(_create_app())
         for url in [
             "https://10.0.0.5/x.pdf",
             "https://192.168.1.1/x.pdf",
             "https://172.16.0.1/x.pdf",
         ]:
-            resp = client.post("/pdf/fetch", json={"url": url}, headers={"X-Broker-Token": BROKER_TOKEN})
+            resp = client.post(
+                "/pdf/fetch",
+                json={"url": url},
+                headers={"X-Broker-Token": BROKER_TOKEN},
+            )
             assert resp.status_code == 400, f"expected 400 for {url}, got {resp.status_code}"
 
     def test_rejects_link_local_and_metadata(self):
-        app = _create_app()
-        client = TestClient(app)
+        client = TestClient(_create_app())
         for url in [
             "https://169.254.169.254/latest/meta-data/",
             "https://169.254.170.2/v2/credentials",
             "https://127.0.0.1/x.pdf",
         ]:
-            resp = client.post("/pdf/fetch", json={"url": url}, headers={"X-Broker-Token": BROKER_TOKEN})
+            resp = client.post(
+                "/pdf/fetch",
+                json={"url": url},
+                headers={"X-Broker-Token": BROKER_TOKEN},
+            )
             assert resp.status_code == 400, f"expected 400 for {url}"
 
     def test_rejects_loopback_hostname(self):
-        app = _create_app()
-        client = TestClient(app)
-        resp = client.post("/pdf/fetch", json={"url": "https://localhost/x.pdf"}, headers={"X-Broker-Token": BROKER_TOKEN})
+        client = TestClient(_create_app())
+        resp = client.post(
+            "/pdf/fetch",
+            json={"url": "https://localhost/x.pdf"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+        assert resp.status_code == 400
+
+    def test_rejects_when_browser_lands_on_private_ip(self):
+        fetcher = _FakeFetcher(
+            result=BrowserFetchResult(
+                status=200,
+                content_type="application/pdf",
+                body=b"%PDF-1.4 bytes",
+                final_url="https://10.0.0.5/internal.pdf",
+            )
+        )
+        client = TestClient(_create_app(fetcher))
+        resp = client.post(
+            "/pdf/fetch",
+            json={"url": "https://example.com/start.pdf"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
         assert resp.status_code == 400
 
     def test_accepts_arbitrary_public_pdf_host(self):
-        # /pdf/fetch has no domain allowlist — only SSRF guards apply.
-        # PDF binaries flow to a runner with no egress, so domain restriction
-        # would not close any exfil risk class that WebFetch doesn't already open.
-        # (example.org resolves to a public IP, passing the SSRF guards.)
-        app = _create_app()
-        client = TestClient(app)
+        client = TestClient(_create_app())
         resp = client.post(
             "/pdf/fetch",
             json={"url": "https://example.org/report.pdf"},
@@ -147,181 +139,108 @@ class TestUrlValidation:
 
 class TestContentGuards:
     def test_rejects_non_pdf_content_type(self):
-        head = _build_head(content_type="text/html")
-        app = _create_app(head=head)
-        client = TestClient(app)
+        fetcher = _FakeFetcher(
+            result=BrowserFetchResult(
+                status=200,
+                content_type="text/html",
+                body=b"<html>not a pdf</html>",
+                final_url=SOURCE_URL,
+            )
+        )
+        client = TestClient(_create_app(fetcher))
         resp = client.post(
             "/pdf/fetch",
-            json={"url": "https://legistar.granicus.com/cityoffayetteville/x.pdf"},
+            json={"url": SOURCE_URL},
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
         assert resp.status_code == 415
         assert "pdf" in resp.json()["detail"].lower()
 
-    def test_rejects_oversized_content_length(self):
-        head = _build_head(content_length=str(260 * 1024 * 1024))
-        app = _create_app(head=head)
-        client = TestClient(app)
+    def test_rejects_oversized_pdf_body(self):
+        oversized = b"%PDF-1.4 " + b"x" * (251 * 1024 * 1024)
+        fetcher = _FakeFetcher(
+            result=BrowserFetchResult(
+                status=200,
+                content_type="application/pdf",
+                body=oversized,
+                final_url=SOURCE_URL,
+            )
+        )
+        client = TestClient(_create_app(fetcher))
         resp = client.post(
             "/pdf/fetch",
-            json={"url": "https://legistar.granicus.com/cityoffayetteville/x.pdf"},
+            json={"url": SOURCE_URL},
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
         assert resp.status_code == 413
-
-    def test_accepts_pdf_at_cap_boundary(self):
-        head = _build_head(content_length=str(250 * 1024 * 1024))
-        app = _create_app(head=head)
-        client = TestClient(app)
-        resp = client.post(
-            "/pdf/fetch",
-            json={"url": "https://legistar.granicus.com/cityoffayetteville/x.pdf"},
-            headers={"X-Broker-Token": BROKER_TOKEN},
-        )
-        assert resp.status_code == 200
-
-
-class TestRelativeRedirects:
-    """RFC 7231 permits relative Location values. The redirect loop must
-    resolve them against the current URL (urljoin), otherwise valid upstream
-    behavior breaks: raw assignment treats `/foo` as a scheme-less URL that
-    the SSRF guard rejects with 400 'URL must use https scheme'."""
-
-    def _redirect_head(self, location: str) -> httpx.Response:
-        return httpx.Response(
-            status_code=302,
-            headers={"location": location, "content-length": "0"},
-            request=httpx.Request("HEAD", "https://legistar.granicus.com/x.pdf"),
-        )
-
-    def _create_app_with_head_redirects(
-        self,
-        head_responses: list[httpx.Response],
-    ) -> FastAPI:
-        app = FastAPI()
-        app.include_router(router)
-        app.dependency_overrides[get_scope_ticket] = lambda: _make_ticket()
-
-        mock_client = MagicMock(spec=httpx.AsyncClient)
-        mock_client.head = AsyncMock(side_effect=head_responses)
-
-        body = b"%PDF-1.4 bytes"
-        def _stream(method, url, **kw):
-            class _Ctx:
-                async def __aenter__(self_):
-                    resp = MagicMock()
-                    resp.status_code = 200
-                    resp.headers = {
-                        "content-type": "application/pdf",
-                        "content-length": str(len(body)),
-                    }
-                    resp.aclose = AsyncMock(return_value=None)
-                    async def _iter(chunk_size=8192):
-                        for i in range(0, len(body), chunk_size):
-                            yield body[i:i + chunk_size]
-                    resp.aiter_bytes = _iter
-                    resp.raise_for_status = lambda: None
-                    return resp
-                async def __aexit__(self_, *a):
-                    return False
-            return _Ctx()
-        mock_client.stream = _stream
-
-        app.dependency_overrides[get_httpx_client] = lambda: mock_client
-        return app
-
-    def test_relative_location_header_follows_correctly(self):
-        app = self._create_app_with_head_redirects([
-            self._redirect_head("/redirected/report.pdf"),
-            _build_head(),
-        ])
-        client = TestClient(app)
-
-        resp = client.post(
-            "/pdf/fetch",
-            json={"url": "https://legistar.granicus.com/initial.pdf"},
-            headers={"X-Broker-Token": BROKER_TOKEN},
-        )
-        assert resp.status_code == 200, (
-            f"expected 200 following relative redirect, got {resp.status_code} "
-            f"detail={resp.text}"
-        )
-
-    def test_protocol_relative_location_header_follows_correctly(self):
-        app = self._create_app_with_head_redirects([
-            self._redirect_head("//www.example.com/report.pdf"),
-            _build_head(),
-        ])
-        client = TestClient(app)
-
-        resp = client.post(
-            "/pdf/fetch",
-            json={"url": "https://legistar.granicus.com/initial.pdf"},
-            headers={"X-Broker-Token": BROKER_TOKEN},
-        )
-        assert resp.status_code == 200, (
-            f"expected 200 following protocol-relative redirect, got {resp.status_code} "
-            f"detail={resp.text}"
-        )
 
 
 class TestStreamingProxy:
     def test_returns_pdf_bytes_and_headers(self):
         payload = b"%PDF-1.4 body bytes here"
-        app = _create_app(head=_build_head(content_length=str(len(payload))))
-        client = TestClient(app)
+        fetcher = _FakeFetcher(
+            result=BrowserFetchResult(
+                status=200,
+                content_type="application/pdf",
+                body=payload,
+                final_url=SOURCE_URL,
+            )
+        )
+        client = TestClient(_create_app(fetcher))
         resp = client.post(
             "/pdf/fetch",
-            json={"url": "https://legistar.granicus.com/cityoffayetteville/x.pdf", "purpose": "budget"},
+            json={"url": SOURCE_URL, "purpose": "budget"},
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
         assert resp.status_code == 200
         assert resp.headers["content-type"] == "application/pdf"
         assert resp.headers.get("x-byte-size") == str(len(payload))
-        assert resp.headers.get("x-source-url") == "https://legistar.granicus.com/cityoffayetteville/x.pdf"
+        assert resp.headers.get("x-source-url") == SOURCE_URL
+        assert resp.content == payload
 
-    def test_upstream_5xx_returns_502_not_200_with_truncated_body(self):
-        app = _create_app(get_status=500)
-        client = TestClient(app)
+    def test_fetcher_upstream_error_returns_502(self):
+        fetcher = _FakeFetcher(
+            raise_exc=HTTPException(status_code=502, detail="upstream nav failed"),
+        )
+        client = TestClient(_create_app(fetcher))
         resp = client.post(
             "/pdf/fetch",
-            json={"url": "https://legistar.granicus.com/cityoffayetteville/x.pdf"},
+            json={"url": SOURCE_URL},
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
-        assert resp.status_code == 502, (
-            f"expected 502 when upstream GET returns 500, got {resp.status_code} "
-            f"(StreamingResponse sent 200 headers before generator could raise)"
-        )
+        assert resp.status_code == 502
 
-    def test_get_content_length_exceeds_cap_returns_413_before_streaming(self):
-        # HEAD returns no content-length, so the HEAD-time check doesn't catch it.
-        # GET reveals content-length > MAX_BYTES — must 413 before committing to 200.
-        head = httpx.Response(
-            status_code=200,
-            headers={"content-type": "application/pdf"},
-            request=httpx.Request("HEAD", "https://legistar.granicus.com/cityoffayetteville/x.pdf"),
+    def test_fetcher_passes_capture_download_true(self):
+        """PDFs from sites with Content-Disposition: attachment arrive as
+        browser-triggered downloads, not as the navigation response. The
+        endpoint must ask the fetcher to capture downloads, not the page DOM."""
+        fetcher = _FakeFetcher(
+            result=BrowserFetchResult(
+                status=200,
+                content_type="application/pdf",
+                body=b"%PDF-1.4 ok",
+                final_url=SOURCE_URL,
+            )
         )
-        oversized = 260 * 1024 * 1024
-        app = _create_app(head=head, get_content_length=oversized)
-        client = TestClient(app)
+        client = TestClient(_create_app(fetcher))
         resp = client.post(
             "/pdf/fetch",
-            json={"url": "https://legistar.granicus.com/cityoffayetteville/x.pdf"},
+            json={"url": SOURCE_URL},
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
-        assert resp.status_code == 413, (
-            f"expected 413 when GET content-length exceeds cap, got {resp.status_code}"
-        )
+        assert resp.status_code == 200
+        assert fetcher.calls == [(SOURCE_URL, True)]
 
+
+class TestAuth:
     def test_rejects_unauthenticated_request(self):
         app = FastAPI()
         app.include_router(router)
 
         def _raise():
-            from fastapi import HTTPException
             raise HTTPException(status_code=401, detail="missing broker token")
 
         app.dependency_overrides[get_scope_ticket] = _raise
         client = TestClient(app)
-        resp = client.post("/pdf/fetch", json={"url": "https://legistar.granicus.com/cityoffayetteville/x.pdf"})
+        resp = client.post("/pdf/fetch", json={"url": SOURCE_URL})
         assert resp.status_code == 401

--- a/uv.lock
+++ b/uv.lock
@@ -888,6 +888,14 @@ wheels = [
 ]
 
 [[package]]
+name = "fake-http-header"
+version = "0.3.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/0b/2849c87d9f13766e29c0a2f4d31681aa72e035016b251ab19d99bde7b592/fake_http_header-0.3.5-py3-none-any.whl", hash = "sha256:cd05f4bebf1b7e38b5f5c03d7fb820c0c17e87d9614fbee0afa39c32c7a2ad3c", size = 14938, upload-time = "2024-10-15T07:27:10.671Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.119.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1360,9 +1368,11 @@ dependencies = [
     { name = "databricks-sql-connector" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "playwright" },
     { name = "pydantic" },
     { name = "python-multipart" },
     { name = "sqlglot" },
+    { name = "tf-playwright-stealth" },
     { name = "uvicorn" },
 ]
 
@@ -1372,9 +1382,11 @@ requires-dist = [
     { name = "databricks-sql-connector", specifier = ">=4.0.5" },
     { name = "fastapi", specifier = ">=0.116.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "playwright", specifier = ">=1.59.0,<1.60.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "sqlglot", specifier = ">=30.4.3" },
+    { name = "tf-playwright-stealth", specifier = ">=1.2.0,<2.0.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
 
@@ -1522,6 +1534,63 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.15.0" },
     { name = "seaborn", specifier = ">=0.13.2" },
     { name = "umap-learn", specifier = ">=0.5.7" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/0f/a91f143f356523ff682309732b175765a9bc2836fd7c081c2c67fedc1ad4/greenlet-3.5.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:8f1cc966c126639cd152fdaa52624d2655f492faa79e013fea161de3e6dda082", size = 284726, upload-time = "2026-04-27T12:20:51.402Z" },
+    { url = "https://files.pythonhosted.org/packages/95/82/800646c7ffc5dbabd75ddd2f6b519bb898c0c9c969e5d0473bfe5d20bcce/greenlet-3.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:362624e6a8e5bca3b8233e45eef33903a100e9539a2b995c364d595dbc4018b3", size = 604264, upload-time = "2026-04-27T12:52:39.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/354867c0bba812fc33b15bc55aedafedd0aee3c7dd91dfca22444157dc0c/greenlet-3.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5ecd83806b0f4c2f53b1018e0005cd82269ea01d42befc0368730028d850ed1c", size = 616099, upload-time = "2026-04-27T12:59:39.623Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ab/192090c4a5b30df148c22bf4b8895457d739a7c7c5a7b9c41e5dd7f537f2/greenlet-3.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa94cb2288681e3a11645958f1871d48ee9211bd2f66628fdace505927d6e564", size = 623976, upload-time = "2026-04-27T13:02:37.363Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/815bece7399e01cadb69014219eebd0042339875c59a59b0820a46ece356/greenlet-3.5.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ff251e9a0279522e62f6176412869395a64ddf2b5c5f782ff609a8216a4e662", size = 615198, upload-time = "2026-04-27T12:25:25.928Z" },
+    { url = "https://files.pythonhosted.org/packages/24/11/05eb2b9b188c6df7d68a89c99134d644a7af616a40b9808e8e6ced315d5d/greenlet-3.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:64d6ac45f7271f48e45f67c95b54ef73534c52ec041fcda8edf520c6d811f4bc", size = 418379, upload-time = "2026-04-27T13:05:12.755Z" },
+    { url = "https://files.pythonhosted.org/packages/10/80/3b2c0a895d6698f6ddb31b07942ebfa982f3e30888bc5546a5b5990de8b2/greenlet-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d874e79afd41a96e11ff4c5d0bc90a80973e476fda1c2c64985667397df432b", size = 1574927, upload-time = "2026-04-27T12:53:25.81Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0e/f354af514a4c61454dbc68e44d47544a5a4d6317e30b77ddfa3a09f4c5f3/greenlet-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0ed006e4b86c59de7467eb2601cd1b77b5a7d657d1ee55e30fe30d76451edba4", size = 1642683, upload-time = "2026-04-27T12:25:23.9Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/6a/87f38255201e993a1915265ebb80cd7c2c78b04a45744995abbf6b259fd8/greenlet-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:703cb211b820dbffbbc55a16bfc6e4583a6e6e990f33a119d2cc8b83211119c8", size = 238115, upload-time = "2026-04-27T12:21:48.845Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f8/450fe3c5938fa737ea4d22699772e6e34e8e24431a47bf4e8a1ceed4a98e/greenlet-3.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:6c18dfb59c70f5a94acd271c72e90128c3c776e41e5f07767908c8c1b74ad339", size = 235017, upload-time = "2026-04-27T12:22:26.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
 ]
 
 [[package]]
@@ -2805,6 +2874,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.59.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/48/abab23f40643b4de8f2665816f0a1bf0994eeecda39d6d62f0f292b2ad01/playwright-1.59.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:bfc6940100b57423175c819ce2422ec5880d55fa2769987f62ab7a1f5fe6783e", size = 43156922, upload-time = "2026-04-29T08:11:08.921Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/5e4d98b2ce3641b4343623c6450ff33b9de1c979d12a957505e392338b07/playwright-1.59.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:af068143a0c045ec11608b67d6c42e58db7e9cf65a742dd21fddedc1a9802c47", size = 41947177, upload-time = "2026-04-29T08:11:12.867Z" },
+    { url = "https://files.pythonhosted.org/packages/80/91/fd219aa78ca03d37e93aaedaed4e224131e3090a9264f9bb773c8271d67e/playwright-1.59.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:4a4a2d4842b0e4120de3fa48636e4b69085a05b81d8a35ad4353f530ade72ed6", size = 43156922, upload-time = "2026-04-29T08:11:16.595Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/1e513d37c5be07d12829ebce93dbfe7baee230084cb66966c423432799c4/playwright-1.59.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c5792aad9e22b91a09264b9edbc18553cf05ea5a39404d65dc19a012c6b2e51d", size = 47151793, upload-time = "2026-04-29T08:11:19.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2d/15f72288cb65d690134e18fefb9483cc4976f7579b580648c45e494481a7/playwright-1.59.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c881a19377d2b900af855fb525b5f22a27bf3cfbecba6d1edb36766d56cb100", size = 46877615, upload-time = "2026-04-29T08:11:23.863Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a1/717ac5bc99f387c0f60def91271ea4262125c0815d764a5d1776a272275c/playwright-1.59.0-py3-none-win32.whl", hash = "sha256:6989c476be2b9cd3e24a18cc9dcf202e266fb3d91e3e5395cd668c54ea54b119", size = 37713698, upload-time = "2026-04-29T08:11:27.251Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a5/4e630ee05d8b46b840f943268e86d6063703e8dadb2d3eb405c7b9b2e48c/playwright-1.59.0-py3-none-win_amd64.whl", hash = "sha256:d5a5cc064b82ca92996080025710844e417f44df8fda9001102c28f44174171c", size = 37713704, upload-time = "2026-04-29T08:11:30.41Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0c/3ece41761ba13c8321009aefcaec7a016eb42799c42eef5e03ace7f2de5b/playwright-1.59.0-py3-none-win_arm64.whl", hash = "sha256:93581ad515728cadc8af39b288a5633ba6d36e7d72048e79d890ce01ea2156f9", size = 33956745, upload-time = "2026-04-29T08:11:34.738Z" },
+]
+
+[[package]]
 name = "plotly"
 version = "6.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3196,6 +3284,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -4187,6 +4287,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "tf-playwright-stealth"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fake-http-header" },
+    { name = "playwright" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/6b/32bb58c65991f91aeaaf7473b650175d9d4af5dd383983d177d49ccba08d/tf_playwright_stealth-1.2.0.tar.gz", hash = "sha256:7bb8d32d3e60324fbf6b9eeae540b8cd9f3b9e07baeb33b025dbc98ad47658ba", size = 23362, upload-time = "2025-06-13T04:51:04.97Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/3d/2653f4cf49660bb44eeac8270617cc4c0287d61716f249f55053f0af0724/tf_playwright_stealth-1.2.0-py3-none-any.whl", hash = "sha256:26ee47ee89fa0f43c606fe37c188ea3ccd36f96ea90c01d167b768df457e7886", size = 33151, upload-time = "2025-06-13T04:51:03.769Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `/http/fetch` and `/pdf/fetch` now route through a persistent Chromium + `tf-playwright-stealth` instead of httpx.
- Reason: Cloudflare's JS challenge 403s plain httpx on muni sites (CivicEngage, alvin.gov, etc.). Reproducer: `https://www.alvin.gov/AgendaCenter/ViewFile/Agenda/_04162026-434` returns the challenge page on httpx, returns the 24 MB PDF via the new path.
- Same response shapes (`HttpFetchResponse`, `StreamingResponse application/pdf`) so no caller changes.
- `pdf_fetch` simplified: full body in memory before `StreamingResponse`, so size caps return clean 413s instead of mid-stream truncations.

## Trade-offs

- Latency: hundreds of ms → 2–5 s per request.
- Image size: ~250 MB → ~1.4 GB (Chromium + libs).
- Fargate memory: each task now needs +250–400 MB resident for the warm browser.

## Security posture

- Endpoint pre-checks `validate_url(input)` and post-checks `validate_url(final_url)`.
- Intra-fetch redirect SSRF enforced inside the fetcher via `context.route("**/*", ...)` aborting any request that fails `validate_url`.
- The egress SG remains the network-layer defense.

## Test plan

- [x] `uv run pytest broker/tests/` — 376 passed.
- [x] Endpoint tests rewritten against in-memory `_FakeFetcher`; redirect-chain tests removed (now a fetcher property, not endpoint behavior).
- [x] Manual: stealth path validated locally against Alvin TX agenda PDF.
- [ ] Smoke test dev ECS task after deploy: hit `/health`, then `/pdf/fetch` with the Alvin URL via an M2M token.

## Follow-ups (not in this PR)

- Unit tests for `PlaywrightBrowserFetcher` itself (route handler + download capture) — currently only `_FakeFetcher` is exercised.
- `test_main.py` boots a real Chromium via lifespan; should be patched to a no-op fake if CI ever runs the suite.
- DNS-rebinding TOCTOU gap (pre-existing per `ARCHITECTURE.md:325`) still open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps `httpx` fetching for a persistent headless Chromium, which materially changes runtime behavior (latency, memory/image size) and introduces a new browser attack surface despite SSRF defenses via `validate_url` and request interception.
> 
> **Overview**
> `/http/fetch` and `/pdf/fetch` are migrated from `httpx`-based fetching/redirect handling to a new `PlaywrightBrowserFetcher` that keeps a Chromium instance warm, applies `tf-playwright-stealth`, and can capture `Content-Disposition: attachment` downloads.
> 
> SSRF enforcement is moved from manual redirect-loop validation to browser-level request interception (`context.route`) plus input/final URL `validate_url` checks; `pdf_fetch` is simplified to buffer the full PDF before responding so oversize files return a clean `413`.
> 
> Container/runtime packaging is updated to install Playwright + Chromium (and OS deps) in the broker image, and tests are rewritten to use an injected fake fetcher instead of mocking `httpx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31213667fbb661477fca244b83a7303d4723ebdc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->