### PR TITLE
pmf attachments: publisher → broker → runner sidecar pipeline

### DIFF
--- a/broker/endpoints/experiment_manifest.py
+++ b/broker/endpoints/experiment_manifest.py
@@ -8,13 +8,16 @@ ticket's experiment_id is the only experiment a given run is allowed to see.
 import json
 import logging
 import os
+import re
 import time
+from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 
 import boto3
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from broker.dynamodb_client import ScopeTicket
 
@@ -25,8 +28,90 @@ router = APIRouter(prefix="/experiment", tags=["experiment"])
 EXPERIMENT_ID_PATTERN = r"^[a-z][a-z0-9_]{0,63}$"
 S3_VERSION_ID_PATTERN = r"^[A-Za-z0-9._\-]{1,1024}$"
 
-_OBJECT_CACHE: dict[tuple[str, str, str], tuple[bytes, str | None]] = {}
+# DoS / resource-exhaustion caps. Picked so a publisher accident (uploading
+# a PDF or an LLM dump) can't OOM the broker or saturate the fetch executor.
+#   - MAX_ATTACHMENT_BYTES: per-object size cap. Real publisher attachments
+#     today are <100 KB; 5 MiB gives plenty of headroom.
+#   - MAX_ATTACHMENTS_PER_EXPERIMENT: count cap. A well-behaved experiment
+#     ships 1-5 attachments; 32 covers the worst legitimate case and stops
+#     a malformed index from spawning thousands of GETs.
+#   - MAX_FETCH_WORKERS: shared thread pool bound. Replaces the old
+#     `max_workers = 2 + len(attachment_specs)` pattern that grew per request.
+MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024
+MAX_ATTACHMENTS_PER_EXPERIMENT = 32
+MAX_FETCH_WORKERS = 16
+
+# Module-level shared executor. Bound to MAX_FETCH_WORKERS so concurrent
+# requests share a fixed thread budget instead of each request spawning its
+# own ThreadPoolExecutor (which sums to unbounded threads under load).
+_FETCH_EXECUTOR: ThreadPoolExecutor | None = None
+
+
+def _get_fetch_executor() -> ThreadPoolExecutor:
+    """Lazy-init the shared fetch executor. Lazy so import-time doesn't
+    spawn threads (cleaner for unit-test startup)."""
+    global _FETCH_EXECUTOR
+    if _FETCH_EXECUTOR is None:
+        _FETCH_EXECUTOR = ThreadPoolExecutor(
+            max_workers=MAX_FETCH_WORKERS,
+            thread_name_prefix="broker-fetch",
+        )
+    return _FETCH_EXECUTOR
+
+
+def _reset_fetch_executor_for_test() -> None:
+    """Shut down + clear the shared executor so test isolation is clean."""
+    global _FETCH_EXECUTOR
+    if _FETCH_EXECUTOR is not None:
+        _FETCH_EXECUTOR.shutdown(wait=False)
+        _FETCH_EXECUTOR = None
+
+
+class _LRUCache:
+    """Bounded LRU cache for fetched S3 objects.
+
+    Replaces the old flush-on-full pattern (`.clear()` when full) — that
+    pattern evicted hot manifest/instruction entries every time a different
+    experiment caused the cache to overflow, defeating the cache's purpose.
+
+    Keys are (bucket, key, version_id). When the version_id is None
+    (unpinned), the bytes-at-S3 can change under us — those entries are
+    skipped entirely (see `_fetch_object_cached`). When a version_id is
+    pinned, the bytes are immutable per S3's contract — TTL=None on `get`
+    is correctness-safe.
+    """
+
+    def __init__(self, maxsize: int) -> None:
+        self._d: OrderedDict[tuple[Any, ...], tuple[bytes, str | None, float]] = OrderedDict()
+        self._maxsize = maxsize
+
+    def get(self, key: tuple[Any, ...], ttl: float | None) -> tuple[bytes, str | None] | None:
+        entry = self._d.get(key)
+        if entry is None:
+            return None
+        body, vid, inserted_at = entry
+        if ttl is not None and time.monotonic() - inserted_at > ttl:
+            self._d.pop(key, None)
+            return None
+        self._d.move_to_end(key)
+        return body, vid
+
+    def put(self, key: tuple[Any, ...], body: bytes, vid: str | None) -> None:
+        if key in self._d:
+            self._d.move_to_end(key)
+        self._d[key] = (body, vid, time.monotonic())
+        while len(self._d) > self._maxsize:
+            self._d.popitem(last=False)
+
+    def clear(self) -> None:
+        self._d.clear()
+
+    def __len__(self) -> int:
+        return len(self._d)
+
+
 _OBJECT_CACHE_MAX = 512
+_OBJECT_CACHE = _LRUCache(_OBJECT_CACHE_MAX)
 
 _INDEX_CACHE: dict[str, tuple[dict, float]] = {}
 _INDEX_TTL = 60.0
@@ -71,6 +156,26 @@ def _emit_metric(metric_name: str, dimensions: list[dict]) -> None:
         )
 
 
+ATTACHMENT_BASENAME_PATTERN = r"^[A-Za-z0-9._\-]{1,255}$"
+_ATTACHMENT_BASENAME_RE = re.compile(ATTACHMENT_BASENAME_PATTERN)
+
+
+def _is_safe_attachment_basename(name: object) -> bool:
+    """Single source of truth for "is this a safe attachment basename".
+
+    Three places need the same answer: the request validator (where keys
+    are checked against the basename pattern), the loop over the index
+    entry's `attachment_keys` (where we derive a basename from an S3 key),
+    and any future surface that maps user-supplied names into S3 keys.
+    Defining the rule once eliminates drift.
+    """
+    if not isinstance(name, str):
+        return False
+    if name in (".", ".."):
+        return False
+    return bool(_ATTACHMENT_BASENAME_RE.fullmatch(name))
+
+
 class ExperimentManifestRequest(BaseModel):
     experiment_id: str = Field(..., pattern=EXPERIMENT_ID_PATTERN)
     # Pin to specific S3 object versions (captured by the dispatch Lambda at
@@ -80,6 +185,37 @@ class ExperimentManifestRequest(BaseModel):
     # doesn't matter.
     manifest_version_id: str | None = Field(None, pattern=S3_VERSION_ID_PATTERN)
     instruction_version_id: str | None = Field(None, pattern=S3_VERSION_ID_PATTERN)
+    # Per-attachment VersionId pins, symmetric with manifest_version_id /
+    # instruction_version_id. Keys are basenames (matching the response's
+    # attachments dict); values are S3 VersionIds. Unset basenames fall
+    # through to "latest" per the same rules as the other two fields.
+    attachment_version_ids: dict[str, str] | None = None
+
+    @field_validator("attachment_version_ids")
+    @classmethod
+    def _validate_attachment_version_ids(
+        cls, v: dict[str, str] | None
+    ) -> dict[str, str] | None:
+        """Reject keys / values that don't match the basename / VersionId
+        patterns. Defends the S3 key construction below: we map a basename
+        to `<experiment_id>/attachments/<basename>`, and a key containing
+        '..' or '/' would point at an unrelated S3 object.
+
+        Uses `_is_safe_attachment_basename` for the key check so this
+        validator stays in sync with the index-loop's basename guard.
+        """
+        if v is None:
+            return v
+        version_re = re.compile(S3_VERSION_ID_PATTERN)
+        for name, version in v.items():
+            if not _is_safe_attachment_basename(name):
+                raise ValueError(f"attachment_version_ids key {name!r} is not a safe basename")
+            # Pydantic's dict[str,str] coerces non-string values to strings
+            # in lax mode; check the runtime type before the regex to keep
+            # rejections explicit.
+            if not isinstance(version, str) or not version_re.match(version):
+                raise ValueError(f"attachment_version_ids value for {name!r} is not a valid S3 VersionId")
+        return v
 
 
 class ExperimentManifestResponse(BaseModel):
@@ -90,6 +226,13 @@ class ExperimentManifestResponse(BaseModel):
     # VersionId weeks later (until S3 lifecycle expires noncurrent versions).
     resolved_manifest_version_id: str | None = None
     resolved_instruction_version_id: str | None = None
+    # Sidecar files published alongside the manifest. Keyed by basename
+    # (e.g. "reference_catalog.md") so the runner can write each one as
+    # /workspace/<basename> with no path translation. UTF-8 strings only —
+    # if binary attachments are ever needed, add a parallel
+    # `attachments_binary: dict[str, str]` (base64) rather than coercing.
+    attachments: dict[str, str] = Field(default_factory=dict)
+    resolved_attachment_version_ids: dict[str, str] = Field(default_factory=dict)
 
 
 def get_scope_ticket() -> ScopeTicket:  # pragma: no cover
@@ -97,6 +240,11 @@ def get_scope_ticket() -> ScopeTicket:  # pragma: no cover
 
 
 def get_s3_client():  # pragma: no cover
+    """Override in app wiring. Note for production wiring:
+    the real boto3 client should be constructed with
+    `Config(max_pool_connections=MAX_FETCH_WORKERS)` so the fetch
+    executor's threads don't starve on a small default urllib3 pool.
+    """
     raise NotImplementedError("Must be overridden via dependency_overrides")
 
 
@@ -110,8 +258,20 @@ def _fetch_object(
     key: str,
     ticket_run_id: str,
     version_id: str | None = None,
+    label: str = "object",
+    size_cap_bytes: int | None = None,
 ) -> tuple[bytes, str | None]:
-    """Returns (body_bytes, resolved_version_id)."""
+    """Returns (body_bytes, resolved_version_id).
+
+    `label` parameterizes the 404 detail so an attachment 404 doesn't read
+    "manifest not found" (misleading). The full S3 key is kept in the log
+    line (for debugging) but stripped from the public detail (it leaks
+    internal pathing — bucket layout, experiment_id, etc).
+
+    `size_cap_bytes`, when set, makes the read short-circuit any object
+    whose ContentLength (or actual body length, if ContentLength lies)
+    exceeds the cap. Defense against publisher accidents OOMing the broker.
+    """
     kwargs = {"Bucket": bucket, "Key": key}
     if version_id:
         kwargs["VersionId"] = version_id
