### PR TITLE
Update gemini 3 to default to the recommended temperature of 1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ CI workflows are mostly `build-*.yml` Docker→ECR builds per workspace member, 
 | AI rule-by-rule code review | `ai-rules/` (git submodule) |
 | Why a thing is the way it is | `docs/adr/` (not yet seeded) |
 
+## LLM defaults
+
+- **Gemini**: prefer Gemini 3 (`shared.llm_gemini_3.Gemini3Client`) over Gemini 2.5 for new work. Use the default temperature of `1.0` unless you have a specific reason to override it — this is the recommended setting for Gemini 3.
+
 ## Code style
 
 - **Python `3.13`** at runtime (`.python-version`). Subprojects declare `requires-python = ">=3.11"`. ruff targets `py311`. mypy `python_version = 3.11`. The 3.13 runtime can run anything ≤3.13; the 3.11 floor is the compatibility line. Don't use 3.12+ syntax features (e.g., PEP 695 type aliases) without checking that ruff and mypy agree.

--- a/shared/llm_gemini_3.py
+++ b/shared/llm_gemini_3.py
@@ -53,7 +53,7 @@ class Gemini3Client:
         self,
         api_key: Optional[str] = None,
         default_model: GeminiModelType = GeminiModelType.FLASH_3,
-        default_temperature: float = 0.7,
+        default_temperature: float = 1.0,
         thinking_level: ThinkingLevel = ThinkingLevel.MINIMAL,
         include_thoughts: bool = False,
         max_connections: int = 100,

--- a/shared/tests/test_llm_gemini_3.py
+++ b/shared/tests/test_llm_gemini_3.py
@@ -41,7 +41,7 @@ class TestGemini3ClientInit:
         client = Gemini3Client(api_key="test-key")
 
         assert client.default_model == GeminiModelType.FLASH_3
-        assert client.default_temperature == 0.7
+        assert client.default_temperature == 1.0
         assert client.thinking_level == ThinkingLevel.MINIMAL
         assert client.include_thoughts is False
         assert client.max_retries == 3
@@ -77,7 +77,7 @@ class TestBuildConfig:
         client = Gemini3Client(api_key="test-key")
         config = client._build_config(GeminiModelType.FLASH_3)
 
-        assert config.temperature == 0.7
+        assert config.temperature == 1.0
         assert "minimal" in str(config.thinking_config.thinking_level).lower()
         assert config.thinking_config.include_thoughts is False
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the default sampling temperature for `Gemini3Client`, which can alter LLM outputs (and potentially downstream behavior) anywhere the default is relied on. Scope is small and covered by updated unit tests, but it’s a behavioral default change.
> 
> **Overview**
> Updates `shared.llm_gemini_3.Gemini3Client` to default Gemini 3 requests to **temperature `1.0`** (from `0.7`), aligning with the recommended setting.
> 
> Adjusts the Gemini 3 unit tests to assert the new default temperature/config, and documents this default in `CLAUDE.md` under **LLM defaults**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e23600f084599a70514a6fc44e20877020910fd6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->