### PR TITLE
fix(broker): redeem Clerk actor tokens via /v1/client/sign_ins

### DIFF
--- a/broker/clerk_client.py
+++ b/broker/clerk_client.py
@@ -3,6 +3,7 @@ import base64
 import json
 import time
 from typing import TypedDict
+from urllib.parse import parse_qs, urlsplit
 
 import httpx
 
@@ -66,30 +67,44 @@ class ClerkClient:
         return body
 
     async def redeem_actor_token(self, actor_token_url: str) -> ClerkSessionInfo:
-        # The actor_token_url comes back from clerkClient.actorTokens.create,
-        # in the form https://<frontend-api>/v1/client/sign_in_tokens/<id>?token=<jwt>.
-        # Hitting it (POST, no body) creates a Client + Session and returns both;
-        # we only need the session id (we mint fresh JWTs per call via Backend API).
+        # actor_token_url comes back from POST /v1/actor_tokens as
+        # https://<frontend-api>/v1/tickets/accept?ticket=<jwt>. That URL is the
+        # browser-facing Account Portal flow (POST→405, GET→HTML), not a
+        # server-redeemable JSON endpoint. Extract the ticket and submit it to
+        # POST /v1/client/sign_ins with strategy=ticket, which is what
+        # @clerk/clerk-js does internally via signIn.ticket({ ticket }). Response
+        # is JSON: { response: { status: "complete", created_session_id, ... } }.
         if not actor_token_url.startswith(f"{self._frontend_api_base}/"):
             raise ClerkClientError(
                 f"actor token URL is not from the configured Clerk frontend API base "
                 f"(base={self._frontend_api_base}, got={actor_token_url[:64]}...)"
             )
-        resp = await self._http.post(actor_token_url)
+        ticket_values = parse_qs(urlsplit(actor_token_url).query).get("ticket")
+        if not ticket_values:
+            raise ClerkClientError(
+                f"actor token URL missing ticket query parameter (url={actor_token_url[:80]}...)"
+            )
+        resp = await self._http.post(
+            f"{self._frontend_api_base}/v1/client/sign_ins",
+            data={"strategy": "ticket", "ticket": ticket_values[0]},
+        )
         if resp.status_code >= 400:
             raise ClerkClientError(
                 f"actor token redemption failed status={resp.status_code} body={resp.text[:500]}"
             )
         body = resp.json()
-        # The Clerk Frontend API response shape varies a bit across versions.
-        # Try the common keys; fail loudly if neither is present.
-        session_id = (
-            body.get("response", {}).get("created_session_id")
-            or body.get("client", {}).get("last_active_session_id")
-        )
+        response = body.get("response") or {}
+        status = response.get("status")
+        if status != "complete":
+            raise ClerkClientError(
+                f"actor token redemption returned non-complete status={status} "
+                f"errors={body.get('errors')}"
+            )
+        session_id = response.get("created_session_id")
         if not session_id:
             raise ClerkClientError(
-                f"actor token redemption response missing session id; keys={list(body.keys())}"
+                f"actor token redemption response missing created_session_id; "
+                f"response_keys={list(response.keys())}"
             )
         return {"session_id": session_id}
 

--- a/broker/tests/test_clerk_client.py
+++ b/broker/tests/test_clerk_client.py
@@ -95,60 +95,90 @@ class TestMintSessionJwt:
 
 
 class TestRedeemActorToken:
-    async def test_returns_session_id_from_response_created_session_id(self):
-        transport = httpx.MockTransport(
-            lambda req: httpx.Response(
+    async def test_posts_form_encoded_ticket_to_sign_ins_endpoint(self):
+        captured: dict = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured["method"] = req.method
+            captured["url"] = str(req.url)
+            captured["content_type"] = req.headers.get("content-type")
+            captured["body"] = req.content.decode()
+            return httpx.Response(
                 200,
-                json={"response": {"created_session_id": "sess_abc"}},
+                json={
+                    "response": {
+                        "status": "complete",
+                        "created_session_id": "sess_abc",
+                    }
+                },
             )
-        )
+
+        transport = httpx.MockTransport(handler)
         client = _make_client_with_http(transport)
 
         info = await client.redeem_actor_token(
-            "https://x.clerk.app/v1/client/sign_in_tokens/tok_1?token=jwt"
+            "https://x.clerk.app/v1/tickets/accept?ticket=jwt-value"
         )
 
         assert info == {"session_id": "sess_abc"}
-        await client.aclose()
-
-    async def test_falls_back_to_client_last_active_session_id(self):
-        transport = httpx.MockTransport(
-            lambda req: httpx.Response(
-                200,
-                json={"client": {"last_active_session_id": "sess_xyz"}},
-            )
-        )
-        client = _make_client_with_http(transport)
-
-        info = await client.redeem_actor_token(
-            "https://x.clerk.app/v1/client/sign_in_tokens/tok_1?token=jwt"
-        )
-
-        assert info == {"session_id": "sess_xyz"}
+        assert captured["method"] == "POST"
+        assert captured["url"] == "https://x.clerk.app/v1/client/sign_ins"
+        assert "application/x-www-form-urlencoded" in captured["content_type"]
+        assert "strategy=ticket" in captured["body"]
+        assert "ticket=jwt-value" in captured["body"]
         await client.aclose()
 
     async def test_raises_on_non_2xx(self):
         transport = httpx.MockTransport(
-            lambda req: httpx.Response(410, text="actor_token_already_used")
+            lambda req: httpx.Response(
+                400,
+                json={
+                    "errors": [{"code": "actor_token_already_used_code"}],
+                },
+            )
         )
         client = _make_client_with_http(transport)
 
         with pytest.raises(ClerkClientError, match="actor token redemption failed"):
             await client.redeem_actor_token(
-                "https://x.clerk.app/v1/client/sign_in_tokens/tok_1?token=jwt"
+                "https://x.clerk.app/v1/tickets/accept?ticket=jwt"
             )
         await client.aclose()
 
-    async def test_raises_when_no_session_id_present(self):
+    async def test_raises_when_status_not_complete(self):
         transport = httpx.MockTransport(
-            lambda req: httpx.Response(200, json={"response": {}, "client": {}})
+            lambda req: httpx.Response(
+                200,
+                json={"response": {"status": "needs_identifier"}},
+            )
         )
         client = _make_client_with_http(transport)
 
-        with pytest.raises(ClerkClientError, match="missing session id"):
+        with pytest.raises(ClerkClientError, match="non-complete status"):
             await client.redeem_actor_token(
-                "https://x.clerk.app/v1/client/sign_in_tokens/tok_1?token=jwt"
+                "https://x.clerk.app/v1/tickets/accept?ticket=jwt"
             )
+        await client.aclose()
+
+    async def test_raises_when_created_session_id_missing(self):
+        transport = httpx.MockTransport(
+            lambda req: httpx.Response(
+                200,
+                json={"response": {"status": "complete"}},
+            )
+        )
+        client = _make_client_with_http(transport)
+
+        with pytest.raises(ClerkClientError, match="missing created_session_id"):
+            await client.redeem_actor_token(
+                "https://x.clerk.app/v1/tickets/accept?ticket=jwt"
+            )
+        await client.aclose()
+
+    async def test_raises_when_ticket_query_param_missing(self):
+        client = _make_client_with_http(httpx.MockTransport(lambda req: httpx.Response(200)))
+        with pytest.raises(ClerkClientError, match="missing ticket query parameter"):
+            await client.redeem_actor_token("https://x.clerk.app/v1/tickets/accept")
         await client.aclose()
 
     async def test_rejects_url_outside_frontend_api_base(self):
@@ -159,7 +189,7 @@ class TestRedeemActorToken:
         )
         with pytest.raises(ClerkClientError, match="not from the configured"):
             await client.redeem_actor_token(
-                "https://attacker.com/v1/sign_in_tokens/abc?token=xyz"
+                "https://attacker.com/v1/tickets/accept?ticket=xyz"
             )
         await client.aclose()
 

--- a/broker/tests/test_delete_run_token.py
+++ b/broker/tests/test_delete_run_token.py
@@ -48,7 +48,7 @@ def app_and_store(moto_env):
     app.include_router(router)
     fake_clerk = MagicMock(spec=ClerkClient)
     fake_clerk.create_actor_token = AsyncMock(
-        return_value={"url": "https://test.clerk.app/v1/client/sign_in_tokens/tok?token=jwt"}
+        return_value={"url": "https://test.clerk.app/v1/tickets/accept?ticket=jwt"}
     )
     fake_clerk.redeem_actor_token = AsyncMock(return_value={"session_id": "sess_test"})
     app.dependency_overrides[mint_get_ticket_store] = lambda: store