@@ -120,20 +280,52 @@ def _fetch_object(
     except ClientError as e:
         code = e.response.get("Error", {}).get("Code", "")
         if code in ("NoSuchKey", "NoSuchVersion", "404"):
-            detail = (
-                f"manifest object not found: {key}"
-                + (f" (version {version_id})" if version_id else "")
+            logger.warning(
+                "S3 %s fetch returned 404 run_id=%s key=%s bucket=%s version_id=%s",
+                label, ticket_run_id, key, bucket, version_id,
             )
-            raise HTTPException(status_code=404, detail=detail)
+            # Public detail intentionally omits the S3 key — no internal
+            # pathing leaks across the broker boundary. Operators have the
+            # log line above for diagnostics.
+            raise HTTPException(status_code=404, detail=f"{label} not found") from e
         logger.error(
-            "S3 manifest fetch failed run_id=%s key=%s bucket=%s version_id=%s code=%s",
-            ticket_run_id, key, bucket, version_id, code, exc_info=True,
+            "S3 %s fetch failed run_id=%s key=%s bucket=%s version_id=%s code=%s",
+            label, ticket_run_id, key, bucket, version_id, code, exc_info=True,
         )
         _emit_metric("broker_s3_manifest_fetch_failure", [
             {"Name": "Environment", "Value": os.environ.get("ENVIRONMENT", "unknown")},
             {"Name": "error_code", "Value": code or "unknown"},
         ])
-        raise HTTPException(status_code=500, detail="manifest store unavailable")
+        raise HTTPException(status_code=500, detail="manifest store unavailable") from e
+    if size_cap_bytes is not None:
+        # ContentLength is reported by S3 on every GetObject; check it
+        # before reading so we short-circuit a 1 GB attachment without
+        # ever materializing the bytes in memory.
+        declared = response.get("ContentLength")
+        if isinstance(declared, int) and declared > size_cap_bytes:
+            logger.error(
+                "S3 %s exceeds size cap run_id=%s key=%s bucket=%s declared=%d cap=%d",
+                label, ticket_run_id, key, bucket, declared, size_cap_bytes,
+            )
+            _emit_metric("broker_attachment_size_cap_exceeded", [
+                {"Name": "Environment", "Value": os.environ.get("ENVIRONMENT", "unknown")},
+                {"Name": "label", "Value": label},
+            ])
+            raise HTTPException(status_code=502, detail=f"{label} exceeds size cap")
+        # Bounded read: even if ContentLength was missing or lying, asking
+        # for cap+1 bytes lets us detect oversize without holding gigabytes.
+        body = response["Body"].read(size_cap_bytes + 1)
+        if len(body) > size_cap_bytes:
+            logger.error(
+                "S3 %s body exceeds size cap (post-read) run_id=%s key=%s bucket=%s actual=%d cap=%d",
+                label, ticket_run_id, key, bucket, len(body), size_cap_bytes,
+            )
+            _emit_metric("broker_attachment_size_cap_exceeded", [
+                {"Name": "Environment", "Value": os.environ.get("ENVIRONMENT", "unknown")},
+                {"Name": "label", "Value": label},
+            ])
+            raise HTTPException(status_code=502, detail=f"{label} exceeds size cap")
+        return body, response.get("VersionId")
     return response["Body"].read(), response.get("VersionId")
 
 
@@ -143,22 +335,26 @@ def _fetch_object_cached(
     key: str,
     ticket_run_id: str,
     version_id: str | None,
+    label: str = "object",
+    size_cap_bytes: int | None = None,
 ) -> tuple[bytes, str | None]:
     """Cache wrapper around _fetch_object.
 
     Cache by (bucket, key, version_id) — when version_id is pinned, S3 bytes
-    are immutable, so the cache hit is correctness-safe. Skip cache when
-    version_id is None (dev/local "latest"), since latest can change under us.
+    are immutable per S3 contract, so the cache hit is correctness-safe and
+    we can use ttl=None. Skip cache when version_id is None (dev/local
+    "latest"), since latest can change under us.
     """
     if version_id is not None:
-        cached = _OBJECT_CACHE.get((bucket, key, version_id))
+        cached = _OBJECT_CACHE.get((bucket, key, version_id), ttl=None)
         if cached is not None:
             return cached
-    body, resolved_version = _fetch_object(s3_client, bucket, key, ticket_run_id, version_id)
+    body, resolved_version = _fetch_object(
+        s3_client, bucket, key, ticket_run_id, version_id,
+        label=label, size_cap_bytes=size_cap_bytes,
+    )
     if version_id is not None:
-        if len(_OBJECT_CACHE) >= _OBJECT_CACHE_MAX:
-            _OBJECT_CACHE.clear()
-        _OBJECT_CACHE[(bucket, key, version_id)] = (body, resolved_version)
+        _OBJECT_CACHE.put((bucket, key, version_id), body, resolved_version)
     return body, resolved_version
 
 
@@ -166,6 +362,12 @@ def _fetch_index_json(s3_client, bucket: str) -> dict:
     """Fetch index.json with a 60s TTL cache. On fetch failure, return stale
     cached value if present, else an empty experiments list — empty causes the
     orphan check to deny all manifests, which is safer than allowing them.
+
+    Both fallback paths emit `broker_index_fetch_failure` with a `fallback`
+    dimension so operators can alert on the empty-fallback case (= total
+    broker blackout: every manifest 404s until index.json comes back).
+    The stale-cache path is degraded but still serving, so it's a WARNING
+    log; the empty-fallback path is ERROR.
     """
     now = time.monotonic()
     cached = _INDEX_CACHE.get(bucket)
@@ -175,9 +377,25 @@ def _fetch_index_json(s3_client, bucket: str) -> dict:
         resp = s3_client.get_object(Bucket=bucket, Key="index.json")
         index = json.loads(resp["Body"].read())
     except Exception as e:
-        logger.warning("index.json fetch failed bucket=%s exc=%s", bucket, e, exc_info=True)
+        env = os.environ.get("ENVIRONMENT", "unknown")
         if cached:
+            logger.warning(
+                "index.json fetch failed bucket=%s exc=%s — falling back to stale cache",
+                bucket, e, exc_info=True,
+            )
+            _emit_metric("broker_index_fetch_failure", [
+                {"Name": "Environment", "Value": env},
+                {"Name": "fallback", "Value": "stale_cache"},
+            ])
             return cached[0]
+        logger.error(
+            "index.json fetch failed bucket=%s exc=%s — falling back to empty (broker blackout)",
+            bucket, e, exc_info=True,
+        )
+        _emit_metric("broker_index_fetch_failure", [
+            {"Name": "Environment", "Value": env},
+            {"Name": "fallback", "Value": "empty"},
+        ])
         return {"experiments": []}
     _INDEX_CACHE[bucket] = (index, now)
     return index
@@ -187,6 +405,25 @@ def _reset_caches_for_test() -> None:
     """Clear module-level caches between tests. Call from a fixture."""
     _OBJECT_CACHE.clear()
     _INDEX_CACHE.clear()
+
+
+def _emit_index_drift(experiment_id: str, run_id: str, drift_kind: str, detail: str) -> None:
+    """Single helper for the four index-drift error sites.
+
+    Index drift = publisher/control-plane bug: the canonical attachment
+    list contains something we can't safely fetch. Old code logged at
+    WARNING + silently `continue`d, so operators never saw it in
+    CloudWatch. Now it's ERROR + metric so SNS → Slack can alert.
+    """
+    logger.error(
+        "attachment_index_drift drift_kind=%s experiment_id=%s run_id=%s detail=%s",
+        drift_kind, experiment_id, run_id, detail,
+    )
+    _emit_metric("broker_attachment_index_drift", [
+        {"Name": "Environment", "Value": os.environ.get("ENVIRONMENT", "unknown")},
+        {"Name": "drift_kind", "Value": drift_kind},
+        {"Name": "experiment_id", "Value": experiment_id},
+    ])
 
 
 @router.post("/manifest", response_model=ExperimentManifestResponse)
@@ -218,7 +455,11 @@ def experiment_manifest(
     # those by checking against the canonical index.json.
     index = _fetch_index_json(s3_client, bucket)
     experiments = index.get("experiments", []) if isinstance(index, dict) else []
-    if not any(isinstance(e, dict) and e.get("id") == ticket.experiment_id for e in experiments):
+    index_entry = next(
+        (e for e in experiments if isinstance(e, dict) and e.get("id") == ticket.experiment_id),
+        None,
+    )
+    if index_entry is None:
         logger.error(
             "orphan_manifest_blocked experiment_id=%s run_id=%s",
             ticket.experiment_id, ticket.run_id,
@@ -232,24 +473,106 @@ def experiment_manifest(
     manifest_key = f"{req.experiment_id}/manifest.json"
     instruction_key = f"{req.experiment_id}/instruction.md"
 
-    # Parallelize the two GETs. When both VersionIds are pinned the cached
-    # path returns immediately so the ThreadPoolExecutor overhead is the only
-    # cost; when unpinned/uncached we cut latency roughly in half.
-    with ThreadPoolExecutor(max_workers=2) as ex:
-        fut_m = ex.submit(
-            _fetch_object_cached,
-            s3_client, bucket, manifest_key, ticket.run_id, req.manifest_version_id,
+    # The index entry lists every attachment key the publisher uploaded. Fetch
+    # only those — never trust a runner-supplied basename to map into an S3
+    # key. attachment_version_ids in the request acts as a per-basename pin
+    # override; absent entries fall through to "latest".
+    raw = index_entry.get("attachment_keys")
+    if raw is None:
+        raw_attachment_keys: list = []
+    elif isinstance(raw, list):
+        raw_attachment_keys = raw
+    else:
+        # Drift: a string here would have iterated character-by-character
+        # in the old code, producing nonsense S3 GETs per character.
+        _emit_index_drift(
+            ticket.experiment_id, ticket.run_id,
+            "non_list_attachment_keys", f"type={type(raw).__name__}",
         )
-        fut_i = ex.submit(
-            _fetch_object_cached,
-            s3_client, bucket, instruction_key, ticket.run_id, req.instruction_version_id,
+        raw_attachment_keys = []
+
+    attachment_specs: list[tuple[str, str, str | None]] = []  # (basename, s3_key, version_id)
+    requested_version_pins = req.attachment_version_ids or {}
+    prefix = f"{ticket.experiment_id}/attachments/"
+    for ak in raw_attachment_keys:
+        if not isinstance(ak, str):
+            _emit_index_drift(
+                ticket.experiment_id, ticket.run_id,
+                "non_string_key", f"type={type(ak).__name__}",
+            )
+            continue
+        # ak must be "<experiment_id>/attachments/<basename>". The publisher
+        # enforces this shape; this is defense-in-depth against a malformed
+        # index.json. Skip anything that doesn't match.
+        if not ak.startswith(prefix):
+            _emit_index_drift(
+                ticket.experiment_id, ticket.run_id,
+                "wrong_prefix", f"key={ak}",
+            )
+            continue
+        basename = ak[len(prefix):]
+        # Use the unified safe-basename rule — same check the request
+        # validator applies. Keeps the two surfaces in sync.
+        if not _is_safe_attachment_basename(basename):
+            _emit_index_drift(
+                ticket.experiment_id, ticket.run_id,
+                "unsafe_basename", f"basename={basename!r}",
+            )
+            continue
+        attachment_specs.append((basename, ak, requested_version_pins.get(basename)))
+
+    # Cap attachment count per experiment. A malformed index with thousands
+    # of keys would otherwise spawn thousands of futures on the shared
+    # executor. Truncate + alert; never silently grow.
+    if len(attachment_specs) > MAX_ATTACHMENTS_PER_EXPERIMENT:
+        logger.error(
+            "attachment_count_exceeded experiment_id=%s run_id=%s declared=%d cap=%d",
+            ticket.experiment_id, ticket.run_id,
+            len(attachment_specs), MAX_ATTACHMENTS_PER_EXPERIMENT,
         )
-        manifest_bytes, manifest_resolved_version = fut_m.result()
-        instruction_bytes, instruction_resolved_version = fut_i.result()
+        _emit_metric("broker_attachment_count_exceeded", [
+            {"Name": "Environment", "Value": os.environ.get("ENVIRONMENT", "unknown")},
+            {"Name": "experiment_id", "Value": ticket.experiment_id},
+        ])
+        attachment_specs = attachment_specs[:MAX_ATTACHMENTS_PER_EXPERIMENT]
+
+    # Parallelize manifest + instruction + every attachment GET via the
+    # shared, bounded fetch executor. Replaces per-request executors
+    # (which summed to unbounded threads under load). When all
+    # VersionIds are pinned the cached path returns immediately; when
+    # unpinned/uncached the executor cuts latency to ~max(fetch_time).
+    ex = _get_fetch_executor()
+    fut_m = ex.submit(
+        _fetch_object_cached,
+        s3_client, bucket, manifest_key, ticket.run_id, req.manifest_version_id,
+        "manifest", None,
+    )
+    fut_i = ex.submit(
+        _fetch_object_cached,
+        s3_client, bucket, instruction_key, ticket.run_id, req.instruction_version_id,
+        "instruction", None,
+    )
+    attachment_futures = [
+        (
+            basename,
+            ex.submit(
+                _fetch_object_cached,
+                s3_client, bucket, s3_key, ticket.run_id, version_id,
+                "attachment", MAX_ATTACHMENT_BYTES,
+            ),
+        )
+        for basename, s3_key, version_id in attachment_specs
+    ]
+    manifest_bytes, manifest_resolved_version = fut_m.result()
+    instruction_bytes, instruction_resolved_version = fut_i.result()
+    attachment_results: list[tuple[str, bytes, str | None]] = [
+        (basename, *fut.result())
+        for basename, fut in attachment_futures
+    ]
 
     try:
         manifest = json.loads(manifest_bytes)
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError) as decode_err:
         logger.error(
             "manifest_decode_error errorType=manifest_decode "
             "experiment_id=%s run_id=%s key=%s bucket=%s version_id=%s",
@@ -260,11 +583,11 @@ def experiment_manifest(
             {"Name": "Environment", "Value": os.environ.get("ENVIRONMENT", "unknown")},
             {"Name": "experiment_id", "Value": req.experiment_id},
         ])
-        raise HTTPException(status_code=500, detail="manifest decode error")
+        raise HTTPException(status_code=500, detail="manifest decode error") from decode_err
 
     try:
         instruction_text = instruction_bytes.decode("utf-8")
-    except UnicodeDecodeError:
+    except UnicodeDecodeError as decode_err:
         logger.error(
             "instruction_decode_error errorType=instruction_decode "
             "experiment_id=%s run_id=%s key=%s version_id=%s",
@@ -275,11 +598,38 @@ def experiment_manifest(
             {"Name": "Environment", "Value": os.environ.get("ENVIRONMENT", "unknown")},
             {"Name": "experiment_id", "Value": req.experiment_id},
         ])
-        raise HTTPException(status_code=500, detail="instruction decode error")
+        raise HTTPException(status_code=500, detail="instruction decode error") from decode_err
+
+    attachments: dict[str, str] = {}
+    resolved_attachment_versions: dict[str, str] = {}
+    for basename, body, resolved_version in attachment_results:
+        try:
+            attachments[basename] = body.decode("utf-8")
+        except UnicodeDecodeError as decode_err:
+            # Binary attachments aren't supported yet — fail loud so a
+            # publisher accident (e.g. uploading a PDF) doesn't silently
+            # corrupt the workspace write downstream. Add an
+            # attachments_binary base64 channel when this becomes a real
+            # requirement, not a guess.
+            logger.error(
+                "attachment_decode_error errorType=attachment_decode "
+                "experiment_id=%s run_id=%s basename=%s",
+                req.experiment_id, ticket.run_id, basename,
+                exc_info=True,
+            )
+            _emit_metric("broker_attachment_decode_error", [
+                {"Name": "Environment", "Value": os.environ.get("ENVIRONMENT", "unknown")},
+                {"Name": "experiment_id", "Value": req.experiment_id},
+            ])
+            raise HTTPException(status_code=500, detail="attachment decode error") from decode_err
+        if resolved_version is not None:
+            resolved_attachment_versions[basename] = resolved_version
 
     return ExperimentManifestResponse(
         manifest=manifest,
         instruction=instruction_text,
         resolved_manifest_version_id=manifest_resolved_version,
         resolved_instruction_version_id=instruction_resolved_version,
+        attachments=attachments,
+        resolved_attachment_version_ids=resolved_attachment_versions,
     )

--- a/broker/tests/test_experiment_manifest.py
+++ b/broker/tests/test_experiment_manifest.py
@@ -8,8 +8,10 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from broker.dynamodb_client import ScopeTicket
+from broker.endpoints import experiment_manifest as em
 from broker.endpoints.experiment_manifest import (
     _reset_caches_for_test,
+    _reset_fetch_executor_for_test,
     get_experiment_metadata_bucket,
     get_s3_client,
     get_scope_ticket,
@@ -24,10 +26,13 @@ BUCKET = "agent-experiment-metadata-dev"
 def _clear_module_caches():
     """Module-level VersionId-pinned object cache + index.json TTL cache must
     be reset between tests; otherwise warm-cache reads from one test bleed
-    into the next."""
+    into the next. Also reset the module-level fetch executor so a test that
+    swaps it doesn't leak into the next test."""
     _reset_caches_for_test()
+    _reset_fetch_executor_for_test()
     yield
     _reset_caches_for_test()
+    _reset_fetch_executor_for_test()
 
 
 @pytest.fixture(autouse=True)
@@ -54,15 +59,46 @@ def _make_ticket(experiment_id: str = "voter_targeting", organization_slug: str 
     )
 
 
-def _s3_body(payload: bytes | str) -> dict:
+def _s3_body(payload: bytes | str, content_length: int | None = None) -> dict:
+    """Build a synthetic S3 GetObject response.
+
+    `content_length` lets a test pin `response["ContentLength"]` so size-cap
+    guards can be exercised. When omitted, real S3 always returns one; the
+    handler must also defend against a missing/lying value by checking the
+    actual byte count after a bounded read.
+    """
+    raw = payload.encode() if isinstance(payload, str) else payload
     body = MagicMock()
-    body.read.return_value = payload.encode() if isinstance(payload, str) else payload
-    return {"Body": body}
+    # Match boto3's StreamingBody.read(amt) semantics: if no amount is
+    # requested, return all the bytes; if an amount is requested, return up
+    # to that many. The handler probes for oversize bodies by reading
+    # MAX+1 bytes — keep that path exercised.
+    body.read.side_effect = lambda amt=None: raw if amt is None else raw[:amt]
+    resp: dict = {"Body": body}
+    if content_length is not None:
+        resp["ContentLength"] = content_length
+    else:
+        resp["ContentLength"] = len(raw)
+    return resp
 
 
-def _default_index(experiment_ids: list[str] | None = None) -> dict:
+def _default_index(
+    experiment_ids: list[str] | None = None,
+    attachment_keys: dict[str, list[str]] | None = None,
+) -> dict:
+    """Build a synthetic index.json.
+
+    `attachment_keys` maps experiment_id → list of "<id>/attachments/<basename>"
+    entries. The broker reads this list to decide which sidecars to fetch.
+    """
     ids = experiment_ids if experiment_ids is not None else ["voter_targeting", "walking_plan"]
-    return {"experiments": [{"id": eid} for eid in ids]}
+    pins = attachment_keys or {}
+    return {
+        "experiments": [
+            {"id": eid, "attachment_keys": pins.get(eid, [])}
+            for eid in ids
+        ]
+    }
 
 
 def _make_s3_responder(manifest: dict | None = None, instruction: str | None = None,
@@ -72,7 +108,11 @@ def _make_s3_responder(manifest: dict | None = None, instruction: str | None = N
                         instruction_body_override: bytes | None = None,
                         recorded_calls: list | None = None,
                         index: dict | None = None,
-                        index_error: Exception | None = None):
+                        index_error: Exception | None = None,
+                        attachments: dict[str, bytes | str] | None = None,
+                        attachment_version_ids: dict[str, str] | None = None,
+                        attachment_errors: dict[str, Exception] | None = None,
+                        attachment_content_lengths: dict[str, int] | None = None):
     """Returns a side_effect for s3_client.get_object that routes by Key suffix.
 
     If `recorded_calls` is passed, append (Key, kwargs_dict) tuples for tests
@@ -80,7 +120,19 @@ def _make_s3_responder(manifest: dict | None = None, instruction: str | None = N
 
     Defaults: index.json lists voter_targeting + walking_plan so the orphan
     check passes for the common case.
+
+    `attachments` is keyed by basename (matching the request/response shape
+    the runner sees) — the responder routes any `<experiment_id>/attachments/<basename>`
+    GET to the matching body. `attachment_version_ids` lets a test pin the
+    VersionId surfaced in the GetObject response (so resolved_*_version_ids
+    can be asserted on). `attachment_errors` injects a per-basename failure
+    so we can exercise the missing-attachment path.
     """
+    att_bodies = attachments or {}
+    att_versions = attachment_version_ids or {}
+    att_errors = attachment_errors or {}
+    att_lengths = attachment_content_lengths or {}
+
     def _get_object(Bucket, Key, **kwargs):
         if recorded_calls is not None:
             recorded_calls.append((Key, dict(kwargs)))
@@ -100,6 +152,19 @@ def _make_s3_responder(manifest: dict | None = None, instruction: str | None = N
             if instruction_body_override is not None:
                 return _s3_body(instruction_body_override)
             return _s3_body(instruction or "# voter targeting instruction\n\nstep 1: foo")
+        if "/attachments/" in Key:
+            basename = Key.split("/attachments/", 1)[1]
+            if basename in att_errors:
+                raise att_errors[basename]
+            if basename not in att_bodies:
+                raise AssertionError(f"unexpected attachment S3 key: {Key}")
+            response = _s3_body(
+                att_bodies[basename],
+                content_length=att_lengths.get(basename),
+            )
+            if basename in att_versions:
+                response["VersionId"] = att_versions[basename]
+            return response
         raise AssertionError(f"unexpected S3 key: {Key}")
     return _get_object
 
@@ -164,7 +229,24 @@ class TestExperimentManifestSuccess:
         assert body["instruction"] == instruction
 
     def test_calls_s3_with_correct_keys_under_configured_bucket(self):
-        app = _create_app(bucket="agent-experiment-metadata-prod")
+        # Use the responder's `recorded_calls` capture instead of reaching
+        # into FastAPI's dependency_overrides. The helper exists for this
+        # exact purpose — keeps the test agnostic to whether the broker
+        # asks for the S3 client once, twice, or via a different mechanism.
+        # We also wrap the responder to capture Bucket so we can assert
+        # the configured bucket is what every GET goes to.
+        recorded: list = []
+        inner = _make_s3_responder(recorded_calls=recorded)
+        called_buckets: list[str] = []
+
+        def _bucket_recording_responder(Bucket, Key, **kwargs):
+            called_buckets.append(Bucket)
+            return inner(Bucket=Bucket, Key=Key, **kwargs)
+
+        app = _create_app(
+            s3_get_object=_bucket_recording_responder,
+            bucket="agent-experiment-metadata-prod",
+        )
         client = TestClient(app)
         client.post(
             "/experiment/manifest",
@@ -172,11 +254,14 @@ class TestExperimentManifestSuccess:
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
 
-        s3_mock = app.dependency_overrides[get_s3_client]()
-        called = {call.kwargs["Key"] for call in s3_mock.get_object.call_args_list}
-        assert called == {"index.json", "voter_targeting/manifest.json", "voter_targeting/instruction.md"}
-        for call in s3_mock.get_object.call_args_list:
-            assert call.kwargs["Bucket"] == "agent-experiment-metadata-prod"
+        called_keys = {key for key, _ in recorded}
+        assert called_keys == {
+            "index.json",
+            "voter_targeting/manifest.json",
+            "voter_targeting/instruction.md",
+        }
+        assert called_buckets, "expected at least one S3 call"
+        assert all(b == "agent-experiment-metadata-prod" for b in called_buckets)
 
 
 # ---------------------------------------------------------------------------
@@ -197,7 +282,11 @@ class TestExperimentManifestAuthorization:
         )
 
         assert resp.status_code == 403
-        assert "denied" in resp.json()["detail"].lower() or "forbidden" in resp.json()["detail"].lower()
+        # Pinned to the exact substring from the handler's denial detail.
+        # Disjunction-substring matches hide drift: if someone reworded the
+        # detail, an `"x" in d or "y" in d` would pass on the wrong branch
+        # and silently miss the rename.
+        assert "manifest access denied" in resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------
@@ -233,7 +322,11 @@ class TestExperimentManifestS3Errors:
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
         assert resp.status_code == 404
-        assert "voter_targeting" in resp.json()["detail"].lower()
+        # Detail labels which object is missing without leaking the full
+        # S3 key (internal pathing). Manifest 404 must say "manifest".
+        detail = resp.json()["detail"]
+        assert "manifest not found" in detail
+        assert "voter_targeting" not in detail
 
     def test_404_when_instruction_missing(self):
         app = _create_app(s3_get_object=_make_s3_responder(instruction_error=_no_such_key("voter_targeting/instruction.md")))
@@ -351,7 +444,8 @@ class TestExperimentManifestCorruptBody:
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
         assert resp.status_code == 500
-        assert "decode" in resp.json()["detail"].lower() or "invalid" in resp.json()["detail"].lower()
+        # Exact substring from the handler's manifest-decode detail.
+        assert "manifest decode error" in resp.json()["detail"]
 
     def test_500_when_instruction_is_not_valid_utf8(self):
         # 0xff is invalid as a UTF-8 start byte. Without explicit handling, the
@@ -392,7 +486,8 @@ class TestExperimentManifestOrphanBlocking:
         )
 
         assert resp.status_code == 404
-        assert "registered" in resp.json()["detail"].lower() or "not currently" in resp.json()["detail"].lower()
+        # Exact substring from the orphan-block handler detail.
+        assert "experiment not currently registered" in resp.json()["detail"]
 
     def test_index_fetch_failure_falls_back_to_deny(self):
         """If index.json itself can't be fetched and there's no cached value,
@@ -581,3 +676,710 @@ class TestExperimentManifestMetrics:
             )
         names = [call.args[0] for call in mock_metric.call_args_list]
         assert "broker_s3_manifest_fetch_failure" in names
+
+
+# ---------------------------------------------------------------------------
+# Attachments — sidecar files the publisher ships next to instruction.md
+# ---------------------------------------------------------------------------
+#
+# Contract: index.json's per-experiment entry carries `attachment_keys` listing
+# every "<experiment_id>/attachments/<basename>". The broker fetches each one
+# (parallel with manifest+instruction), exposes them in the response as
+# `attachments[basename] = utf8_body`, and surfaces per-attachment VersionIds
+# in `resolved_attachment_version_ids[basename]` for audit-trail symmetry
+# with manifest_version_id / instruction_version_id.
+
+
+class TestExperimentManifestAttachmentFetch:
+    def test_attachments_in_index_are_fetched_and_returned_by_basename(self):
+        index = _default_index(attachment_keys={
+            "voter_targeting": [
+                "voter_targeting/attachments/notes.md",
+                "voter_targeting/attachments/lookup.csv",
+            ],
+        })
+        responder = _make_s3_responder(
+            index=index,
+            attachments={
+                "notes.md": "# notes\nfoo\n",
+                "lookup.csv": "k,v\n1,a\n",
+            },
+        )
+        app = _create_app(s3_get_object=responder)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/experiment/manifest",
+            json={"experiment_id": "voter_targeting"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        # Basename-keyed so the runner can write straight to /workspace/<basename>.
+        assert body["attachments"] == {
+            "notes.md": "# notes\nfoo\n",
+            "lookup.csv": "k,v\n1,a\n",
+        }
+
+    def test_no_attachments_in_index_yields_empty_attachments_dict(self):
+        """Existing experiments have no attachment_keys in their index entry.
+        Default response shape must keep `attachments` as an empty dict — not
+        absent, not None — so runners can iterate it unconditionally."""
+        app = _create_app()  # _default_index has attachment_keys=[] by default
+        client = TestClient(app)
+
+        resp = client.post(
+            "/experiment/manifest",
+            json={"experiment_id": "voter_targeting"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["attachments"] == {}
+        assert resp.json()["resolved_attachment_version_ids"] == {}
+
+    def test_runner_never_fetches_attachments_not_listed_in_index(self):
+        """The index is the canonical list of what's published. A runner
+        request that names an attachment not in the index must NOT trigger
+        a speculative S3 GET on `<id>/attachments/<basename>` — that would
+        be a vector for probing arbitrary keys via attachment_version_ids."""
+        recorded: list = []
+        index = _default_index(attachment_keys={"voter_targeting": []})
+        responder = _make_s3_responder(index=index, recorded_calls=recorded)
+        app = _create_app(s3_get_object=responder)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/experiment/manifest",
+            json={
+                "experiment_id": "voter_targeting",
+                # Request a pin for an attachment that's not in the index.
+                # Broker must ignore it.
+                "attachment_version_ids": {"phantom.md": "V-phantom-1"},
+            },
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 200
+        fetched_keys = [Key for Key, _ in recorded]
+        assert not any("phantom.md" in k for k in fetched_keys)
+
+    def test_attachment_with_unsafe_prefix_skipped(self):
+        """A hand-edited index entry with an attachment_key that doesn't
+        start with `<experiment_id>/attachments/` would let a malformed
+        index point at an unrelated S3 key. Broker must skip those."""
+        recorded: list = []
+        index = {
+            "experiments": [{
+                "id": "voter_targeting",
+                "attachment_keys": [
+                    "voter_targeting/attachments/legit.md",
+                    "other_experiment/attachments/cross.md",  # wrong prefix
+                    "../etc/passwd",                          # nonsense
+                ],
+            }],
+        }
+        responder = _make_s3_responder(
+            index=index,
+            attachments={"legit.md": "ok\n"},
+            recorded_calls=recorded,
+        )
+        app = _create_app(s3_get_object=responder)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/experiment/manifest",
+            json={"experiment_id": "voter_targeting"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["attachments"] == {"legit.md": "ok\n"}
+        fetched = {k for k, _ in recorded}
+        assert "other_experiment/attachments/cross.md" not in fetched
+        assert "../etc/passwd" not in fetched
+
+
+class TestExperimentManifestAttachmentVersionPinning:
+    def test_resolved_attachment_version_ids_surfaced(self):
+        index = _default_index(attachment_keys={
+            "voter_targeting": ["voter_targeting/attachments/lookup.csv"],
+        })
+        responder = _make_s3_responder(
+            index=index,
+            attachments={"lookup.csv": "k,v\n"},
+            attachment_version_ids={"lookup.csv": "V-lookup-abc-123"},
+        )
+        app = _create_app(s3_get_object=responder)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/experiment/manifest",
+            json={"experiment_id": "voter_targeting"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["resolved_attachment_version_ids"] == {
+            "lookup.csv": "V-lookup-abc-123",
+        }
+
+    def test_attachment_version_ids_forwarded_to_s3(self):
+        """Symmetric with manifest_version_id pinning: when the runner
+        passes attachment_version_ids, those VersionIds must reach S3 so
+        the pinned-replay path returns the same bytes Lambda saw."""
+        recorded: list = []
+        index = _default_index(attachment_keys={
+            "voter_targeting": ["voter_targeting/attachments/notes.md"],
+        })
+        responder = _make_s3_responder(
+            index=index,
+            attachments={"notes.md": "frozen\n"},
+            recorded_calls=recorded,
+        )
+        app = _create_app(s3_get_object=responder)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/experiment/manifest",
+            json={
+                "experiment_id": "voter_targeting",
+                "attachment_version_ids": {"notes.md": "V-notes-pin-7"},
+            },
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 200
+        att_call = next(c for c in recorded if c[0].endswith("/notes.md"))
+        assert att_call[1].get("VersionId") == "V-notes-pin-7"
+
+    def test_unpinned_attachment_omits_version_id_to_s3(self):
+        """Without a pin, the broker must default to 'latest' (no
+        VersionId in the GetObject kwargs). Sending an empty string would
+        be rejected by S3."""
+        recorded: list = []
+        index = _default_index(attachment_keys={
+            "voter_targeting": ["voter_targeting/attachments/notes.md"],
+        })
+        responder = _make_s3_responder(
+            index=index,
+            attachments={"notes.md": "latest\n"},
+            recorded_calls=recorded,
+        )
+        app = _create_app(s3_get_object=responder)
+        client = TestClient(app)
+
+        client.post(
+            "/experiment/manifest",
+            json={"experiment_id": "voter_targeting"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        att_call = next(c for c in recorded if c[0].endswith("/notes.md"))
+        assert "VersionId" not in att_call[1]
+
+
+class TestExperimentManifestAttachmentValidation:
+    @pytest.mark.parametrize("bad_key", [
+        "has/slash.md",      # path separator in basename — not safe
+        "..",                # traversal
+        ".",                 # current-dir
+        "spaces in name.md", # whitespace not in basename pattern
+        "",                  # empty
+    ])
+    def test_rejects_unsafe_attachment_version_id_keys(self, bad_key):
+        app = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/experiment/manifest",
+            json={
+                "experiment_id": "voter_targeting",
+                "attachment_version_ids": {bad_key: "V-pinned"},
+            },
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 422
+
+    def test_rejects_unsafe_attachment_version_id_values(self):
+        app = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/experiment/manifest",
+            json={
+                "experiment_id": "voter_targeting",
+                "attachment_version_ids": {"notes.md": "has space"},
+            },
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 422
+
+
+class TestExperimentManifestAttachmentDecodeError:
+    def test_non_utf8_attachment_returns_500_and_emits_metric(self):
+        """Binary attachments are explicitly unsupported. A publisher
+        accident (e.g. uploading a PDF) must surface as a loud 500 with a
+        metric, not corrupt the runner workspace by silently coercing."""
+        index = _default_index(attachment_keys={
+            "voter_targeting": ["voter_targeting/attachments/bad.bin"],
+        })
+        responder = _make_s3_responder(
+            index=index,
+            attachments={"bad.bin": b"\xff\xfe\xfd not utf-8"},
+        )
+        app = _create_app(s3_get_object=responder)
+        with patch("broker.endpoints.experiment_manifest._emit_metric") as mock_metric:
+            client = TestClient(app)
+            resp = client.post(
+                "/experiment/manifest",
+                json={"experiment_id": "voter_targeting"},
+                headers={"X-Broker-Token": BROKER_TOKEN},
+            )
+
+        assert resp.status_code == 500
+        assert "attachment" in resp.json()["detail"].lower()
+        names = [call.args[0] for call in mock_metric.call_args_list]
+        assert "broker_attachment_decode_error" in names
+
+
+# ---------------------------------------------------------------------------
+# B1 — Attachment size cap + count cap + bounded executor (DoS defense)
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentManifestSizeAndCountCaps:
+    def test_rejects_attachment_exceeding_size_cap(self):
+        """Unbounded `response['Body'].read()` would OOM the broker on a
+        publisher accident (e.g. someone uploads a 1 GB attachment). The
+        handler must check ContentLength and short-circuit before reading
+        the body."""
+        oversize_bytes = b"a" * (em.MAX_ATTACHMENT_BYTES + 1)
+        index = _default_index(attachment_keys={
+            "voter_targeting": ["voter_targeting/attachments/huge.bin"],
+        })
+        responder = _make_s3_responder(
+            index=index,
+            attachments={"huge.bin": oversize_bytes},
+            # ContentLength is what real S3 reports; the cap must trip on it.
+            attachment_content_lengths={"huge.bin": em.MAX_ATTACHMENT_BYTES + 1},
+        )
+        app = _create_app(s3_get_object=responder)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/experiment/manifest",
+            json={"experiment_id": "voter_targeting"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        # 502 — broker refused to surface upstream object that violates
+        # the size contract. Detail must mention "size cap".
+        assert resp.status_code == 502
+        assert "exceeds size cap" in resp.json()["detail"]
+
+    def test_rejects_attachment_with_missing_content_length_but_oversize_body(self):
+        """Defense in depth: even if ContentLength is missing or lying,
+        a bounded read with `read(MAX+1)` catches the oversize case before
+        the broker process holds gigabytes in memory."""
+        oversize_bytes = b"b" * (em.MAX_ATTACHMENT_BYTES + 1)
+        index = _default_index(attachment_keys={
+            "voter_targeting": ["voter_targeting/attachments/huge.bin"],
+        })
+        responder = _make_s3_responder(
+            index=index,
+            attachments={"huge.bin": oversize_bytes},
+            # ContentLength=0 lies about the size — handler must still
+            # catch the oversize via the bounded read.
+            attachment_content_lengths={"huge.bin": 0},
+        )
+        app = _create_app(s3_get_object=responder)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/experiment/manifest",
+            json={"experiment_id": "voter_targeting"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 502
+        assert "exceeds size cap" in resp.json()["detail"]
+
+    def test_caps_attachment_count_per_experiment_at_max(self):
+        """An index entry with thousands of attachment_keys would spawn
+        thousands of threads under the old per-request executor. After
+        the cap, the handler truncates to MAX_ATTACHMENTS_PER_EXPERIMENT
+        and emits a drift metric so operators see the publisher bug."""
+        # Build an index that exceeds the cap.
+        total = em.MAX_ATTACHMENTS_PER_EXPERIMENT + 10
+        keys = [f"voter_targeting/attachments/a{i:04d}.md" for i in range(total)]
+        bodies = {f"a{i:04d}.md": f"body-{i}\n" for i in range(total)}
+        index = _default_index(attachment_keys={"voter_targeting": keys})
+        recorded: list = []
+        responder = _make_s3_responder(
+            index=index,
+            attachments=bodies,
+            recorded_calls=recorded,
+        )
+        app = _create_app(s3_get_object=responder)
+        with patch("broker.endpoints.experiment_manifest._emit_metric") as mock_metric:
+            client = TestClient(app)
+            resp = client.post(
+                "/experiment/manifest",
+                json={"experiment_id": "voter_targeting"},
+                headers={"X-Broker-Token": BROKER_TOKEN},
+            )
+
+        assert resp.status_code == 200
+        # Count S3 GETs targeting `/attachments/`; expect at most MAX, not total.
+        attachment_gets = [k for k, _ in recorded if "/attachments/" in k]
+        assert len(attachment_gets) == em.MAX_ATTACHMENTS_PER_EXPERIMENT, (
+            f"expected exactly {em.MAX_ATTACHMENTS_PER_EXPERIMENT} attachment "
+            f"fetches after truncation, got {len(attachment_gets)}"
+        )
+        names = [call.args[0] for call in mock_metric.call_args_list]
+        assert "broker_attachment_count_exceeded" in names
+
+
+# ---------------------------------------------------------------------------
+# B2 — LRU cache evicts least-recently-used (not a full flush)
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentManifestLRUCache:
+    def test_cache_evicts_lru_not_full_flush(self):
+        """The cache must evict the oldest entry when it overflows, not
+        wipe everything. Otherwise hot manifest/instruction entries get
+        churned out whenever a different experiment is fetched."""
+        # Pre-fill the cache to capacity with synthetic keys; touch
+        # entries in a known order so we can assert LRU semantics.
+        em._OBJECT_CACHE.clear()
+        maxsize = em._OBJECT_CACHE_MAX
+
+        # Inject `maxsize` distinct entries.
+        for i in range(maxsize):
+            em._OBJECT_CACHE.put(
+                ("bucket", f"key-{i}", "v"),
+                f"body-{i}".encode(),
+                "v",
+            )
+
+        # Touch the oldest entry so it becomes MRU.
+        em._OBJECT_CACHE.get(("bucket", "key-0", "v"), ttl=None)
+
+        # Add one more entry — overflow. With LRU semantics, the
+        # least-recently-used should be evicted. After touching key-0,
+        # the LRU is key-1.
+        em._OBJECT_CACHE.put(
+            ("bucket", "new-key", "v"),
+            b"new",
+            "v",
+        )
+
+        # key-1 should be gone (it was the LRU after the touch).
+        assert em._OBJECT_CACHE.get(("bucket", "key-1", "v"), ttl=None) is None
+        # key-0 (touched) should still be present.
+        assert em._OBJECT_CACHE.get(("bucket", "key-0", "v"), ttl=None) is not None
+        # New key should be present.
+        assert em._OBJECT_CACHE.get(("bucket", "new-key", "v"), ttl=None) is not None
+        # Some other middle key should still be there too.
+        assert em._OBJECT_CACHE.get(("bucket", f"key-{maxsize - 1}", "v"), ttl=None) is not None
+
+
+# ---------------------------------------------------------------------------
+# B3 — Unified basename safety helper (whitespace, etc.)
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentManifestUnsafeBasename:
+    def test_index_basename_with_whitespace_rejected(self):
+        """The validator for `attachment_version_ids` already rejects
+        whitespace basenames at the request boundary; the index-side
+        loop must use the same helper so a malformed index entry can't
+        slip a `spaces in name.md` basename past defense-in-depth."""
+        recorded: list = []
+        index = {
+            "experiments": [{
+                "id": "voter_targeting",
+                "attachment_keys": [
+                    "voter_targeting/attachments/legit.md",
+                    "voter_targeting/attachments/spaces in name.md",
+                ],
+            }],
+        }
+        responder = _make_s3_responder(
+            index=index,
+            attachments={"legit.md": "ok\n"},
+            recorded_calls=recorded,
+        )
+        app = _create_app(s3_get_object=responder)
+        with patch("broker.endpoints.experiment_manifest._emit_metric") as mock_metric:
+            client = TestClient(app)
+            resp = client.post(
+                "/experiment/manifest",
+                json={"experiment_id": "voter_targeting"},
+                headers={"X-Broker-Token": BROKER_TOKEN},
+            )
+
+        assert resp.status_code == 200
+        # The unsafe key was skipped; only the legit attachment came back.
+        assert resp.json()["attachments"] == {"legit.md": "ok\n"}
+        fetched = {k for k, _ in recorded}
+        assert "voter_targeting/attachments/spaces in name.md" not in fetched
+        # Drift metric must fire with the unsafe-basename label.
+        drift_calls = [
+            call for call in mock_metric.call_args_list
+            if call.args[0] == "broker_attachment_index_drift"
+        ]
+        assert drift_calls, "expected broker_attachment_index_drift metric"
+        dims = [
+            d for call in drift_calls for d in call.args[1]
+            if d.get("Name") == "drift_kind"
+        ]
+        assert any(d.get("Value") == "unsafe_basename" for d in dims)
+
+
+# ---------------------------------------------------------------------------
+# B4 — Index-drift error reporting via metric
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentManifestIndexDriftMetrics:
+    def test_non_string_attachment_key_emits_drift_metric(self):
+        """A non-string entry in attachment_keys is publisher-side drift.
+        The old code silently `continue`d at WARNING — operators saw
+        nothing in CloudWatch. Now it must fire a drift metric with
+        kind=non_string_key."""
+        recorded: list = []
+        index = {
+            "experiments": [{
+                "id": "voter_targeting",
+                "attachment_keys": [
+                    "voter_targeting/attachments/legit.md",
+                    42,  # non-string drift
+                ],
+            }],
+        }
+        responder = _make_s3_responder(
+            index=index,
+            attachments={"legit.md": "ok\n"},
+            recorded_calls=recorded,
+        )
+        app = _create_app(s3_get_object=responder)
+        with patch("broker.endpoints.experiment_manifest._emit_metric") as mock_metric:
+            client = TestClient(app)
+            resp = client.post(
+                "/experiment/manifest",
+                json={"experiment_id": "voter_targeting"},
+                headers={"X-Broker-Token": BROKER_TOKEN},
+            )
+
+        assert resp.status_code == 200
+        # Only the legit one comes back.
+        assert resp.json()["attachments"] == {"legit.md": "ok\n"}
+        drift_calls = [
+            call for call in mock_metric.call_args_list
+            if call.args[0] == "broker_attachment_index_drift"
+        ]
+        assert drift_calls
+        kinds = {
+            d.get("Value")
+            for call in drift_calls
+            for d in call.args[1]
+            if d.get("Name") == "drift_kind"
+        }
+        assert "non_string_key" in kinds
+
+    def test_wrong_prefix_attachment_key_emits_drift_metric(self):
+        """The wrong-prefix path used to log WARNING with no metric —
+        operators couldn't alert on it. Must emit the drift metric with
+        kind=wrong_prefix."""
+        index = {
+            "experiments": [{
+                "id": "voter_targeting",
+                "attachment_keys": [
+                    "voter_targeting/attachments/legit.md",
+                    "other_experiment/attachments/cross.md",
+                ],
+            }],
+        }
+        responder = _make_s3_responder(
+            index=index,
+            attachments={"legit.md": "ok\n"},
+        )
+        app = _create_app(s3_get_object=responder)
+        with patch("broker.endpoints.experiment_manifest._emit_metric") as mock_metric:
+            client = TestClient(app)
+            resp = client.post(
+                "/experiment/manifest",
+                json={"experiment_id": "voter_targeting"},
+                headers={"X-Broker-Token": BROKER_TOKEN},
+            )
+
+        assert resp.status_code == 200
+        drift_calls = [
+            call for call in mock_metric.call_args_list
+            if call.args[0] == "broker_attachment_index_drift"
+        ]
+        assert drift_calls
+        kinds = {
+            d.get("Value")
+            for call in drift_calls
+            for d in call.args[1]
+            if d.get("Name") == "drift_kind"
+        }
+        assert "wrong_prefix" in kinds
+
+
+# ---------------------------------------------------------------------------
+# B5 — Non-list attachment_keys in index drops + emits drift metric
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentManifestNonListAttachmentKeys:
+    def test_non_list_attachment_keys_in_index_drops_and_emits_drift(self):
+        """If `attachment_keys` is a string instead of a list, iterating
+        over it yields one S3 GET per *character* — a silent bug. The
+        handler must treat non-list as drift, skip entirely, and emit
+        a metric."""
+        recorded: list = []
+        index = {
+            "experiments": [{
+                "id": "voter_targeting",
+                # Drift: string, not a list.
+                "attachment_keys": "single.md",
+            }],
+        }
+        responder = _make_s3_responder(
+            index=index,
+            attachments={},  # any attachment fetch raises AssertionError
+            recorded_calls=recorded,
+        )
+        app = _create_app(s3_get_object=responder)
+        with patch("broker.endpoints.experiment_manifest._emit_metric") as mock_metric:
+            client = TestClient(app)
+            resp = client.post(
+                "/experiment/manifest",
+                json={"experiment_id": "voter_targeting"},
+                headers={"X-Broker-Token": BROKER_TOKEN},
+            )
+
+        assert resp.status_code == 200
+        # No attachment S3 GETs attempted — confirms the per-character
+        # iteration bug is fixed.
+        attachment_gets = [k for k, _ in recorded if "/attachments/" in k]
+        assert attachment_gets == []
+        assert resp.json()["attachments"] == {}
+        drift_calls = [
+            call for call in mock_metric.call_args_list
+            if call.args[0] == "broker_attachment_index_drift"
+        ]
+        assert drift_calls
+        kinds = {
+            d.get("Value")
+            for call in drift_calls
+            for d in call.args[1]
+            if d.get("Name") == "drift_kind"
+        }
+        assert "non_list_attachment_keys" in kinds
+
+
+# ---------------------------------------------------------------------------
+# B6 — Index fetch failure emits a metric (empty fallback = total blackout)
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentManifestIndexFetchFailureMetric:
+    def test_index_fetch_failure_empty_fallback_emits_metric(self):
+        """When index.json can't be fetched and there's no cached copy,
+        the orphan check denies every manifest — a total broker
+        blackout. Old code logged WARNING with no metric; operators
+        would never alert. Must emit `broker_index_fetch_failure` with
+        fallback=empty."""
+        responder = _make_s3_responder(index_error=_other_s3_error())
+        app = _create_app(s3_get_object=responder)
+        with patch("broker.endpoints.experiment_manifest._emit_metric") as mock_metric:
+            client = TestClient(app)
+            resp = client.post(
+                "/experiment/manifest",
+                json={"experiment_id": "voter_targeting"},
+                headers={"X-Broker-Token": BROKER_TOKEN},
+            )
+
+        assert resp.status_code == 404
+        fetch_failure_calls = [
+            call for call in mock_metric.call_args_list
+            if call.args[0] == "broker_index_fetch_failure"
+        ]
+        assert fetch_failure_calls
+        fallbacks = {
+            d.get("Value")
+            for call in fetch_failure_calls
+            for d in call.args[1]
+            if d.get("Name") == "fallback"
+        }
+        assert "empty" in fallbacks
+
+
+# ---------------------------------------------------------------------------
+# B7 — Attachment 404 detail labels object correctly (not "manifest")
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentManifestAttachmentMissingDetail:
+    def test_attachment_404_detail_says_attachment_not_manifest(self):
+        """If an attachment listed in index.json has been deleted from
+        S3, the 404 detail must say `attachment not found`, not
+        `manifest not found` (which would mislead the runner / operator
+        into looking at the wrong S3 path)."""
+        index = _default_index(attachment_keys={
+            "voter_targeting": ["voter_targeting/attachments/gone.md"],
+        })
+        responder = _make_s3_responder(
+            index=index,
+            attachments={},
+            attachment_errors={"gone.md": _no_such_key("voter_targeting/attachments/gone.md")},
+        )
+        app = _create_app(s3_get_object=responder)
+        client = TestClient(app)
+        resp = client.post(
+            "/experiment/manifest",
+            json={"experiment_id": "voter_targeting"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 404
+        detail = resp.json()["detail"]
+        assert "attachment not found" in detail
+        assert "manifest" not in detail
+
+
+# ---------------------------------------------------------------------------
+# B9 — Max-length experiment_id is accepted (pin the boundary, not just over)
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentManifestIdLengthBoundary:
+    def test_accepts_max_length_experiment_id(self):
+        """EXPERIMENT_ID_PATTERN allows `[a-z][a-z0-9_]{0,63}` — total
+        max length 64. The existing parametrized test only pins 65
+        (above-cap); pin 64 (at-cap) too so a future regex tweak that
+        drops the cap to 63 fails loudly."""
+        ticket_id = "v" + ("x" * 63)  # 64 chars total, first char a-z
+        ticket = _make_ticket(experiment_id=ticket_id)
+        # Make the index list the experiment so the orphan check passes.
+        index = _default_index(experiment_ids=[ticket_id])
+        responder = _make_s3_responder(index=index)
+        app = _create_app(ticket=ticket, s3_get_object=responder)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/experiment/manifest",
+            json={"experiment_id": ticket_id},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 200

--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -397,6 +397,18 @@ def build_container_overrides(
         env.append({"name": "MANIFEST_VERSION_ID", "value": experiment["manifest_version_id"]})
     if experiment.get("instruction_version_id"):
         env.append({"name": "INSTRUCTION_VERSION_ID", "value": experiment["instruction_version_id"]})
+    # Attachment VersionIds are sidecar pins captured by the manifest loader's
+    # per-attachment HEADs. sort_keys keeps the env-var value byte-deterministic
+    # across dispatches so downstream caches / idempotency tests don't churn
+    # on dict iteration order. Skip when empty/absent — empty env vars are
+    # noise and the runner already special-cases empty/unset.
+    if experiment.get("attachment_version_ids"):
+        env.append(
+            {
+                "name": "ATTACHMENT_VERSION_IDS",
+                "value": json.dumps(experiment["attachment_version_ids"], sort_keys=True),
+            }
+        )
     # Write-action manifest fields (system_prompt, permission_mode,
     # allowed_external_tools — ENG-10128) are not forwarded as env vars on
     # purpose: the runner fetches the full manifest itself via

--- a/pmf_engine/control_plane/manifest_loader.py
+++ b/pmf_engine/control_plane/manifest_loader.py
@@ -87,6 +87,10 @@ class ManifestRoutingLoader:
         # was upstream and brittle.
         self._manifest_cache: dict[str, tuple[tuple[dict, str | None], float]] = {}
         self._instruction_version_cache: dict[str, tuple[str | None, float]] = {}
+        # Per-experiment cache of {basename: version_id}. Single-source-of-
+        # truth for the runner's attachment pin so a publish during the
+        # dispatch→runner window can't swap bytes out under us.
+        self._attachment_version_cache: dict[str, tuple[dict[str, str], float]] = {}
 
     # ---------- public ----------
 
@@ -120,9 +124,14 @@ class ManifestRoutingLoader:
             experiment_id,
             entry.get("instruction_key", f"{experiment_id}/instruction.md"),
         )
+        attachment_keys = entry.get("attachment_keys") or []
+        attachment_version_ids = self._fetch_attachment_version_ids(
+            experiment_id, attachment_keys
+        )
         routing = _project_routing(manifest, experiment_id=experiment_id)
         routing["manifest_version_id"] = manifest_version_id
         routing["instruction_version_id"] = instruction_version_id
+        routing["attachment_version_ids"] = attachment_version_ids
         return routing
 
     def known_experiments(self) -> list[str]:
@@ -229,6 +238,84 @@ class ManifestRoutingLoader:
             self._instruction_version_cache.clear()
         self._instruction_version_cache[experiment_id] = (version_id, now)
         return version_id
+
+    def _fetch_attachment_version_ids(
+        self, experiment_id: str, attachment_keys: list[str]
+    ) -> dict[str, str]:
+        """HEAD each attachment key, return {basename: VersionId}.
+
+        Error-handling contract mirrors `_fetch_instruction_version_id`:
+        - `NoSuchKey` / `NoSuchVersion` / `"404"` on a single attachment:
+          WARN-log + skip that basename. Dispatch proceeds; the runner will
+          surface the missing attachment via the broker fetch when it tries
+          to materialize the workspace file.
+        - Any other ClientError (AccessDenied, ServiceUnavailable, SlowDown,
+          throttling, transient 5xx): raise ManifestLoaderTransientError.
+          Falling through to "latest" defeats the entire pinning system the
+          dispatch-time HEAD was designed to guarantee.
+        - Wrong-prefix attachment_key (doesn't start with
+          `{experiment_id}/attachments/`): WARN-log + skip. Defense in depth
+          against publish-pipeline bugs / manual S3 edits.
+
+        Cached under the same TTL as manifest+instruction so warm Lambdas
+        don't re-HEAD on every invocation.
+        """
+        now = time.monotonic()
+        cached = self._attachment_version_cache.get(experiment_id)
+        if cached and now - cached[1] < self._ttl:
+            return cached[0]
+
+        result: dict[str, str] = {}
+        expected_prefix = f"{experiment_id}/attachments/"
+        for ak in attachment_keys:
+            if not isinstance(ak, str) or not ak.startswith(expected_prefix):
+                logger.warning(
+                    "attachment_key has unexpected prefix — skipping: "
+                    "experiment_id=%s key=%r expected_prefix=%s",
+                    experiment_id,
+                    ak,
+                    expected_prefix,
+                )
+                continue
+            basename = ak.split("/attachments/", 1)[1]
+            try:
+                response = self._s3.head_object(Bucket=self._bucket, Key=ak)
+            except ClientError as e:
+                code = e.response.get("Error", {}).get("Code", "")
+                request_id = e.response.get("ResponseMetadata", {}).get("RequestId", "")
+                if code in ("NoSuchKey", "NoSuchVersion", "404"):
+                    logger.warning(
+                        "attachment object absent — proceeding without version pin: "
+                        "experiment_id=%s key=%s bucket=%s code=%s request_id=%s",
+                        experiment_id,
+                        ak,
+                        self._bucket,
+                        code,
+                        request_id,
+                    )
+                    continue
+                logger.error(
+                    "S3 HeadObject failed for attachment (NOT swallowed — version pin lost): "
+                    "experiment_id=%s key=%s bucket=%s code=%s request_id=%s",
+                    experiment_id,
+                    ak,
+                    self._bucket,
+                    code,
+                    request_id,
+                    exc_info=True,
+                )
+                raise ManifestLoaderTransientError(
+                    f"failed to head attachment s3://{self._bucket}/{ak} "
+                    f"for '{experiment_id}': {code} (request_id={request_id})"
+                ) from e
+            version_id = response.get("VersionId")
+            if version_id is not None:
+                result[basename] = version_id
+
+        if len(self._attachment_version_cache) >= _MANIFEST_CACHE_MAX:
+            self._attachment_version_cache.clear()
+        self._attachment_version_cache[experiment_id] = (result, now)
+        return result
 
     def _get_object(self, key: str, label: str) -> tuple[bytes, str | None]:
         try:

--- a/pmf_engine/runner/config.py
+++ b/pmf_engine/runner/config.py
@@ -40,18 +40,30 @@ def _redact_userinfo(url: str) -> str:
 
 
 def _is_draft7_object_schema(schema: object) -> bool:
-    """Quick shape check: is this a JSON Schema Draft-07 object schema?
+    """Quick shape check: is this a real Draft-07 schema, not the legacy GP shape?
 
-    Without this guard, the legacy GP-shape format (`{"name": "string"}`) would
-    sail through `Draft7Validator` as a no-op — every artifact validates "valid"
-    because the schema declares no constraints. We want to reject those at
-    config load, not silently accept invalid artifacts in production.
+    Accepts:
+      - `{"type": "object", "properties": {...}}` — the common single-shape form.
+      - `{"oneOf": [...]}` / `{"anyOf": [...]}` / `{"allOf": [...]}` with at
+        least one branch — combinator-at-root schemas used to discriminate
+        between artifact variants (e.g. status-keyed shapes in meeting_briefing
+        and meeting_schedule).
+
+    Rejects:
+      - The legacy GP-shape `{"name": "string", ...}` example-dict format, which
+        Draft7Validator treats as a no-op (every artifact validates).
+      - Empty combinators like `{"oneOf": []}` — structurally a combinator but
+        declares no constraints, so it's equivalent to the legacy form.
     """
-    return (
-        isinstance(schema, dict)
-        and schema.get("type") == "object"
-        and isinstance(schema.get("properties"), dict)
-    )
+    if not isinstance(schema, dict):
+        return False
+    if schema.get("type") == "object" and isinstance(schema.get("properties"), dict):
+        return True
+    for combinator in ("oneOf", "anyOf", "allOf"):
+        branches = schema.get(combinator)
+        if isinstance(branches, list) and branches:
+            return True
+    return False
 
 
 def validate_broker_url_scheme(broker_url: str, environment: str) -> None:

--- a/pmf_engine/runner/config.py
+++ b/pmf_engine/runner/config.py
@@ -39,30 +39,44 @@ def _redact_userinfo(url: str) -> str:
     return urlunparse(parsed._replace(netloc=netloc))
 
 
-def _is_draft7_object_schema(schema: object) -> bool:
+_COMBINATOR_KEYS = ("oneOf", "anyOf", "allOf")
+_MAX_COMBINATOR_DEPTH = 4
+
+
+def _is_draft7_object_schema(schema: object, _depth: int = 0) -> bool:
     """Quick shape check: is this a real Draft-07 schema, not the legacy GP shape?
 
     Accepts:
       - `{"type": "object", "properties": {...}}` — the common single-shape form.
-      - `{"oneOf": [...]}` / `{"anyOf": [...]}` / `{"allOf": [...]}` with at
-        least one branch — combinator-at-root schemas used to discriminate
-        between artifact variants (e.g. status-keyed shapes in meeting_briefing
-        and meeting_schedule).
+      - `{"oneOf": [...]}` / `{"anyOf": [...]}` / `{"allOf": [...]}` where every
+        branch itself satisfies this check — combinator-at-root schemas used to
+        discriminate between artifact variants (e.g. status-keyed shapes in
+        meeting_briefing and meeting_schedule). The recursion makes
+        `{"oneOf": [{}]}` (and other no-op-branch variants) get rejected the
+        same way `{"oneOf": []}` is — a branch of `{}` would let Draft7Validator
+        accept every artifact.
 
     Rejects:
       - The legacy GP-shape `{"name": "string", ...}` example-dict format, which
         Draft7Validator treats as a no-op (every artifact validates).
-      - Empty combinators like `{"oneOf": []}` — structurally a combinator but
-        declares no constraints, so it's equivalent to the legacy form.
+      - Empty combinators like `{"oneOf": []}` and no-op-branch combinators like
+        `{"oneOf": [{}]}` — structurally a combinator but declares no
+        constraints, so it's equivalent to the legacy form.
+
+    Defensive depth limit (4) guards against pathological nesting; real
+    manifests stay well under that.
     """
+    if _depth > _MAX_COMBINATOR_DEPTH:
+        return False
     if not isinstance(schema, dict):
         return False
     if schema.get("type") == "object" and isinstance(schema.get("properties"), dict):
         return True
-    for combinator in ("oneOf", "anyOf", "allOf"):
+    for combinator in _COMBINATOR_KEYS:
         branches = schema.get(combinator)
         if isinstance(branches, list) and branches:
-            return True
+            if all(_is_draft7_object_schema(b, _depth + 1) for b in branches):
+                return True
     return False
 
 
@@ -110,6 +124,11 @@ class RunnerConfig:
     contract_schema: dict | None = None
     max_turns: int = 50
     timeout_seconds: int = 600
+    # Sidecar files the broker shipped alongside instruction.md. Basename →
+    # UTF-8 body; the runner writes each one to /workspace/<basename> before
+    # spawning the agent. Default-empty so legacy code paths (INSTRUCTION env
+    # override for local-dev runs) work without explicit plumbing.
+    attachments: dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def from_env(cls) -> RunnerConfig:
@@ -150,6 +169,7 @@ class RunnerConfig:
         validate_broker_url_scheme(broker_url, environment_raw)
 
         contract_schema = None
+        attachments: dict[str, str] = {}
         if experiment_id:
             # The broker is the only source for manifest+instruction. The
             # broker reads s3://agent-experiment-metadata-{env}/<id>/* and
@@ -164,6 +184,31 @@ class RunnerConfig:
                     "BROKER_URL and BROKER_TOKEN must both be set. "
                     "Local-dev runs must point at scripts/local_runtime.py."
                 )
+            # ATTACHMENT_VERSION_IDS is the per-attachment pinning dict the
+            # dispatch Lambda serialized (sort_keys=True for byte-determinism).
+            # Parsing/validating here means a malformed env value raises early
+            # — before the broker call — rather than producing a confusing
+            # broker-side rejection. Empty/whitespace string is treated the
+            # same as unset, mirroring the MANIFEST_VERSION_ID convention.
+            attachment_version_ids_raw = os.environ.get("ATTACHMENT_VERSION_IDS", "").strip()
+            attachment_version_ids: dict[str, str] | None = None
+            if attachment_version_ids_raw:
+                try:
+                    parsed_avi = json.loads(attachment_version_ids_raw)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"Invalid ATTACHMENT_VERSION_IDS: {exc}"
+                    ) from exc
+                if not isinstance(parsed_avi, dict):
+                    raise ValueError(
+                        f"ATTACHMENT_VERSION_IDS must decode to an object, "
+                        f"got {type(parsed_avi).__name__}"
+                    )
+                # Defend against env-var tampering and narrow types for the
+                # type checker — dispatch is trusted but we cross a process
+                # boundary so this is cheap insurance.
+                attachment_version_ids = {str(k): str(v) for k, v in parsed_avi.items()}
+
             from pmf_engine.runner.manifest_loader import load_from_broker
             envelope = load_from_broker(
                 experiment_id=experiment_id,
@@ -171,17 +216,20 @@ class RunnerConfig:
                 broker_token=broker_token_for_manifest,
                 manifest_version_id=os.environ.get("MANIFEST_VERSION_ID", "").strip() or None,
                 instruction_version_id=os.environ.get("INSTRUCTION_VERSION_ID", "").strip() or None,
+                attachment_version_ids=attachment_version_ids,
             )
             manifest = envelope["manifest"]
             instruction = envelope["instruction"]
+            attachments = dict(envelope.get("attachments") or {})
             model = manifest.get("model", model)
             max_turns = manifest.get("max_turns", max_turns)
             timeout_seconds = manifest.get("timeout_seconds", timeout_seconds)
             contract_schema = manifest.get("output_schema")
             if contract_schema is not None and not _is_draft7_object_schema(contract_schema):
                 raise ValueError(
-                    f"Manifest output_schema is not JSON Schema Draft-07 "
-                    f"(must have type='object' and a properties dict at root); "
+                    f"Manifest output_schema must be a JSON Schema Draft-07 object: "
+                    f"either type='object' with a properties dict, or a non-empty "
+                    f"oneOf/anyOf/allOf with at least one well-formed branch; "
                     f"got {contract_schema!r}"
                 )
 
@@ -208,4 +256,5 @@ class RunnerConfig:
             contract_schema=contract_schema,
             max_turns=max_turns,
             timeout_seconds=timeout_seconds,
+            attachments=attachments,
         )

--- a/pmf_engine/runner/main.py
+++ b/pmf_engine/runner/main.py
@@ -23,6 +23,26 @@ _shutdown_requested = False
 _current_task: "asyncio.Task | None" = None
 _terminal_callback_sent = False
 
+# Files the runner writes itself during workspace setup. An attachment that
+# matches one of these names would silently clobber the runner's own write.
+# The publisher rejects these at upload time; this set is the runtime
+# defense-in-depth guard.
+_RESERVED_WORKSPACE_FILES = frozenset({
+    "instruction.md",
+    "contract_schema.json",
+    "validate_output.py",
+})
+
+
+class AttachmentSafetyViolation(RuntimeError):
+    """Raised when an attachment write would clobber a reserved file, escape
+    the workspace, or otherwise violate the runner's path-safety guarantees.
+
+    Distinct subclass of RuntimeError so the outer error handler surfaces
+    reason_code='AttachmentSafetyViolation' to gp-api — operators get a
+    greppable, alertable error type instead of a generic 'RuntimeError'.
+    """
+
 _VALIDATOR_SCRIPT = '''#!/usr/bin/env python3
 """Validate output artifact against the contract schema.
 Usage: python3 /workspace/validate_output.py
@@ -658,6 +678,54 @@ async def main():
             with open(validator_path, "w") as f:
                 f.write(_VALIDATOR_SCRIPT)
             logger.info(f"Wrote contract validator to {validator_path}")
+
+        # Defense in depth: the publisher and broker both validate attachment
+        # names, but we double-check here because the workspace is a real
+        # filesystem and a malformed broker response could otherwise write
+        # outside /workspace/ or clobber files the runner just wrote.
+        workspace_real = os.path.realpath(workspace_dir)
+        for name, body in (config.attachments or {}).items():
+            if name in _RESERVED_WORKSPACE_FILES:
+                logger.error(
+                    "attachment_safety_violation errorType=%s "
+                    "run_id=%s experiment_id=%s basename=%r",
+                    "reserved_basename", config.run_id, config.experiment_id, name,
+                )
+                raise AttachmentSafetyViolation(
+                    f"attachment {name!r} collides with reserved basename"
+                )
+            if name != os.path.basename(name) or name.startswith("/") or ".." in name.split("/"):
+                logger.error(
+                    "attachment_safety_violation errorType=%s "
+                    "run_id=%s experiment_id=%s basename=%r",
+                    "unsafe_basename", config.run_id, config.experiment_id, name,
+                )
+                raise AttachmentSafetyViolation(
+                    f"attachment {name!r} has an unsafe basename"
+                )
+            attachment_path = os.path.realpath(os.path.join(workspace_dir, name))
+            # Realpath containment check: even after the basename guard, a
+            # symlinked workspace_dir or future validator drift could let
+            # the path leave /workspace/. Catch it before we open.
+            if not (
+                attachment_path == workspace_real
+                or attachment_path.startswith(workspace_real + os.sep)
+            ):
+                logger.error(
+                    "attachment_safety_violation errorType=%s "
+                    "run_id=%s experiment_id=%s basename=%r resolved=%r",
+                    "path_escape", config.run_id, config.experiment_id, name,
+                    attachment_path,
+                )
+                raise AttachmentSafetyViolation(
+                    f"attachment path {attachment_path!r} escapes workspace {workspace_real!r}"
+                )
+            # Exclusive-create + explicit utf-8: never silently clobber an
+            # existing file (FileExistsError), never trust the locale's
+            # default encoding (UnicodeEncodeError on locale-C with non-ASCII).
+            with open(attachment_path, "x", encoding="utf-8") as f:
+                f.write(body)
+            logger.info("Wrote attachment to %s (%d bytes)", attachment_path, len(body))
 
         _current_task = asyncio.ensure_future(run_experiment(config))
         await asyncio.wait_for(_current_task, timeout=timeout)

--- a/pmf_engine/runner/manifest_loader.py
+++ b/pmf_engine/runner/manifest_loader.py
@@ -10,7 +10,7 @@ uses for everything else.
 from __future__ import annotations
 
 import logging
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 import httpx
 
@@ -18,8 +18,27 @@ logger = logging.getLogger(__name__)
 
 
 class ManifestEnvelope(TypedDict):
+    """Envelope returned by POST /experiment/manifest.
+
+    `manifest` and `instruction` are always present after envelope validation
+    in `load_from_broker` — the previous `total=False` declaration was a
+    correctness regression: subscript access like `envelope["manifest"]` was
+    type-unsafe. Use `NotRequired` only for the truly optional fields the
+    broker may omit on older versions.
+    """
+
     manifest: dict
     instruction: str
+    # Sidecar files keyed by basename. Empty dict (not absent) when the
+    # experiment publishes no attachments — keeps downstream iteration
+    # unconditional in the runner. NotRequired only because older brokers
+    # (pre-attachment-feature) won't include the key at all.
+    attachments: NotRequired[dict[str, str]]
+    # VersionIds the broker actually resolved per attachment. Surfaced for
+    # audit-trail symmetry with manifest+instruction pinning so operators can
+    # cross-check what the runner saw against what dispatch HEADed at routing
+    # time. Older brokers (or experiments with no attachments) omit this key.
+    resolved_attachment_version_ids: NotRequired[dict[str, str]]
 
 
 class ManifestLoadError(RuntimeError):
@@ -32,6 +51,7 @@ def load_from_broker(
     broker_token: str,
     manifest_version_id: str | None = None,
     instruction_version_id: str | None = None,
+    attachment_version_ids: dict[str, str] | None = None,
     timeout_seconds: float = 30.0,
     client: httpx.Client | None = None,
 ) -> ManifestEnvelope:
@@ -65,6 +85,8 @@ def load_from_broker(
         request_body["manifest_version_id"] = manifest_version_id
     if instruction_version_id:
         request_body["instruction_version_id"] = instruction_version_id
+    if attachment_version_ids:
+        request_body["attachment_version_ids"] = attachment_version_ids
 
     try:
         try:
@@ -106,7 +128,60 @@ def load_from_broker(
             if required not in manifest:
                 raise ManifestLoadError(f"manifest missing required field '{required}'")
 
-        return ManifestEnvelope(manifest=manifest, instruction=instruction)
+        # Attachments are optional — older broker versions that haven't been
+        # redeployed yet don't include the field. Distinguish "key absent"
+        # (broker too old to ship attachments — emit operator-facing INFO so
+        # the discrepancy is visible) from "key present but {}" (broker is
+        # current, this experiment publishes no attachments — quiet).
+        has_attachments_key = "attachments" in envelope
+        if not has_attachments_key:
+            logger.info(
+                "broker did not return attachments key — running against older broker? "
+                "experiment_id=%s",
+                experiment_id,
+            )
+        raw_attachments = envelope.get("attachments", {})
+        if raw_attachments is None:
+            raw_attachments = {}
+        if not isinstance(raw_attachments, dict):
+            raise ManifestLoadError("envelope.attachments must be an object (basename → body)")
+        attachments: dict[str, str] = {}
+        for name, body in raw_attachments.items():
+            if not isinstance(name, str) or not isinstance(body, str):
+                raise ManifestLoadError(
+                    f"envelope.attachments['{name}'] must map a string basename to a string body"
+                )
+            attachments[name] = body
+
+        # Resolved attachment VersionIds — broker's audit-trail echo of what
+        # it actually fetched after the pinning request body was applied.
+        # Optional and only surfaced when present; legacy brokers (or
+        # experiments with no attachments) omit it entirely.
+        raw_resolved = envelope.get("resolved_attachment_version_ids")
+        resolved_attachment_version_ids: dict[str, str] | None = None
+        if raw_resolved is not None:
+            if not isinstance(raw_resolved, dict):
+                raise ManifestLoadError(
+                    "envelope.resolved_attachment_version_ids must be an object "
+                    "(basename → version_id)"
+                )
+            resolved_attachment_version_ids = {}
+            for name, vid in raw_resolved.items():
+                if not isinstance(name, str) or not isinstance(vid, str):
+                    raise ManifestLoadError(
+                        f"envelope.resolved_attachment_version_ids['{name}'] must map "
+                        f"a string basename to a string version_id"
+                    )
+                resolved_attachment_version_ids[name] = vid
+
+        result: ManifestEnvelope = {
+            "manifest": manifest,
+            "instruction": instruction,
+            "attachments": attachments,
+        }
+        if resolved_attachment_version_ids is not None:
+            result["resolved_attachment_version_ids"] = resolved_attachment_version_ids
+        return result
     finally:
         if owns_client and client is not None:
             client.close()

--- a/pmf_engine/tests/BOUNDARY_TESTS.md
+++ b/pmf_engine/tests/BOUNDARY_TESTS.md
@@ -231,6 +231,56 @@ that validator behavior.
 | R3 | Status values match Zod enum (success, failed, contract_violation) | [x] |
 | R4 | Optional fields (artifactKey, artifactBucket, durationSeconds, error) pass Zod | [x] |
 
+## S. Publisher attachments contract (NEW)
+
+| # | Condition | Status | Test |
+|---|-----------|--------|------|
+| S1 | Reject symlinks under attachments/ (security) | [x] | test_publisher (publisher suite) |
+| S2 | Reject binary attachments (UTF-8 only) | [x] | test_publisher (publisher suite) |
+| S3 | Reject files exceeding 5 MB total cap (with size pre-check) | [x] | test_publisher (publisher suite) |
+| S4 | Reject reserved basenames (clobber instruction.md etc.) | [x] | test_publisher (publisher suite) |
+| S5 | Reject nested subdirs | [x] | test_publisher (publisher suite) |
+| S6 | Reject "output/" prefix (independent of nested rule) | [x] | test_publisher (publisher suite) |
+| S7 | Empty attachments dir no-op | [x] | test_publisher (publisher suite) |
+| S8 | Hash includes attachment bodies in sorted order | [x] | test_publisher (publisher suite) |
+| S9 | Removed attachment drops from index_keys | [x] | test_publisher (publisher suite) |
+
+## T. Broker attachments fetch (NEW)
+
+| # | Condition | Status | Test |
+|---|-----------|--------|------|
+| T1 | attachment_keys in index → fetched and returned by basename | [x] | test_broker (broker suite) |
+| T2 | No attachment_keys → empty attachments dict (not absent) | [x] | test_broker (broker suite) |
+| T3 | Wrong-prefix attachment_keys skipped + drift metric | [x] | test_broker (broker suite) |
+| T4 | Non-string attachment_keys entry skipped + drift metric | [x] | test_broker (broker suite) |
+| T5 | Non-list attachment_keys value handled | [x] | test_broker (broker suite) |
+| T6 | Unsafe basename (whitespace, control chars) skipped + drift metric | [x] | test_broker (broker suite) |
+| T7 | Per-object size cap (502 when exceeded) | [x] | test_broker (broker suite) |
+| T8 | Per-experiment count cap (truncates + metric) | [x] | test_broker (broker suite) |
+| T9 | attachment_version_ids forwarded to S3 GetObject as VersionId | [x] | test_broker (broker suite) |
+| T10 | resolved_attachment_version_ids surfaced in response | [x] | test_broker (broker suite) |
+
+## U. Runner attachment writes (NEW)
+
+| # | Condition | Status | Test |
+|---|-----------|--------|------|
+| U1 | Attachments written before run_experiment is invoked (ordering) | [x] | test_main_writes_attachments_to_workspace_before_running_experiment |
+| U2 | Reserved basename raises AttachmentSafetyViolation | [x] | test_main_rejects_reserved_basename_attachment |
+| U3 | Unsafe basename (path traversal/absolute/nested) raises AttachmentSafetyViolation | [x] | test_main_rejects_unsafe_attachment_basenames |
+| U4 | Path escape via realpath caught | [x] | test_main_rejects_reserved_basename_attachment + test_attachment_safety_violation_log_includes_error_type (path_escape branch logged) |
+| U5 | open("x", encoding="utf-8") — no silent clobber, no encoding ambiguity | [x] | test_main_attachment_write_uses_exclusive_create + test_main_writes_attachments_with_utf8_encoding |
+| U6 | ATTACHMENT_VERSION_IDS env var parsed and forwarded to broker | [x] | test_from_env_parses_attachment_version_ids_from_env (test_config.py) |
+
+## V. VersionId pinning round-trip (NEW)
+
+| # | Condition | Status | Test |
+|---|-----------|--------|------|
+| V1 | Dispatch handler serializes ATTACHMENT_VERSION_IDS env var | [x] | test_dispatch_handler (TestBuildContainerOverrides) |
+| V2 | Lambda manifest_loader captures attachment VersionIds via HEAD | [x] | test_lambda_manifest_loader |
+| V3 | Partial 404 on attachment → that basename omitted, others pinned | [x] | test_lambda_manifest_loader |
+| V4 | Round-trip dispatch→runner→broker preserves attachment_version_ids dict | [x] | test_dispatch_runner_env_roundtrip |
+| V5 | Older broker response (no attachments key) logs INFO and runs cleanly | [x] | test_from_env_defaults_attachments_to_empty_dict_when_envelope_omits (test_config.py) |
+
 ---
 
 ## Summary
@@ -255,4 +305,8 @@ that validator behavior.
 | P. Config Loading | 7 | 7 |
 | Q. Registry Sync | 4 | 4 |
 | R. Cross-Service Contract | 4 | 4 |
-| **Total** | **142** | **142** |
+| S. Publisher attachments | 9 | 9 |
+| T. Broker attachments fetch | 10 | 10 |
+| U. Runner attachment writes | 6 | 6 |
+| V. VersionId pinning round-trip | 5 | 5 |
+| **Total** | **172** | **172** |

--- a/pmf_engine/tests/test_config.py
+++ b/pmf_engine/tests/test_config.py
@@ -125,6 +125,92 @@ def test_from_env_rejects_non_draft7_output_schema(monkeypatch):
             RunnerConfig.from_env()
 
 
+@pytest.mark.parametrize("combinator", ["oneOf", "anyOf", "allOf"])
+def test_from_env_accepts_combinator_at_root_output_schema(monkeypatch, combinator):
+    """Schemas using oneOf/anyOf/allOf at the root (e.g. status-discriminated
+    artifact shapes like meeting_briefing and meeting_schedule) are real
+    Draft-07 schemas and must be accepted. They have no top-level
+    `type: 'object'` or `properties` dict — that's the whole point of the
+    combinator pattern. Only the legacy GP-shape dict should be rejected."""
+    manifest = synthetic_manifest()
+    combinator_schema = {
+        "title": "TestCombinatorSchema",
+        combinator: [
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["status"],
+                "properties": {
+                    "status": {"type": "string", "const": "ok"},
+                    "data": {"type": "string"},
+                },
+            },
+            {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["status"],
+                "properties": {
+                    "status": {"type": "string", "const": "error"},
+                    "error": {"type": "string"},
+                },
+            },
+        ],
+    }
+    envelope = {
+        "manifest": {
+            "model": manifest["model"],
+            "max_turns": manifest["max_turns"],
+            "timeout_seconds": manifest["timeout_seconds"],
+            "output_schema": combinator_schema,
+        },
+        "instruction": synthetic_instruction(),
+    }
+    monkeypatch.setenv("EXPERIMENT_ID", SYNTHETIC_EXPERIMENT_ID)
+    monkeypatch.setenv("RUN_ID", f"run-{combinator}-schema")
+    monkeypatch.setenv("ORGANIZATION_SLUG", "test")
+    monkeypatch.setenv("PARAMS_JSON", "{}")
+    monkeypatch.setenv("BROKER_URL", "https://broker.test")
+    monkeypatch.setenv("BROKER_TOKEN", "tok")
+    monkeypatch.setenv("ENVIRONMENT", "dev")
+
+    with patch(
+        "pmf_engine.runner.manifest_loader.load_from_broker",
+        return_value=envelope,
+    ):
+        config = RunnerConfig.from_env()
+
+    assert config.contract_schema == combinator_schema
+
+
+def test_from_env_rejects_empty_combinator_output_schema(monkeypatch):
+    """`{"oneOf": []}` is structurally a combinator but declares no constraints
+    — every artifact validates. Reject as a legacy-shape-equivalent."""
+    manifest = synthetic_manifest()
+    envelope = {
+        "manifest": {
+            "model": manifest["model"],
+            "max_turns": manifest["max_turns"],
+            "timeout_seconds": manifest["timeout_seconds"],
+            "output_schema": {"oneOf": []},
+        },
+        "instruction": synthetic_instruction(),
+    }
+    monkeypatch.setenv("EXPERIMENT_ID", SYNTHETIC_EXPERIMENT_ID)
+    monkeypatch.setenv("RUN_ID", "run-empty-oneof")
+    monkeypatch.setenv("ORGANIZATION_SLUG", "test")
+    monkeypatch.setenv("PARAMS_JSON", "{}")
+    monkeypatch.setenv("BROKER_URL", "https://broker.test")
+    monkeypatch.setenv("BROKER_TOKEN", "tok")
+    monkeypatch.setenv("ENVIRONMENT", "dev")
+
+    with patch(
+        "pmf_engine.runner.manifest_loader.load_from_broker",
+        return_value=envelope,
+    ):
+        with pytest.raises(ValueError, match="output_schema"):
+            RunnerConfig.from_env()
+
+
 def test_from_env_raises_loud_on_invalid_json_params(monkeypatch):
     """Corrupted PARAMS_JSON must fail loud — a silent default to {} causes
     the agent to run on empty inputs and produce plausible but wrong artifacts

--- a/pmf_engine/tests/test_config.py
+++ b/pmf_engine/tests/test_config.py
@@ -1,4 +1,5 @@
 import json
+import os
 from unittest.mock import patch
 
 import pytest
@@ -42,7 +43,10 @@ def patched_broker():
         yield p
 
 
-def test_from_env_loads_all_fields(monkeypatch, patched_broker):
+def _set_full_env(monkeypatch):
+    """Shared setup for the from_env split tests below — every contract pinned
+    independently below was previously bundled into test_from_env_loads_all_fields
+    where a failure couldn't tell you which behavior broke."""
     monkeypatch.setenv("EXPERIMENT_ID", SYNTHETIC_EXPERIMENT_ID)
     monkeypatch.setenv("RUN_ID", "run-abc")
     monkeypatch.setenv("ORGANIZATION_SLUG", "org-123")
@@ -54,20 +58,82 @@ def test_from_env_loads_all_fields(monkeypatch, patched_broker):
     monkeypatch.setenv("BROKER_TOKEN", "tok-secret-123")
     monkeypatch.delenv("INSTRUCTION", raising=False)
 
+
+def test_from_env_pass_through_experiment_id_run_id_organization_slug(
+    monkeypatch, patched_broker
+):
+    """The three identity fields are read straight from env vars unchanged."""
+    _set_full_env(monkeypatch)
+
     config = RunnerConfig.from_env()
 
     assert config.experiment_id == SYNTHETIC_EXPERIMENT_ID
     assert config.run_id == "run-abc"
     assert config.organization_slug == "org-123"
-    # INSTRUCTION env var is no longer consulted when broker fetch happens.
-    # Broker envelope's instruction wins.
+
+
+def test_from_env_uses_broker_envelope_instruction_not_INSTRUCTION_env_var(
+    monkeypatch, patched_broker
+):
+    """Precedence rule: when EXPERIMENT_ID is set, the broker envelope's
+    instruction wins. The INSTRUCTION env var is deliberately ignored to
+    prevent stale-env footguns on re-runs."""
+    _set_full_env(monkeypatch)
+    # Even if a stale INSTRUCTION value sneaks into the env, it must not win.
+    monkeypatch.setenv("INSTRUCTION", "STALE — must be ignored")
+
+    config = RunnerConfig.from_env()
+
     assert config.instruction == synthetic_instruction()
-    assert config.params == {"district": "CA-12"}
-    assert config.harness == "claude_sdk"
-    # AGENT_MODEL was opus, but broker manifest overrides. The runner trusts
-    # the broker for model.
+    assert "STALE" not in config.instruction
+
+
+def test_from_env_broker_manifest_model_overrides_agent_model_env(
+    monkeypatch, patched_broker
+):
+    """Precedence rule: AGENT_MODEL env var loses to the broker manifest's
+    model. The runner trusts the broker for model choice so ops can swap
+    models per-experiment without redeploying the runner."""
+    _set_full_env(monkeypatch)
+    # AGENT_MODEL is set to opus in _set_full_env; manifest specifies its own.
+    assert os.environ.get("AGENT_MODEL") == "opus"
+
+    config = RunnerConfig.from_env()
+
     assert config.model == synthetic_manifest()["model"]
+    assert config.model != "opus", (
+        f"manifest model must override AGENT_MODEL env var; got {config.model!r}"
+    )
+
+
+def test_from_env_params_json_parses_to_dict(monkeypatch, patched_broker):
+    """PARAMS_JSON must decode into a plain dict and land on .params unchanged."""
+    _set_full_env(monkeypatch)
+
+    config = RunnerConfig.from_env()
+
+    assert config.params == {"district": "CA-12"}
+
+
+def test_from_env_environment_normalized_lowercase(monkeypatch, patched_broker):
+    """ENVIRONMENT is normalized to lowercase before being stored — the rest
+    of the codebase compares against lowercase tokens like 'prod' / 'dev'."""
+    _set_full_env(monkeypatch)
+    # Override with a mixed-case value to prove normalization happens.
+    monkeypatch.setenv("ENVIRONMENT", "PROD")
+
+    config = RunnerConfig.from_env()
+
     assert config.environment == "prod"
+
+
+def test_from_env_broker_url_and_token_pass_through(monkeypatch, patched_broker):
+    """BROKER_URL and BROKER_TOKEN are stored on the config so downstream
+    re-init / fallback paths can reuse the same credentials."""
+    _set_full_env(monkeypatch)
+
+    config = RunnerConfig.from_env()
+
     assert config.broker_url == "https://broker.goodparty.org"
     assert config.broker_token == "tok-secret-123"
 
@@ -209,6 +275,113 @@ def test_from_env_rejects_empty_combinator_output_schema(monkeypatch):
     ):
         with pytest.raises(ValueError, match="output_schema"):
             RunnerConfig.from_env()
+
+
+def _envelope_with_output_schema(schema: dict) -> dict:
+    manifest = synthetic_manifest()
+    return {
+        "manifest": {
+            "model": manifest["model"],
+            "max_turns": manifest["max_turns"],
+            "timeout_seconds": manifest["timeout_seconds"],
+            "output_schema": schema,
+        },
+        "instruction": synthetic_instruction(),
+    }
+
+
+def _set_broker_env(monkeypatch, run_id: str = "run-x"):
+    monkeypatch.setenv("EXPERIMENT_ID", SYNTHETIC_EXPERIMENT_ID)
+    monkeypatch.setenv("RUN_ID", run_id)
+    monkeypatch.setenv("ORGANIZATION_SLUG", "test")
+    monkeypatch.setenv("PARAMS_JSON", "{}")
+    monkeypatch.setenv("BROKER_URL", "https://broker.test")
+    monkeypatch.setenv("BROKER_TOKEN", "tok")
+    monkeypatch.setenv("ENVIRONMENT", "dev")
+
+
+def test_from_env_rejects_combinator_with_empty_branch_objects(monkeypatch):
+    """`{"oneOf": [{}]}` is a combinator whose only branch is the empty schema —
+    Draft7Validator treats `{}` as a no-op so every artifact would validate.
+    The shape check must recurse into branches and reject this."""
+    envelope = _envelope_with_output_schema({"oneOf": [{}]})
+    _set_broker_env(monkeypatch, run_id="run-empty-branch-obj")
+
+    with patch(
+        "pmf_engine.runner.manifest_loader.load_from_broker",
+        return_value=envelope,
+    ):
+        with pytest.raises(ValueError, match="output_schema"):
+            RunnerConfig.from_env()
+
+
+def test_from_env_rejects_combinator_with_only_typeless_branches(monkeypatch):
+    """A branch with only metadata (`description`, `title`) and no `type` /
+    `properties` / nested combinator is structurally a no-op. Reject."""
+    envelope = _envelope_with_output_schema(
+        {"oneOf": [{"description": "x"}, {"title": "y"}]}
+    )
+    _set_broker_env(monkeypatch, run_id="run-typeless-branch")
+
+    with patch(
+        "pmf_engine.runner.manifest_loader.load_from_broker",
+        return_value=envelope,
+    ):
+        with pytest.raises(ValueError, match="output_schema"):
+            RunnerConfig.from_env()
+
+
+def test_from_env_accepts_nested_combinator(monkeypatch):
+    """Combinators may nest — `oneOf` of an `allOf` of a real object schema is
+    legitimate. The recursive shape check must accept it."""
+    nested_schema = {
+        "oneOf": [
+            {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {"k": {"type": "string"}},
+                    }
+                ]
+            }
+        ]
+    }
+    envelope = _envelope_with_output_schema(nested_schema)
+    _set_broker_env(monkeypatch, run_id="run-nested-combinator")
+
+    with patch(
+        "pmf_engine.runner.manifest_loader.load_from_broker",
+        return_value=envelope,
+    ):
+        config = RunnerConfig.from_env()
+
+    assert config.contract_schema == nested_schema
+
+
+def test_combinator_validation_error_message_matches_function_contract(monkeypatch):
+    """Pin the error message wording so a future refactor of the shape check
+    can't silently drift the operator-facing error from what the function
+    actually accepts. The old message claimed `type='object'` was required —
+    after combinators landed, that lied to the operator."""
+    envelope = _envelope_with_output_schema({"name": "string", "count": "number"})
+    _set_broker_env(monkeypatch, run_id="run-msg-pin")
+
+    with patch(
+        "pmf_engine.runner.manifest_loader.load_from_broker",
+        return_value=envelope,
+    ):
+        with pytest.raises(ValueError) as exc_info:
+            RunnerConfig.from_env()
+
+    msg = str(exc_info.value)
+    # Message must mention BOTH supported shapes.
+    assert "type='object'" in msg
+    assert "properties" in msg
+    # And the combinator branch — old message omitted this entirely.
+    assert "oneOf/anyOf/allOf" in msg, (
+        f"error must name the combinator forms the function actually accepts; got: {msg!r}"
+    )
+    assert "well-formed branch" in msg or "non-empty" in msg
 
 
 def test_from_env_raises_loud_on_invalid_json_params(monkeypatch):
@@ -626,3 +799,200 @@ class TestRedactUserinfoEdgeCases:
             f"URL with no parseable hostname must default to safe placeholder, "
             f"got: {result!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Attachments — sidecar files in the broker envelope
+# ---------------------------------------------------------------------------
+#
+# RunnerConfig must thread the envelope's attachments dict through to the
+# runner unchanged so main.py can write each entry to /workspace/<basename>.
+# The default-empty contract is load-bearing for legacy local-dev runs that
+# don't go through the broker.
+
+
+def test_from_env_populates_attachments_from_envelope(monkeypatch):
+    """Broker-resolved attachments must be wired into RunnerConfig so main.py
+    can write them to the workspace. Basename-keyed dict, UTF-8 string bodies."""
+    envelope = _envelope_for_synthetic()
+    envelope["attachments"] = {
+        "reference_catalog.md": "# Reference\n\n- item 1\n- item 2\n",
+        "lookup.csv": "key,value\nalpha,1\n",
+    }
+    monkeypatch.setenv("EXPERIMENT_ID", SYNTHETIC_EXPERIMENT_ID)
+    monkeypatch.setenv("RUN_ID", "run-attachments")
+    monkeypatch.setenv("ORGANIZATION_SLUG", "org-a")
+    monkeypatch.setenv("PARAMS_JSON", "{}")
+    monkeypatch.setenv("BROKER_URL", "https://broker.test")
+    monkeypatch.setenv("BROKER_TOKEN", "tok")
+    monkeypatch.setenv("ENVIRONMENT", "dev")
+
+    with patch(
+        "pmf_engine.runner.manifest_loader.load_from_broker",
+        return_value=envelope,
+    ):
+        config = RunnerConfig.from_env()
+
+    assert config.attachments == {
+        "reference_catalog.md": "# Reference\n\n- item 1\n- item 2\n",
+        "lookup.csv": "key,value\nalpha,1\n",
+    }
+
+
+def test_from_env_defaults_attachments_to_empty_dict_when_envelope_omits(monkeypatch):
+    """Broker responses from a not-yet-redeployed broker don't include the
+    `attachments` field. Runner must default to {} so main.py's iteration
+    works without a None-guard at every call site."""
+    envelope = _envelope_for_synthetic()
+    # Deliberately no `attachments` key — older brokers omit it.
+    assert "attachments" not in envelope
+    monkeypatch.setenv("EXPERIMENT_ID", SYNTHETIC_EXPERIMENT_ID)
+    monkeypatch.setenv("RUN_ID", "run-no-attachments")
+    monkeypatch.setenv("ORGANIZATION_SLUG", "org-a")
+    monkeypatch.setenv("PARAMS_JSON", "{}")
+    monkeypatch.setenv("BROKER_URL", "https://broker.test")
+    monkeypatch.setenv("BROKER_TOKEN", "tok")
+    monkeypatch.setenv("ENVIRONMENT", "dev")
+
+    with patch(
+        "pmf_engine.runner.manifest_loader.load_from_broker",
+        return_value=envelope,
+    ):
+        config = RunnerConfig.from_env()
+
+    assert config.attachments == {}
+
+
+def test_runner_config_attachments_field_uses_default_factory_dict():
+    """Dataclass-level pin: the `attachments` field MUST use
+    `field(default_factory=dict)` so direct-construction code paths get an
+    empty dict (never None or a shared mutable default).
+
+    Companion behavioral test:
+        test_main_works_with_runner_config_default_attachments
+    in test_runner_main.py exercises main.py's iteration on the default to
+    catch any future runtime regression of the contract this pins."""
+    config = RunnerConfig(
+        experiment_id="x",
+        run_id="r",
+        organization_slug="o",
+        instruction="hi",
+    )
+    assert config.attachments == {}
+    # No shared-mutable-default footgun: two instances must not share storage.
+    other = RunnerConfig(
+        experiment_id="y",
+        run_id="r2",
+        organization_slug="o",
+        instruction="hi",
+    )
+    config.attachments["a.md"] = "leaked"
+    assert other.attachments == {}, (
+        "default_factory must yield a fresh dict per-instance; got shared state"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ATTACHMENT_VERSION_IDS env var → load_from_broker forwarding
+#
+# The dispatch Lambda serializes attachment_version_ids as a JSON object env
+# var (see test_dispatch_handler.TestBuildContainerOverrides). The runner
+# must deserialize that and forward it as a kwarg to load_from_broker, or
+# the broker silently falls through to "latest" and the publish-during-run
+# race re-opens for sidecar files.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_broker_capturing():
+    """Patch load_from_broker so tests can inspect every kwarg passed.
+
+    Unlike `patched_broker` (returns a fixed envelope), this fixture also
+    records the kwargs each call received. Use when the assertion is about
+    *what was passed to* load_from_broker, not just that RunnerConfig
+    populated correctly.
+    """
+    envelope = _envelope_for_synthetic()
+    captured: dict = {}
+
+    def fake_load(**kwargs):
+        captured.update(kwargs)
+        return envelope
+
+    with patch(
+        "pmf_engine.runner.manifest_loader.load_from_broker",
+        side_effect=fake_load,
+    ):
+        yield captured
+
+
+def _base_env_for_attachment_tests(monkeypatch):
+    monkeypatch.setenv("EXPERIMENT_ID", SYNTHETIC_EXPERIMENT_ID)
+    monkeypatch.setenv("RUN_ID", "run-attachpin")
+    monkeypatch.setenv("ORGANIZATION_SLUG", "org-a")
+    monkeypatch.setenv("PARAMS_JSON", "{}")
+    monkeypatch.setenv("BROKER_URL", "https://broker.test")
+    monkeypatch.setenv("BROKER_TOKEN", "tok")
+    monkeypatch.setenv("ENVIRONMENT", "dev")
+    monkeypatch.delenv("INSTRUCTION", raising=False)
+
+
+def test_from_env_parses_attachment_version_ids_from_env(monkeypatch, patched_broker_capturing):
+    """When ATTACHMENT_VERSION_IDS env var holds a JSON object, RunnerConfig
+    must deserialize it and forward the dict to load_from_broker."""
+    _base_env_for_attachment_tests(monkeypatch)
+    monkeypatch.setenv(
+        "ATTACHMENT_VERSION_IDS",
+        json.dumps({"a.md": "V1", "b.csv": "V2"}, sort_keys=True),
+    )
+
+    RunnerConfig.from_env()
+
+    assert patched_broker_capturing["attachment_version_ids"] == {"a.md": "V1", "b.csv": "V2"}
+
+
+def test_from_env_with_empty_attachment_version_ids_passes_none(monkeypatch, patched_broker_capturing):
+    """Empty / unset ATTACHMENT_VERSION_IDS → load_from_broker called with
+    attachment_version_ids=None so the POST body omits the key (older brokers
+    that reject unexpected fields stay happy)."""
+    _base_env_for_attachment_tests(monkeypatch)
+    monkeypatch.delenv("ATTACHMENT_VERSION_IDS", raising=False)
+
+    RunnerConfig.from_env()
+
+    assert patched_broker_capturing["attachment_version_ids"] is None
+
+
+def test_from_env_with_blank_attachment_version_ids_passes_none(monkeypatch, patched_broker_capturing):
+    """Whitespace-only env value is equivalent to unset."""
+    _base_env_for_attachment_tests(monkeypatch)
+    monkeypatch.setenv("ATTACHMENT_VERSION_IDS", "   ")
+
+    RunnerConfig.from_env()
+
+    assert patched_broker_capturing["attachment_version_ids"] is None
+
+
+def test_from_env_raises_on_malformed_attachment_version_ids_json(monkeypatch):
+    """Garbage JSON in ATTACHMENT_VERSION_IDS must raise — silently falling
+    back to None would defeat the entire pinning system."""
+    _base_env_for_attachment_tests(monkeypatch)
+    monkeypatch.setenv("ATTACHMENT_VERSION_IDS", "not json")
+    with patch(
+        "pmf_engine.runner.manifest_loader.load_from_broker",
+        return_value=_envelope_for_synthetic(),
+    ):
+        with pytest.raises(ValueError, match="ATTACHMENT_VERSION_IDS"):
+            RunnerConfig.from_env()
+
+
+def test_from_env_raises_on_non_dict_attachment_version_ids(monkeypatch):
+    """JSON value that decodes to a non-dict (list/string/number) must raise."""
+    _base_env_for_attachment_tests(monkeypatch)
+    monkeypatch.setenv("ATTACHMENT_VERSION_IDS", json.dumps([1, 2, 3]))
+    with patch(
+        "pmf_engine.runner.manifest_loader.load_from_broker",
+        return_value=_envelope_for_synthetic(),
+    ):
+        with pytest.raises(ValueError, match="object"):
+            RunnerConfig.from_env()

--- a/pmf_engine/tests/test_dispatch_handler.py
+++ b/pmf_engine/tests/test_dispatch_handler.py
@@ -294,6 +294,91 @@ class TestBuildContainerOverrides:
         assert "ARTIFACT_KEY_TEMPLATE" not in env_map
         assert "RESULTS_QUEUE_URL" not in env_map
 
+    def test_attachment_version_ids_serialized_to_env(self):
+        """When the routing dict carries attachment_version_ids,
+        build_container_overrides MUST emit ATTACHMENT_VERSION_IDS as a
+        JSON-encoded env var so the runner can pin its broker fetch."""
+        experiment = {
+            "model": "sonnet",
+            "timeout_seconds": 600,
+            "manifest_version_id": "mv1",
+            "instruction_version_id": "iv1",
+            "attachment_version_ids": {"lookup.csv": "Vlk", "notes.md": "Vnt"},
+        }
+        message = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-abc",
+            "params": {},
+        }
+        overrides = build_container_overrides(
+            experiment=experiment,
+            message=message,
+            broker_token="tok",
+            broker_url="https://broker.example.com",
+            container_name="pmf-engine",
+        )
+        env_map = {e["name"]: e["value"] for e in overrides["containerOverrides"][0]["environment"]}
+        assert "ATTACHMENT_VERSION_IDS" in env_map
+        # sort_keys=True: env-var bytes must be deterministic across dispatches
+        # so idempotency checks / cache keys downstream don't churn on dict
+        # iteration order.
+        assert env_map["ATTACHMENT_VERSION_IDS"] == json.dumps(
+            {"lookup.csv": "Vlk", "notes.md": "Vnt"}, sort_keys=True
+        )
+
+    def test_attachment_version_ids_omitted_when_empty(self):
+        """Empty attachment_version_ids dict must NOT produce an env var
+        entry — empty env vars are noise and downstream parsing
+        (RunnerConfig.from_env) special-cases empty strings."""
+        experiment = {
+            "model": "sonnet",
+            "timeout_seconds": 600,
+            "manifest_version_id": "mv1",
+            "instruction_version_id": "iv1",
+            "attachment_version_ids": {},
+        }
+        message = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-abc",
+            "params": {},
+        }
+        overrides = build_container_overrides(
+            experiment=experiment,
+            message=message,
+            broker_token="tok",
+            broker_url="https://broker.example.com",
+            container_name="pmf-engine",
+        )
+        env_map = {e["name"]: e["value"] for e in overrides["containerOverrides"][0]["environment"]}
+        assert "ATTACHMENT_VERSION_IDS" not in env_map
+
+    def test_attachment_version_ids_omitted_when_absent(self):
+        """No attachment_version_ids key on the routing dict → no env var.
+        Legacy experiments without attachments must dispatch unchanged."""
+        experiment = {
+            "model": "sonnet",
+            "timeout_seconds": 600,
+            "manifest_version_id": "mv1",
+            "instruction_version_id": "iv1",
+        }
+        message = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-abc",
+            "params": {},
+        }
+        overrides = build_container_overrides(
+            experiment=experiment,
+            message=message,
+            broker_token="tok",
+            broker_url="https://broker.example.com",
+            container_name="pmf-engine",
+        )
+        env_map = {e["name"]: e["value"] for e in overrides["containerOverrides"][0]["environment"]}
+        assert "ATTACHMENT_VERSION_IDS" not in env_map
+
 
 class TestHandler:
     @patch("pmf_engine.control_plane.dispatch_handler.BrokerClient")

--- a/pmf_engine/tests/test_dispatch_runner_env_roundtrip.py
+++ b/pmf_engine/tests/test_dispatch_runner_env_roundtrip.py
@@ -204,3 +204,66 @@ def test_dispatch_env_timeout_is_string_type():
         "ECS runTask environment values must be strings"
     )
     int(env_map["TIMEOUT_SECONDS"])
+
+
+def test_attachment_version_ids_round_trip_dispatch_to_runner_request(monkeypatch):
+    """Attachment VersionIds captured at dispatch MUST reach the broker
+    request body unchanged.
+
+    Whole-pipeline contract test: this fails if ANY link in
+        dispatch_handler → ECS env → runner config → manifest_loader → POST body
+    drops or mangles the attachment_version_ids dict.
+
+    Until this test landed, the whole pipeline was broken at runtime: the
+    broker advertises attachment_version_ids on the request body but nothing
+    upstream populated it, so every attachment fetch silently fell through
+    to 'latest' — re-opening the publish-during-run race for sidecars.
+    """
+    pin_dict = {"lookup.csv": "V-lookup-abc", "notes.md": "V-notes-xyz"}
+    manifest = synthetic_manifest()
+    experiment_id = manifest["id"]
+    instruction = synthetic_instruction()
+    message = _base_message(experiment_id)
+
+    # 1. dispatch_handler serializes ATTACHMENT_VERSION_IDS env var
+    overrides = build_container_overrides(
+        experiment={
+            "model": manifest["model"],
+            "timeout_seconds": manifest["timeout_seconds"],
+            "manifest_version_id": "Mv1",
+            "instruction_version_id": "Iv1",
+            "attachment_version_ids": pin_dict,
+        },
+        message=message,
+        broker_token="tok-attach-rt",
+        broker_url="https://broker.example.com",
+        container_name="pmf-engine",
+    )
+    env_map = _env_list_to_map(overrides["containerOverrides"][0]["environment"])
+    assert env_map["ATTACHMENT_VERSION_IDS"] == json.dumps(pin_dict, sort_keys=True), (
+        "dispatch_handler must serialize attachment_version_ids as sort_keys JSON"
+    )
+
+    # 2. runner config parses + forwards to load_from_broker
+    envelope = _broker_envelope(manifest, instruction)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        # The key behavior under test: attachment_version_ids made it into
+        # the broker request body. If anything between dispatch and here drops
+        # it, the assertion fails.
+        assert body.get("attachment_version_ids") == pin_dict, (
+            f"runner did not forward pin dict to broker; body was {body!r}"
+        )
+        return httpx.Response(200, json=envelope)
+
+    factory = _ClientFactory(handler)
+
+    with patch.dict(os.environ, env_map, clear=False), \
+         patch("pmf_engine.runner.manifest_loader.httpx.Client", factory):
+        os.environ.pop("INSTRUCTION", None)
+        RunnerConfig.from_env()
+
+    assert len(factory.requests) == 1, (
+        f"runner must hit broker exactly once, got {len(factory.requests)}"
+    )

--- a/pmf_engine/tests/test_lambda_manifest_loader.py
+++ b/pmf_engine/tests/test_lambda_manifest_loader.py
@@ -459,6 +459,181 @@ class TestInstructionVersionIdPinning:
 
 
 # ---------------------------------------------------------------------------
+# Attachment VersionId pinning
+#
+# Index entries can declare `attachment_keys: list[str]` pointing at sidecar
+# objects in S3 (e.g. lookup CSVs, reference markdown). To close the publish-
+# during-run race the same way we do for manifest+instruction, Lambda must
+# HEAD each attachment key, capture VersionIds, and forward them via the
+# routing dict so the runner can pin its broker fetch.
+#
+# Symmetric error contract to _fetch_instruction_version_id: a 404 on a
+# single attachment is benign (publish-pipeline bug, runner will discover it
+# when broker fetch fails) and that basename is omitted from the dict; any
+# other ClientError raises ManifestLoaderTransientError so SQS retries and
+# we never silently fall through to "latest" for the published sidecars.
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentVersionIdPinning:
+    def _index_with_attachments(self, attachment_keys: list[str]):
+        return _index_payload(
+            [
+                {
+                    "id": "smoke_test",
+                    "version": 1,
+                    "mode": "win",
+                    "manifest_key": "smoke_test/manifest.json",
+                    "instruction_key": "smoke_test/instruction.md",
+                    "attachment_keys": attachment_keys,
+                },
+            ]
+        )
+
+    def _s3_with_manifest_and_instruction(self, attachment_keys: list[str]) -> FakeS3:
+        s3 = _fake_s3_with_index(self._index_with_attachments(attachment_keys))
+        s3.set_json(BUCKET, "smoke_test/manifest.json", _manifest_payload("smoke_test"))
+        # Always make the instruction HEAD succeed so attachment behavior
+        # is isolated from instruction-side variance.
+        s3.set_object(BUCKET, "smoke_test/instruction.md", b"# instr", version_id="instr_v")
+        return s3
+
+    def test_routing_includes_attachment_version_ids_from_head(self):
+        """Happy path: each attachment_key gets HEADed; the resulting
+        VersionIds appear in routing['attachment_version_ids'] keyed by basename."""
+        keys = ["smoke_test/attachments/lookup.csv", "smoke_test/attachments/notes.md"]
+        s3 = self._s3_with_manifest_and_instruction(keys)
+        s3.set_object(BUCKET, keys[0], b"k,v\n", version_id="lookup_v_abc")
+        s3.set_object(BUCKET, keys[1], b"# notes", version_id="notes_v_xyz")
+        loader = ManifestRoutingLoader(bucket=BUCKET, s3_client=s3)
+
+        routing = loader.routing_for("smoke_test")
+
+        assert routing["attachment_version_ids"] == {
+            "lookup.csv": "lookup_v_abc",
+            "notes.md": "notes_v_xyz",
+        }
+        # Behavioral: HEAD was actually called against both attachment keys.
+        for k in keys:
+            assert s3.calls_for_key(k) == [("head_object", BUCKET, k)], (
+                f"expected exactly one head_object call for {k}"
+            )
+
+    def test_routing_omits_missing_attachment_but_keeps_others(self):
+        """A single attachment 404 is benign: that basename is omitted, other
+        attachments still get pinned. Mirrors the instruction-absent contract:
+        publish-pipeline bug, runner will surface the missing file at fetch
+        time. Dispatch must NOT raise."""
+        keys = ["smoke_test/attachments/lookup.csv", "smoke_test/attachments/notes.md"]
+        s3 = self._s3_with_manifest_and_instruction(keys)
+        # lookup.csv exists; notes.md is missing (404).
+        s3.set_object(BUCKET, keys[0], b"k,v\n", version_id="lookup_v_abc")
+        s3.set_error(BUCKET, keys[1], code="404", op="HeadObject")
+        loader = ManifestRoutingLoader(bucket=BUCKET, s3_client=s3)
+
+        routing = loader.routing_for("smoke_test")
+
+        assert routing["attachment_version_ids"] == {"lookup.csv": "lookup_v_abc"}, (
+            "missing attachment must be omitted from the dict; others must still be pinned"
+        )
+
+    def test_routing_raises_transient_on_attachment_access_denied(self):
+        """AccessDenied on an attachment HEAD means IAM drift — falling back
+        to 'latest' would silently defeat the version-pin guarantee. Must raise
+        Transient so SQS retries."""
+        keys = ["smoke_test/attachments/lookup.csv"]
+        s3 = self._s3_with_manifest_and_instruction(keys)
+        s3.set_error(BUCKET, keys[0], code="AccessDenied", op="HeadObject")
+        loader = ManifestRoutingLoader(bucket=BUCKET, s3_client=s3)
+
+        with pytest.raises(ManifestLoaderError) as exc:
+            loader.routing_for("smoke_test")
+
+        assert isinstance(exc.value, ManifestLoaderTransientError), (
+            f"AccessDenied on attachment HEAD must raise Transient, got {type(exc.value).__name__}"
+        )
+
+    def test_routing_raises_transient_on_attachment_service_unavailable(self):
+        """ServiceUnavailable on an attachment HEAD must raise Transient so
+        SQS retries — silently dropping the version pin defeats the system."""
+        keys = ["smoke_test/attachments/lookup.csv"]
+        s3 = self._s3_with_manifest_and_instruction(keys)
+        s3.set_error(BUCKET, keys[0], code="ServiceUnavailable", op="HeadObject")
+        loader = ManifestRoutingLoader(bucket=BUCKET, s3_client=s3)
+
+        with pytest.raises(ManifestLoaderError) as exc:
+            loader.routing_for("smoke_test")
+
+        assert isinstance(exc.value, ManifestLoaderTransientError)
+
+    def test_routing_returns_empty_dict_when_no_attachment_keys(self):
+        """A manifest without attachment_keys produces an empty dict, not a
+        missing key — the contract downstream (dispatch_handler) checks
+        truthiness, so empty-vs-missing must not matter."""
+        s3 = _fake_s3_with_index(
+            _index_payload(
+                [
+                    {
+                        "id": "smoke_test",
+                        "version": 1,
+                        "mode": "win",
+                        "manifest_key": "smoke_test/manifest.json",
+                        "instruction_key": "smoke_test/instruction.md",
+                    },
+                ]
+            )
+        )
+        s3.set_json(BUCKET, "smoke_test/manifest.json", _manifest_payload("smoke_test"))
+        s3.set_object(BUCKET, "smoke_test/instruction.md", b"# instr", version_id="iv")
+        loader = ManifestRoutingLoader(bucket=BUCKET, s3_client=s3)
+
+        routing = loader.routing_for("smoke_test")
+
+        assert routing["attachment_version_ids"] == {}
+
+    def test_routing_for_with_attachment_keys_still_returns_other_routing_fields(self):
+        """Pin: adding attachment handling must not alter the rest of the
+        routing dict shape. model/timeout_seconds/input_schema/scope/
+        manifest_version_id/instruction_version_id keep working."""
+        keys = ["smoke_test/attachments/lookup.csv"]
+        s3 = self._s3_with_manifest_and_instruction(keys)
+        s3.set_object(BUCKET, keys[0], b"x", version_id="lv1")
+        loader = ManifestRoutingLoader(bucket=BUCKET, s3_client=s3)
+
+        routing = loader.routing_for("smoke_test")
+
+        # Pre-existing fields untouched.
+        assert routing["model"] == "sonnet"
+        assert routing["timeout_seconds"] == 900
+        assert "input_schema" in routing
+        assert "scope" in routing
+        assert "manifest_version_id" in routing
+        assert routing["instruction_version_id"] == "instr_v"
+        # New field present.
+        assert routing["attachment_version_ids"] == {"lookup.csv": "lv1"}
+
+    def test_routing_skips_attachment_key_with_wrong_prefix(self):
+        """Defense-in-depth: an attachment_key not under the experiment's
+        own attachments/ prefix is suspicious (publish-pipeline bug or
+        manual S3 edit). Skip it with a WARN rather than including it under
+        a misleading basename."""
+        keys = [
+            "smoke_test/attachments/good.md",
+            "other_experiment/attachments/leaked.md",  # wrong prefix
+        ]
+        s3 = self._s3_with_manifest_and_instruction(keys)
+        s3.set_object(BUCKET, keys[0], b"ok", version_id="good_v")
+        s3.set_object(BUCKET, keys[1], b"leak", version_id="leak_v")
+        loader = ManifestRoutingLoader(bucket=BUCKET, s3_client=s3)
+
+        routing = loader.routing_for("smoke_test")
+
+        assert routing["attachment_version_ids"] == {"good.md": "good_v"}, (
+            "wrong-prefix attachment key must be skipped, not exposed under a bare basename"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Scope validation (defense-in-depth on top of publish-time meta-schema)
 # ---------------------------------------------------------------------------
 

--- a/pmf_engine/tests/test_manifest_loader.py
+++ b/pmf_engine/tests/test_manifest_loader.py
@@ -196,3 +196,126 @@ class TestManifestLoaderEnvelopeValidation:
         with pytest.raises(ManifestLoadError) as exc:
             load_from_broker("smoke_test", BROKER_URL, BROKER_TOKEN, client=_client_returning(handler))
         assert "non-json" in str(exc.value).lower() or "json" in str(exc.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# attachment_version_ids forwarding into POST body + envelope acceptance
+#
+# The whole point of attachment VersionId pinning is end-to-end: dispatch
+# captures, runner forwards into POST /experiment/manifest, broker resolves
+# bytes. If load_from_broker drops the dict, the broker silently falls
+# through to "latest" and the publish-during-run race re-opens.
+# ---------------------------------------------------------------------------
+
+
+class TestManifestLoaderAttachmentVersionIds:
+    def test_attachment_version_ids_included_in_broker_request_body(self):
+        """When the caller passes attachment_version_ids, it MUST appear in the
+        POST body so the broker can pin its S3 GetObject calls."""
+        envelope = _good_envelope()
+        captured: dict = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json=envelope)
+
+        pin = {"lookup.csv": "Vlk1", "notes.md": "Vnt2"}
+        load_from_broker(
+            "smoke_test",
+            BROKER_URL,
+            BROKER_TOKEN,
+            attachment_version_ids=pin,
+            client=_client_returning(handler),
+        )
+
+        assert captured["body"]["attachment_version_ids"] == pin
+
+    def test_attachment_version_ids_omitted_when_none(self):
+        """Calling with attachment_version_ids=None (default) must NOT add
+        the key to the request body — that would force older brokers to
+        reject as 'unexpected field'."""
+        envelope = _good_envelope()
+        captured: dict = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json=envelope)
+
+        load_from_broker(
+            "smoke_test", BROKER_URL, BROKER_TOKEN, client=_client_returning(handler)
+        )
+
+        assert "attachment_version_ids" not in captured["body"]
+
+    def test_envelope_parses_resolved_attachment_version_ids(self):
+        """Brokers that pinned attachments echo the resolved VersionIds back
+        in the envelope so the runner can log them as an audit trail.
+        load_from_broker must surface this dict on the returned envelope."""
+        envelope = _good_envelope()
+        envelope["attachments"] = {"lookup.csv": "k,v\n"}
+        envelope["resolved_attachment_version_ids"] = {"lookup.csv": "Vlk_resolved"}
+
+        def handler(request):
+            return httpx.Response(200, json=envelope)
+
+        result = load_from_broker(
+            "smoke_test", BROKER_URL, BROKER_TOKEN, client=_client_returning(handler)
+        )
+        assert result["resolved_attachment_version_ids"] == {"lookup.csv": "Vlk_resolved"}
+
+    def test_envelope_absent_attachments_key_logs_info(self, caplog):
+        """If the broker response omits the `attachments` key entirely (an
+        older broker not yet redeployed) the runner logs INFO so operators
+        can distinguish 'old broker' from 'no attachments published'. Empty
+        attachments dict (key present, value {}) must NOT trigger the log —
+        that's the 'no attachments' case."""
+        envelope = _good_envelope()
+        assert "attachments" not in envelope
+
+        def handler(request):
+            return httpx.Response(200, json=envelope)
+
+        import logging
+        with caplog.at_level(logging.INFO, logger="pmf_engine.runner.manifest_loader"):
+            load_from_broker(
+                "smoke_test", BROKER_URL, BROKER_TOKEN, client=_client_returning(handler)
+            )
+
+        messages = [r.message for r in caplog.records if r.name == "pmf_engine.runner.manifest_loader"]
+        assert any("attachments" in m.lower() and "older broker" in m.lower() for m in messages), (
+            f"expected an INFO log mentioning attachments + older broker; got {messages!r}"
+        )
+
+    def test_envelope_empty_attachments_dict_does_not_log_older_broker(self, caplog):
+        envelope = _good_envelope()
+        envelope["attachments"] = {}
+
+        def handler(request):
+            return httpx.Response(200, json=envelope)
+
+        import logging
+        with caplog.at_level(logging.INFO, logger="pmf_engine.runner.manifest_loader"):
+            load_from_broker(
+                "smoke_test", BROKER_URL, BROKER_TOKEN, client=_client_returning(handler)
+            )
+
+        messages = [r.message for r in caplog.records if r.name == "pmf_engine.runner.manifest_loader"]
+        assert not any("older broker" in m.lower() for m in messages), (
+            "empty attachments dict must NOT log 'older broker' — that's a "
+            "different operator signal (no attachments published) vs (broker too old to ship them)"
+        )
+
+    def test_envelope_rejects_non_dict_resolved_attachment_version_ids(self):
+        """Defense-in-depth: if the broker returns a malformed value for
+        resolved_attachment_version_ids (e.g. a list), reject loudly rather
+        than carrying garbage into the runner's audit trail."""
+        envelope = _good_envelope()
+        envelope["resolved_attachment_version_ids"] = ["not", "a", "dict"]
+
+        def handler(request):
+            return httpx.Response(200, json=envelope)
+
+        with pytest.raises(ManifestLoadError):
+            load_from_broker(
+                "smoke_test", BROKER_URL, BROKER_TOKEN, client=_client_returning(handler)
+            )

--- a/pmf_engine/tests/test_runner_main.py
+++ b/pmf_engine/tests/test_runner_main.py
@@ -6,13 +6,43 @@ import sys
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch, call
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from pmf_engine.runner.config import RunnerConfig
 from pmf_engine.runner.harness.base import HarnessResult
 from pmf_engine.runner.main import run_experiment, get_harness, main
+
+
+class Clock:
+    """Controllable monotonic-clock fake.
+
+    Replaces the brittle `iter([100.0, 130.0, 130.0, 130.0])` pattern that
+    silently masked drift when a refactor added one more `time.monotonic()`
+    call (StopIteration → fallback default → test still passes for the
+    wrong reason).
+
+    Usage:
+        clock = Clock(start=100.0)
+        with patch("pmf_engine.runner.main.time.monotonic", clock.now):
+            # tick the clock manually between assertions
+            clock.advance(30.0)
+            ...
+
+    Each `.now()` returns the *current* cursor — no consumption, no
+    StopIteration. The caller controls all advancement explicitly via
+    `.advance(seconds)`.
+    """
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._now = start
+
+    def now(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
 
 
 def _make_config(**overrides):
@@ -42,8 +72,6 @@ class TestUploadLogsObservability:
     keep the swallow (terminal callback is more important than logs) but
     make it observable.
     """
-
-    import logging as _logging  # class-local to avoid top-of-file churn
 
     def test_upload_logs_failure_warns_with_run_id_experiment_id_and_stacktrace(
         self, tmp_path
@@ -94,12 +122,6 @@ class TestUploadLogsObservability:
         assert "smoke_test" in msg, f"expected experiment_id in log, got: {msg}"
         assert "RuntimeError" in msg, f"expected exc_type in log, got: {msg}"
         assert warns[0].exc_info is not None, "expected exc_info=True so stacktrace is preserved"
-
-
-def test_get_harness_returns_claude_sdk():
-    harness = get_harness("claude_sdk")
-    from pmf_engine.runner.harness.claude_sdk import ClaudeSdkHarness
-    assert isinstance(harness, ClaudeSdkHarness)
 
 
 def test_get_harness_raises_on_unknown():
@@ -200,7 +222,7 @@ async def test_publish_failure_then_report_status_failure_leaves_callback_unsent
     mock_publish.publish.side_effect = Exception("Broker down")
     mock_publish.report_status.side_effect = Exception("Broker still down")
 
-    with pytest.raises(Exception):
+    with pytest.raises(Exception, match="Broker down"):
         await run_experiment(config, harness=mock_harness)
 
     assert _is_callback_already_sent() is False, (
@@ -227,6 +249,380 @@ async def test_main_writes_instruction_to_workspace():
             assert f.read() == "# Test Instruction\n\nDo the thing."
 
 
+# ---------------------------------------------------------------------------
+# Attachments — runner writes sidecar files to /workspace/ before agent spawn
+# ---------------------------------------------------------------------------
+#
+# Contract: every entry in config.attachments lands as /workspace/<basename>
+# *before* run_experiment is invoked, so the agent can read it from turn 1.
+# The runner also re-checks the safety constraints the publisher/broker
+# already enforced — defense in depth, because the workspace is a real
+# filesystem.
+
+
+@pytest.mark.asyncio
+async def test_main_writes_attachments_to_workspace_before_running_experiment():
+    """Pin strict ordering: attachments land on disk AFTER from_env returns
+    but BEFORE run_experiment is invoked. Use two snapshot hooks:
+
+      1. from_env side_effect — fires before the workspace-setup section
+         runs. Attachments must NOT yet be on disk.
+      2. run_experiment side_effect — fires after the workspace-setup
+         section finishes. Attachments MUST be on disk.
+
+    The previous version only snapshotted at run_experiment, which couldn't
+    distinguish "writes happen before run" from "writes happen at any point
+    in main()". This catches a regression where attachment writes drift to
+    after run_experiment.start()."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = _make_config(
+            instruction="# Hello",
+            attachments={
+                "catalog.md": "# Catalog\n\n- alpha\n- beta\n",
+                "lookup.csv": "k,v\n1,a\n",
+            },
+        )
+
+        files_before_setup: dict[str, str] = {}
+        files_at_run_time: dict[str, str] = {}
+
+        def _snapshot_before_setup():
+            for name in os.listdir(tmpdir):
+                path = os.path.join(tmpdir, name)
+                if os.path.isfile(path):
+                    with open(path) as fh:
+                        files_before_setup[name] = fh.read()
+            return config
+
+        async def _capture_workspace_state(*args, **kwargs):
+            for name in os.listdir(tmpdir):
+                path = os.path.join(tmpdir, name)
+                if os.path.isfile(path):
+                    with open(path) as fh:
+                        files_at_run_time[name] = fh.read()
+
+        with patch.dict(os.environ, {"WORKSPACE_DIR": tmpdir}):
+            with patch(
+                "pmf_engine.runner.main.RunnerConfig.from_env",
+                side_effect=_snapshot_before_setup,
+            ):
+                with patch("pmf_engine.runner.main.init_config"):
+                    with patch("pmf_engine.runner.main.publish"):
+                        with patch(
+                            "pmf_engine.runner.main.run_experiment",
+                            side_effect=_capture_workspace_state,
+                        ):
+                            await main()
+
+        # BEFORE workspace setup: attachments must NOT be on disk yet.
+        assert "catalog.md" not in files_before_setup, (
+            f"attachments must not exist before from_env returns; got: "
+            f"{list(files_before_setup.keys())!r}"
+        )
+        assert "lookup.csv" not in files_before_setup
+        assert "instruction.md" not in files_before_setup
+
+        # AT run_experiment time: every attachment + instruction.md is on disk.
+        assert files_at_run_time.get("catalog.md") == "# Catalog\n\n- alpha\n- beta\n"
+        assert files_at_run_time.get("lookup.csv") == "k,v\n1,a\n"
+        assert files_at_run_time.get("instruction.md") == "# Hello"
+
+
+@pytest.mark.asyncio
+async def test_main_rejects_reserved_basename_attachment():
+    """The publisher and broker already refuse these, but the runner
+    double-checks at write time. A broker drift that surfaces a reserved
+    basename must crash loudly, not silently clobber instruction.md.
+
+    The runner's main() catches the AttachmentSafetyViolation, reports
+    "failed" with reason_code='AttachmentSafetyViolation' so ops can grep
+    for the distinct cause, then re-raises — so callers see the original
+    exception, not a SystemExit."""
+    from pmf_engine.runner.main import AttachmentSafetyViolation
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = _make_config(
+            instruction="legit instruction",
+            attachments={"instruction.md": "MALICIOUS — would clobber instruction"},
+        )
+
+        with patch.dict(os.environ, {"WORKSPACE_DIR": tmpdir}):
+            with patch("pmf_engine.runner.main.RunnerConfig.from_env", return_value=config):
+                with patch("pmf_engine.runner.main.init_config"):
+                    with patch("pmf_engine.runner.main.publish") as mock_publish:
+                        with patch("pmf_engine.runner.main.run_experiment", new_callable=AsyncMock) as mock_run:
+                            with pytest.raises(AttachmentSafetyViolation, match="reserved basename"):
+                                await main()
+
+        # The agent must NEVER have been spawned — the bad attachment is a
+        # routing-level bug, not something the agent can recover from.
+        mock_run.assert_not_called()
+        # The legit instruction.md write happened before the attachment
+        # write, so the file exists with the *legitimate* content — never
+        # the attempted clobber.
+        with open(os.path.join(tmpdir, "instruction.md")) as fh:
+            content = fh.read()
+        assert content == "legit instruction"
+        # And the runner must have reported failure with the distinct
+        # error type so the run doesn't hang in PENDING and ops can grep
+        # CloudWatch for AttachmentSafetyViolation specifically.
+        mock_publish.report_status.assert_called()
+        failed_call = mock_publish.report_status.call_args
+        assert failed_call[0][0] == "failed"
+        assert failed_call[1]["reason_code"] == "AttachmentSafetyViolation"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("unsafe_name", [
+    "../escape.md",        # parent-dir traversal
+    "/abs/path.md",        # absolute path
+    "nested/file.md",      # nested subdir (not a basename)
+])
+async def test_main_rejects_unsafe_attachment_basenames(unsafe_name):
+    """Path-safety belt-and-suspenders: the runner refuses any attachment
+    name that isn't a clean basename, even if the broker somehow forwards
+    one. Without this guard, a malformed broker response could write
+    outside /workspace/ entirely.
+
+    Pin reason_code='AttachmentSafetyViolation' so the unsafe-basename and
+    reserved-basename branches share the same greppable error type but
+    distinct error messages."""
+    from pmf_engine.runner.main import AttachmentSafetyViolation
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = _make_config(
+            instruction="legit",
+            attachments={unsafe_name: "would-escape-or-nest"},
+        )
+
+        with patch.dict(os.environ, {"WORKSPACE_DIR": tmpdir}):
+            with patch("pmf_engine.runner.main.RunnerConfig.from_env", return_value=config):
+                with patch("pmf_engine.runner.main.init_config"):
+                    with patch("pmf_engine.runner.main.publish") as mock_publish:
+                        with patch("pmf_engine.runner.main.run_experiment", new_callable=AsyncMock) as mock_run:
+                            with pytest.raises(AttachmentSafetyViolation, match="unsafe basename"):
+                                await main()
+
+        mock_run.assert_not_called()
+        failed_calls = [
+            c for c in mock_publish.report_status.call_args_list
+            if c[0][0] == "failed"
+        ]
+        assert failed_calls
+        assert failed_calls[-1].kwargs.get("reason_code") == "AttachmentSafetyViolation"
+
+
+@pytest.mark.asyncio
+async def test_main_writes_attachments_with_utf8_encoding(tmp_path):
+    """Attachments may contain non-ASCII content (em-dashes, CJK, smart quotes).
+    The runner must explicitly write UTF-8 — otherwise on a locale-C container
+    the default `open()` encoding is ASCII and non-ASCII bodies crash mid-write,
+    leaving a partial file.
+    """
+    body = "Hello—world. 你好.\n"  # em-dash + "hello" in Chinese
+    config = _make_config(
+        instruction="# Hello",
+        attachments={"unicode.md": body},
+    )
+
+    with patch.dict(os.environ, {"WORKSPACE_DIR": str(tmp_path)}):
+        with patch("pmf_engine.runner.main.RunnerConfig.from_env", return_value=config):
+            with patch("pmf_engine.runner.main.init_config"):
+                with patch("pmf_engine.runner.main.publish"):
+                    with patch("pmf_engine.runner.main.run_experiment", new_callable=AsyncMock):
+                        await main()
+
+    written_path = tmp_path / "unicode.md"
+    on_disk_bytes = written_path.read_bytes()
+    # Exact UTF-8 byte sequence — proves no locale fallback happened.
+    assert on_disk_bytes == body.encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_main_attachment_write_uses_exclusive_create(tmp_path):
+    """`open(..., "w")` silently truncates. `open(..., "x")` raises
+    FileExistsError on collision — a non-reserved-but-already-present file
+    must NOT be clobbered, even though the reserved-name set blocks the
+    obvious cases. Defense in depth for any file the runner/harness writes
+    that isn't in the reserved set."""
+    # Pre-create a file at the target attachment path with old content.
+    target = tmp_path / "preexisting.txt"
+    target.write_text("ORIGINAL — must not be clobbered")
+
+    config = _make_config(
+        instruction="# Hello",
+        attachments={"preexisting.txt": "new contents"},
+    )
+
+    with patch.dict(os.environ, {"WORKSPACE_DIR": str(tmp_path)}):
+        with patch("pmf_engine.runner.main.RunnerConfig.from_env", return_value=config):
+            with patch("pmf_engine.runner.main.init_config"):
+                with patch("pmf_engine.runner.main.publish") as mock_publish:
+                    with patch("pmf_engine.runner.main.run_experiment", new_callable=AsyncMock) as mock_run:
+                        with pytest.raises((FileExistsError, RuntimeError)):
+                            await main()
+
+    # File contents must be unchanged — the exclusive-create open raised
+    # *before* writing.
+    assert target.read_text() == "ORIGINAL — must not be clobbered"
+    # Agent must NOT have been spawned.
+    mock_run.assert_not_called()
+    # Runner must have surfaced a failed callback so the run doesn't hang
+    # PENDING in gp-api.
+    mock_publish.report_status.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_attachment_safety_violation_log_includes_error_type(tmp_path):
+    """When the runner rejects a reserved-name attachment, it must emit a
+    structured log with errorType=reserved_basename so ops can grep
+    CloudWatch for the specific cause without parsing free-form messages."""
+    import logging
+    import pmf_engine.runner.main as _main_mod
+
+    config = _make_config(
+        instruction="legit",
+        attachments={"instruction.md": "would clobber"},
+    )
+
+    from pmf_engine.runner.main import AttachmentSafetyViolation
+
+    captured: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    handler = _Capture(level=logging.ERROR)
+    _main_mod.logger.addHandler(handler)
+    try:
+        with patch.dict(os.environ, {"WORKSPACE_DIR": str(tmp_path)}):
+            with patch("pmf_engine.runner.main.RunnerConfig.from_env", return_value=config):
+                with patch("pmf_engine.runner.main.init_config"):
+                    with patch("pmf_engine.runner.main.publish"):
+                        with patch("pmf_engine.runner.main.run_experiment", new_callable=AsyncMock):
+                            with pytest.raises(AttachmentSafetyViolation):
+                                await main()
+    finally:
+        _main_mod.logger.removeHandler(handler)
+
+    msgs = [r.getMessage() for r in captured]
+    joined = "\n".join(msgs)
+    assert "errorType=reserved_basename" in joined, (
+        f"expected structured log with errorType=reserved_basename; got: {msgs!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_main_partial_attachment_write_failure_does_not_invoke_run_experiment(tmp_path):
+    """If attachment N raises mid-loop, partial writes from N-1 and earlier
+    stay on disk (current behavior — workspace state is undefined). The
+    contract worth pinning: run_experiment must NOT be invoked and the
+    runner must report 'failed' with the safety-violation reason code.
+    """
+    from pmf_engine.runner.main import AttachmentSafetyViolation
+
+    config = _make_config(
+        instruction="instruction",
+        attachments={
+            "first.md": "first body",
+            "instruction.md": "RESERVED — must raise",
+            "third.md": "third body",
+        },
+    )
+
+    with patch.dict(os.environ, {"WORKSPACE_DIR": str(tmp_path)}):
+        with patch("pmf_engine.runner.main.RunnerConfig.from_env", return_value=config):
+            with patch("pmf_engine.runner.main.init_config"):
+                with patch("pmf_engine.runner.main.publish") as mock_publish:
+                    with patch("pmf_engine.runner.main.run_experiment", new_callable=AsyncMock) as mock_run:
+                        with pytest.raises(AttachmentSafetyViolation):
+                            await main()
+
+    # run_experiment never invoked.
+    mock_run.assert_not_called()
+
+    # report_status('failed') called with the new error class.
+    failed_calls = [
+        c for c in mock_publish.report_status.call_args_list
+        if c[0][0] == "failed"
+    ]
+    assert failed_calls, "expected a failed callback"
+    assert any(
+        c.kwargs.get("reason_code") == "AttachmentSafetyViolation"
+        for c in failed_calls
+    ), (
+        f"expected reason_code='AttachmentSafetyViolation'; got: "
+        f"{[c.kwargs.get('reason_code') for c in failed_calls]!r}"
+    )
+
+    # Document current partial-write behavior — first.md on disk, instruction.md
+    # is the legit one (written before the attachment loop ran), third.md
+    # never reached the disk. If a future "clean up on failure" change lands,
+    # this assertion forces a deliberate update.
+    assert (tmp_path / "first.md").exists()
+    assert (tmp_path / "instruction.md").read_text() == "instruction"
+    assert not (tmp_path / "third.md").exists()
+
+
+@pytest.mark.asyncio
+async def test_main_works_with_runner_config_default_attachments(tmp_path):
+    """Integration pin for D13: when RunnerConfig is constructed without
+    attachments=... (the default factory produces an empty dict), main.py's
+    attachment-write loop must iterate cleanly — no AttributeError on None,
+    no extra files created, run_experiment still spawned. This catches
+    regressions where the default factory is removed without auditing the
+    callsite."""
+    # Construct WITHOUT attachments kwarg — exercises default_factory.
+    config = RunnerConfig(
+        experiment_id="hello_world",
+        run_id="run-default-attachments",
+        organization_slug="org-x",
+        instruction="# Hi",
+        broker_url="https://broker.test",
+        broker_token="tok",
+    )
+    # Sanity: the default factory produced an empty dict, not None.
+    assert config.attachments == {}
+
+    with patch.dict(os.environ, {"WORKSPACE_DIR": str(tmp_path)}):
+        with patch("pmf_engine.runner.main.RunnerConfig.from_env", return_value=config):
+            with patch("pmf_engine.runner.main.init_config"):
+                with patch("pmf_engine.runner.main.publish"):
+                    with patch("pmf_engine.runner.main.run_experiment", new_callable=AsyncMock) as mock_run:
+                        await main()
+
+    mock_run.assert_called_once()
+    # Only instruction.md present — no spurious attachment files.
+    assert (tmp_path / "instruction.md").exists()
+    extra_files = [
+        p.name for p in tmp_path.iterdir()
+        if p.is_file() and p.name != "instruction.md"
+    ]
+    assert extra_files == [], (
+        f"default-attachments path must not create extra files; got: {extra_files!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_main_handles_empty_attachments_dict():
+    """The common case (experiment publishes no sidecars) must not regress.
+    Empty attachments dict → instruction.md written, run_experiment called,
+    no errors."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = _make_config(instruction="just instruction", attachments={})
+
+        with patch.dict(os.environ, {"WORKSPACE_DIR": tmpdir}):
+            with patch("pmf_engine.runner.main.RunnerConfig.from_env", return_value=config):
+                with patch("pmf_engine.runner.main.init_config"):
+                    with patch("pmf_engine.runner.main.publish"):
+                        with patch("pmf_engine.runner.main.run_experiment", new_callable=AsyncMock) as mock_run:
+                            await main()
+
+        mock_run.assert_called_once()
+        assert os.path.exists(os.path.join(tmpdir, "instruction.md"))
+
+
 @pytest.mark.asyncio
 async def test_main_sends_failed_status_on_timeout():
     config = _make_config(instruction="Do stuff", timeout_seconds=1)
@@ -247,6 +643,10 @@ async def test_main_sends_failed_status_on_timeout():
     statuses = [c[0][0] for c in status_calls]
     assert "failed" in statuses
     failed_call = next(c for c in status_calls if c[0][0] == "failed")
+    # Primary contract: reason_code is the stable greppable field operators
+    # alert on. The free-form detail string is a secondary, human-readable
+    # signal.
+    assert failed_call[1]["reason_code"] == "Timeout"
     assert "timed out" in failed_call[1]["detail"]
 
 
@@ -954,7 +1354,7 @@ class TestCallbackLifecycleFix:
                         with patch("pmf_engine.runner.main.publish", mock_pub):
                             with patch("pmf_engine.runner.main.get_harness", return_value=mock_harness):
                                 with patch("pmf_engine.runner.main._upload_logs"):
-                                    with pytest.raises(Exception):
+                                    with pytest.raises(Exception, match="Broker down"):
                                         await main()
 
         assert statuses_reported.count("failed") == 1, (
@@ -975,18 +1375,17 @@ class TestFailureCallbacksCarryDurationAndCost:
     @patch("pmf_engine.runner.main.publish")
     async def test_harness_failure_reports_duration_seconds(self, mock_publish, _mock_logs):
         config = _make_config()
+        clock = Clock(start=100.0)
+
+        async def harness_run_advances_clock(*args, **kwargs):
+            # The agent ran for 30s before crashing.
+            clock.advance(30.0)
+            raise RuntimeError("Agent crashed")
+
         mock_harness = AsyncMock()
-        mock_harness.run.side_effect = RuntimeError("Agent crashed")
+        mock_harness.run.side_effect = harness_run_advances_clock
 
-        monotonic_values = iter([100.0, 130.0, 130.0, 130.0])
-
-        def fake_monotonic():
-            try:
-                return next(monotonic_values)
-            except StopIteration:
-                return 130.0
-
-        with patch("pmf_engine.runner.main.time.monotonic", side_effect=fake_monotonic):
+        with patch("pmf_engine.runner.main.time.monotonic", clock.now):
             with pytest.raises(RuntimeError, match="Agent crashed"):
                 await run_experiment(config, harness=mock_harness)
 
@@ -1006,18 +1405,16 @@ class TestFailureCallbacksCarryDurationAndCost:
             cost_usd=0.13,
             num_turns=2,
         )
+        clock = Clock(start=100.0)
+
+        async def harness_run_advances_clock(*args, **kwargs):
+            clock.advance(42.5)
+            return fake_result
+
         mock_harness = AsyncMock()
-        mock_harness.run.return_value = fake_result
+        mock_harness.run.side_effect = harness_run_advances_clock
 
-        monotonic_values = iter([100.0, 142.5, 142.5, 142.5])
-
-        def fake_monotonic():
-            try:
-                return next(monotonic_values)
-            except StopIteration:
-                return 142.5
-
-        with patch("pmf_engine.runner.main.time.monotonic", side_effect=fake_monotonic):
+        with patch("pmf_engine.runner.main.time.monotonic", clock.now):
             await run_experiment(config, harness=mock_harness)
 
         mock_publish.report_status.assert_called_once()
@@ -1037,19 +1434,17 @@ class TestFailureCallbacksCarryDurationAndCost:
             cost_usd=0.21,
             num_turns=1,
         )
+        clock = Clock(start=100.0)
+
+        async def harness_run_advances_clock(*args, **kwargs):
+            clock.advance(15.0)
+            return fake_result
+
         mock_harness = AsyncMock()
-        mock_harness.run.return_value = fake_result
+        mock_harness.run.side_effect = harness_run_advances_clock
         mock_publish.publish.side_effect = Exception("Broker down")
 
-        monotonic_values = iter([100.0, 115.0, 115.0, 115.0])
-
-        def fake_monotonic():
-            try:
-                return next(monotonic_values)
-            except StopIteration:
-                return 115.0
-
-        with patch("pmf_engine.runner.main.time.monotonic", side_effect=fake_monotonic):
+        with patch("pmf_engine.runner.main.time.monotonic", clock.now):
             with pytest.raises(Exception, match="Broker down"):
                 await run_experiment(config, harness=mock_harness)
 


### PR DESCRIPTION
## Summary

Adds an end-to-end sidecar-file channel for PMF experiments. Each experiment can ship arbitrary text files under `experiments/<id>/attachments/`; the publisher uploads them to S3, the broker parallel-fetches them on `/experiment/manifest`, and the runner writes each to `/workspace/<basename>` before spawning the agent. Companion publisher changes live in the runbooks repo.

Also includes the existing `runner: accept oneOf/anyOf/allOf at root in output_schema` change (the original branch reason) and a substantial round of safety hardening from a multi-agent code review.

## What's new

- **VersionId pinning end-to-end.** `control_plane/manifest_loader` HEADs each attachment object at routing time and captures the VersionId; `dispatch_handler` serializes the dict into an `ATTACHMENT_VERSION_IDS` env var; `runner/config` parses it and forwards to `load_from_broker`, which threads it into the broker request body. Symmetric with `manifest_version_id` / `instruction_version_id`. Closes the publish-during-run race for attachments.
- **Broker hardening.** Per-object size cap (5 MiB), per-experiment count cap (32), shared bounded ThreadPoolExecutor (16 workers), bounded LRU cache replacing the flush-on-full pattern, shared `_is_safe_attachment_basename` helper used by request validator + index iteration, ERROR + `broker_attachment_index_drift` metric on all silent-skip sites (`non_string_key`, `wrong_prefix`, `unsafe_basename`, `non_list_attachment_keys`), `_fetch_object` label parameterization so 404 details name the object type accurately.
- **Runner hardening.** `AttachmentSafetyViolation(RuntimeError)` with distinct `errorType=` tags per cause; writes use `open("x", encoding="utf-8")` + realpath containment check.
- **`ManifestEnvelope` split** using `typing.NotRequired` so consumer-side `envelope["manifest"]` stays type-safe.
- **`_is_draft7_object_schema` recurses** into combinator branches, rejecting `{"oneOf": [{}]}` and other no-op shapes.

## Test plan

- [x] `uv run pytest broker/tests/test_experiment_manifest.py pmf_engine/tests/` — 501 passed, 1 skipped locally.
- [x] BOUNDARY_TESTS.md updated: 142 → 172 boundaries across new sections S/T/U/V.
- [ ] After deploy to dev: drop `experiments/meeting_briefing/attachments/test.md` in runbooks (companion PR), publish to dev, dispatch a `meeting_briefing` run, tail `/ecs/pmf-engine-dev` for `"Wrote attachment to /workspace/test.md"`.
- [ ] Promote develop → qa after soak.
- [ ] Promote qa → master after qa validation.

## Deploy ordering

This PR (gp-ai-projects) should land **before** the runbooks publisher PR. Older broker reading a new index with `attachment_keys` is safe (it just ignores them); but a new publisher writing `attachment_keys` to an old broker means the runner won't see the files. Land here first, then runbooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches the end-to-end dispatch→broker→runner manifest path, adding new S3 fetches, caching/concurrency changes, and filesystem writes in the runner; bugs here could break experiment startup or expose unsafe file writes despite added validation.
> 
> **Overview**
> Adds an **attachments sidecar channel** to PMF experiments: `index.json` can list per-experiment `attachment_keys`, the broker’s `POST /experiment/manifest` now fetches and returns `attachments` (basename→UTF-8 body) plus `resolved_attachment_version_ids`, and the runner writes these files into `/workspace/<basename>` before starting the agent.
> 
> Implements **end-to-end VersionId pinning** for attachments: control-plane `ManifestRoutingLoader` HEADs attachment keys to capture VersionIds, `dispatch_handler` serializes them into `ATTACHMENT_VERSION_IDS`, the runner parses/forwards them to `load_from_broker`, and the broker applies them per attachment.
> 
> Hardens the broker fetch path with a bounded shared executor, per-attachment size and per-experiment count caps, an LRU object cache, safer basename validation, less-informative 404s (no S3 key leakage), and new metrics for index fetch failures and attachment index drift. The runner also tightens `output_schema` validation to accept combinator-at-root Draft-07 schemas while rejecting no-op combinators, and adds attachment path-safety checks (reserved names, traversal/escape, exclusive create, UTF-8 writes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b94eaa885226c78b0970e98f6328b3457913267f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->