### PR TITLE
fix(broker): clear cookie jar between actor-token redemptions

### DIFF
--- a/broker/clerk_client.py
+++ b/broker/clerk_client.py
@@ -74,6 +74,13 @@ class ClerkClient:
         # POST /v1/client/sign_ins with strategy=ticket, which is what
         # @clerk/clerk-js does internally via signIn.ticket({ ticket }). Response
         # is JSON: { response: { status: "complete", created_session_id, ... } }.
+        #
+        # The shared httpx client's cookie jar is cleared in the finally block
+        # below. Without that reset, Set-Cookie headers from prior sign-ins
+        # (Clerk's __client / __session) accumulate, and dev Clerk instances
+        # (*.clerk.accounts.dev) reject the next sign-in carrying an existing
+        # client cookie with `dev_browser_unauthenticated`. Clearing matches
+        # the wire semantics of a real first-time browser sign-in per call.
         if not actor_token_url.startswith(f"{self._frontend_api_base}/"):
             raise ClerkClientError(
                 f"actor token URL is not from the configured Clerk frontend API base "
@@ -84,10 +91,13 @@ class ClerkClient:
             raise ClerkClientError(
                 f"actor token URL missing ticket query parameter (url={actor_token_url[:80]}...)"
             )
-        resp = await self._http.post(
-            f"{self._frontend_api_base}/v1/client/sign_ins",
-            data={"strategy": "ticket", "ticket": ticket_values[0]},
-        )
+        try:
+            resp = await self._http.post(
+                f"{self._frontend_api_base}/v1/client/sign_ins",
+                data={"strategy": "ticket", "ticket": ticket_values[0]},
+            )
+        finally:
+            self._http.cookies.clear()
         if resp.status_code >= 400:
             raise ClerkClientError(
                 f"actor token redemption failed status={resp.status_code} body={resp.text[:500]}"

--- a/broker/tests/test_clerk_client.py
+++ b/broker/tests/test_clerk_client.py
@@ -193,6 +193,53 @@ class TestRedeemActorToken:
             )
         await client.aclose()
 
+    async def test_clears_cookies_between_redemptions(self):
+        # Dev Clerk instances (*.clerk.accounts.dev) 401 with
+        # dev_browser_unauthenticated when a second sign-in arrives carrying
+        # the __client / __session cookies set by the first. The httpx jar
+        # must be empty before each redemption.
+        call_count = 0
+        cookies_received_per_call: list[dict[str, str]] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            cookies_received_per_call.append(dict(req.headers))
+            return httpx.Response(
+                200,
+                json={
+                    "response": {
+                        "status": "complete",
+                        "created_session_id": f"sess_{call_count}",
+                    }
+                },
+                headers={
+                    "set-cookie": "__client=client_cookie_value; Path=/; HttpOnly",
+                },
+            )
+
+        transport = httpx.MockTransport(handler)
+        client = _make_client_with_http(transport)
+
+        await client.redeem_actor_token(
+            "https://x.clerk.app/v1/tickets/accept?ticket=jwt-1"
+        )
+        # Cookies set by the first response would normally land in the jar.
+        # After clearing, the next call must not carry them.
+        await client.redeem_actor_token(
+            "https://x.clerk.app/v1/tickets/accept?ticket=jwt-2"
+        )
+
+        assert call_count == 2
+        first_cookies = cookies_received_per_call[0].get("cookie", "")
+        second_cookies = cookies_received_per_call[1].get("cookie", "")
+        assert first_cookies == ""
+        assert second_cookies == "", (
+            f"second call leaked cookies from the first: {second_cookies!r}"
+        )
+        assert dict(client._http.cookies) == {}
+        await client.aclose()
+
 
 class TestCreateActorToken:
     async def test_returns_body_with_url(self):


### PR DESCRIPTION
## Why

After PR #94 fixed `redeem_actor_token` to call `POST /v1/client/sign_ins`, the *first* redemption per broker task succeeded but every subsequent one 401'd with `dev_browser_unauthenticated`:

```
2026-05-16T01:26:49 INFO: POST /internal/mint-run-token HTTP/1.1 200 OK
2026-05-16T01:27:58 mint_run_token clerk_actor_token_redemption_failed
  run_id=019e2e65-aeea-7ee8-aee6-b045935d1ea9 experiment_id=meeting_briefing
  status=401 body={"errors":[{"message":"Browser unauthenticated",
  "long_message":"Unable to authenticate this browser for your development instance.
  Check your Clerk cookies and try again.","code":"dev_browser_unauthenticated"}]}
```

Reproduced live against `leading-camel-31.clerk.accounts.dev`:
- 3 cold connections via separate `httpx.AsyncClient` → 200, 200, 200.
- 3 sequential calls via one shared `httpx.AsyncClient` → 200, 401, 401.

## Root cause

`clerk-js` sign-in flow sets `__client` (and post-complete `__session`) cookies on each successful sign-in. `httpx.AsyncClient` persists those across requests, so the next redemption arrives carrying an existing client cookie. Dev Clerk instances treat that as a browser session that wasn't bootstrapped through `/v1/dev_browser` and reject the new sign-in. Production Clerk instances on a custom domain don't enforce `dev_browser`, so this is dev-only — but in dev it means **every meeting_briefing / meeting_schedule dispatch after the first one in a broker task lifetime fails to start**.

## Fix

`self._http.cookies.clear()` in a `finally` block after each redemption. Each redemption is an independent session bound to a fresh `broker_token` — sharing cookies across them has never been intentional. Clearing matches the wire semantics of a real first-time sign-in.

## Regression test

`test_clears_cookies_between_redemptions` asserts that (a) the second redemption call's request `Cookie` header is empty and (b) `client._http.cookies` is empty after the call returns. Without the fix, the second-call cookie header would carry `__client=...` and the test fails.

`broker/tests/test_clerk_client.py`: 19/19 passed (1 new + 18 pre-existing).

## Unrelated pre-existing failures

`broker/tests/test_browser_fetcher.py` has 25 failing tests on `develop` — confirmed by stashing this change and running them. Out of scope for this PR; flagging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small behavioral change limited to `redeem_actor_token`, with a targeted test to prevent cookie leakage between sequential redemptions.
> 
> **Overview**
> Fixes repeated Clerk actor-token redemptions in the broker by **clearing the shared `httpx.AsyncClient` cookie jar** after each `POST /v1/client/sign_ins` call (via a `finally` block), preventing dev-instance failures caused by persisted `__client`/`__session` cookies.
> 
> Adds a regression test (`test_clears_cookies_between_redemptions`) that simulates `Set-Cookie` on the first redemption and asserts the second request sends no `Cookie` header and the client cookie jar is empty afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ab9d33eae1d9dae8be8d23d08a2a47edd03ca0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->