--- a/broker/tests/test_mint_run_token.py
+++ b/broker/tests/test_mint_run_token.py
@@ -26,7 +26,7 @@ from broker.endpoints.mint_run_token import (
 SERVICE_TOKEN = "test-dispatch-lambda-token"
 SERVICE_TOKEN_HASH = hash_service_token(SERVICE_TOKEN)
 DEFAULT_CLERK_USER_ID = "user_test_abc123"
-DEFAULT_ACTOR_TOKEN_URL = "https://test.clerk.app/v1/client/sign_in_tokens/tok_1?token=jwt"
+DEFAULT_ACTOR_TOKEN_URL = "https://test.clerk.app/v1/tickets/accept?ticket=jwt"
 
 
 def _make_fake_clerk(


### PR DESCRIPTION
## Why

Every `mint-run-token` call against `broker-dev` has been failing since the Clerk actor-token flow shipped (f7f405e, 2026-05-12) — no agent run has ever made it to the Fargate runner from a real dispatch path. Symptom in dev:

```
mint_run_token clerk_actor_token_redemption_failed run_id=… status=405 body=
```

## What was wrong

`ClerkClient.redeem_actor_token` POSTs directly to the URL Clerk returns from `POST /v1/actor_tokens`. That URL is now `https://<frontend-api>/v1/tickets/accept?ticket=<jwt>` — Clerk's browser-facing Account Portal endpoint. Live probe:

- `POST` → `405 Method Not Allowed` (empty body)
- `GET` → `200` with HTML (the sign-in landing page)

Neither is what we want. The original design doc (`docs/superpowers/plans/2026-05-05-agent-mcp-and-actor-tokens.md`) noted "Verification needed at implementation time: the Clerk Frontend API response shape … may differ" but the endpoint itself had also moved by the time we shipped.

## What this changes

`redeem_actor_token` now does what `signIn.ticket({ ticket })` does internally on the frontend:

1. Extract the `ticket` query param from the actor-token URL.
2. `POST <frontend_api_base>/v1/client/sign_ins` with form-encoded body `strategy=ticket&ticket=<jwt>`.
3. Assert `response.status == "complete"`, read `response.created_session_id`.

The frontend-API-base SSRF check is preserved (URL must start with the configured base; rejects attacker.com).

## Verified live in dev

Minted a real actor token via the broker's `CLERK_SECRET_KEY`:

```
POST https://leading-camel-31.clerk.accounts.dev/v1/client/sign_ins
  Content-Type: application/x-www-form-urlencoded
  strategy=ticket&ticket=<jwt>
→ 200
  {"response":{"status":"complete","created_session_id":"sess_…","identifier":"swain+0317@goodparty.org"}, …}
```

## Tests

19 `TestRedeemActorToken` cases pass (rewrote the suite for the new endpoint + form-body contract; added a tests for status≠complete, missing ticket param, and missing `created_session_id`). Full broker suite: 387 passed.

## Unblocks

Once this deploys, an end-to-end agent run dispatch (e.g. the `meeting_schedule` event SQS message currently retrying for `run_id=019e2e33-dc90-7331-8542-e05f6618cb90`) will progress past mint and reach the Fargate runner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the broker’s Clerk session-creation flow to call a different Frontend API endpoint and enforce a stricter response contract, which could break minting if Clerk’s API shape/behavior differs in other environments.
> 
> **Overview**
> Fixes Clerk actor-token redemption by no longer POSTing to the returned `.../v1/tickets/accept?ticket=...` (browser flow) and instead extracting the `ticket` query param and POSTing form-encoded `strategy=ticket` to `.../v1/client/sign_ins`.
> 
> Tightens validation/error handling in `redeem_actor_token` by requiring `response.status == "complete"` and `response.created_session_id`, adds a guard for missing `ticket`, and updates related tests/fixtures to the new URL shape and request contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 284c5ef1c08af4790a641b7c661f4858a1d9cc8f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->