### PR TITLE
broker + Dockerfile fixes from 2026-05-16 dev failure investigation

### DIFF
--- a/broker/browser_fetcher.py
+++ b/broker/browser_fetcher.py
@@ -116,20 +116,22 @@ def _is_textual_content_type(ct: str) -> bool:
 
 
 class PlaywrightBrowserFetcher:
-    # 20 concurrent contexts on a 4 vCPU / 8 GB Fargate task. Stress-tested at
-    # 8 concurrent on 2026-05-16: 100 in-flight requests against a real
-    # Granicus page peaked at ~30% CPU and ~6% memory on a single task —
-    # ~3.75% CPU per active context, plenty of headroom on memory regardless.
-    # Bumping to 20 puts the expected peak at ~75% CPU under burst, which
-    # will reliably trigger the ECS service's 55% CPU autoscale target and
-    # add a second task. That's intentional: we'd rather scale out under real
-    # demand than leave throughput on the table. Memory at 20 concurrent is
-    # ~15% — still nowhere near the 70% target.
+    # 30 concurrent contexts on a 4 vCPU / 8 GB Fargate task. Stress-tested
+    # incrementally on 2026-05-16:
+    #   max_concurrent=8,  100 reqs burst:  CPU peak ~30%, mem peak ~8%
+    #   max_concurrent=20, 200 reqs burst:  CPU peak ~50%, mem peak ~8.5%
+    # Per-context CPU cost is ~2.5% (sub-linear vs. linear projection because
+    # network-wait dominates each fetch's lifecycle, so 30 contexts don't all
+    # hit JS-exec at the same instant). Predicted at 30 concurrent: ~75% peak
+    # CPU and ~12% memory — above the 55% CPU autoscale target, so sustained
+    # bursts will reliably trigger the ECS service to add a second task.
+    # Intentional: prefer scale-out under demand to leaving throughput on the
+    # table. Memory stays well clear of the 70% target.
     #
     # If sustained load keeps the service scaled out at high cost, the next
     # move is the path-based pool split described in broker/README.md
     # (/http/fetch gets its own target group with a memory-tuned task size).
-    def __init__(self, max_concurrent: int = 20) -> None:
+    def __init__(self, max_concurrent: int = 30) -> None:
         self._semaphore = asyncio.Semaphore(max_concurrent)
         self._max_concurrent = max_concurrent
         self._closing = False

--- a/broker/browser_fetcher.py
+++ b/broker/browser_fetcher.py
@@ -116,7 +116,13 @@ def _is_textual_content_type(ct: str) -> bool:
 
 
 class PlaywrightBrowserFetcher:
-    def __init__(self, max_concurrent: int = 4) -> None:
+    # 8 concurrent contexts on a 4 vCPU / 8 GB Fargate task. At ~100-300 MB per
+    # Chromium context (worst case, JS-heavy pages), peak is ~2.4 GB out of 8 —
+    # leaves ~5 GB headroom. CPU is the binding constraint at this concurrency,
+    # not memory: most fetches are in network-wait at any given moment, so
+    # contexts overlap their JS-exec phases rather than colliding. If sustained
+    # load pushes CPU avg past 55%, the ECS service autoscales out.
+    def __init__(self, max_concurrent: int = 8) -> None:
         self._semaphore = asyncio.Semaphore(max_concurrent)
         self._max_concurrent = max_concurrent
         self._closing = False

--- a/broker/browser_fetcher.py
+++ b/broker/browser_fetcher.py
@@ -116,13 +116,20 @@ def _is_textual_content_type(ct: str) -> bool:
 
 
 class PlaywrightBrowserFetcher:
-    # 8 concurrent contexts on a 4 vCPU / 8 GB Fargate task. At ~100-300 MB per
-    # Chromium context (worst case, JS-heavy pages), peak is ~2.4 GB out of 8 —
-    # leaves ~5 GB headroom. CPU is the binding constraint at this concurrency,
-    # not memory: most fetches are in network-wait at any given moment, so
-    # contexts overlap their JS-exec phases rather than colliding. If sustained
-    # load pushes CPU avg past 55%, the ECS service autoscales out.
-    def __init__(self, max_concurrent: int = 8) -> None:
+    # 20 concurrent contexts on a 4 vCPU / 8 GB Fargate task. Stress-tested at
+    # 8 concurrent on 2026-05-16: 100 in-flight requests against a real
+    # Granicus page peaked at ~30% CPU and ~6% memory on a single task —
+    # ~3.75% CPU per active context, plenty of headroom on memory regardless.
+    # Bumping to 20 puts the expected peak at ~75% CPU under burst, which
+    # will reliably trigger the ECS service's 55% CPU autoscale target and
+    # add a second task. That's intentional: we'd rather scale out under real
+    # demand than leave throughput on the table. Memory at 20 concurrent is
+    # ~15% — still nowhere near the 70% target.
+    #
+    # If sustained load keeps the service scaled out at high cost, the next
+    # move is the path-based pool split described in broker/README.md
+    # (/http/fetch gets its own target group with a memory-tuned task size).
+    def __init__(self, max_concurrent: int = 20) -> None:
         self._semaphore = asyncio.Semaphore(max_concurrent)
         self._max_concurrent = max_concurrent
         self._closing = False

--- a/broker/endpoints/artifact_publish.py
+++ b/broker/endpoints/artifact_publish.py
@@ -120,16 +120,34 @@ def artifact_publish(
     # list — broker stays consumer-domain-agnostic. Any new experiment that
     # adds allowed_tables automatically gets the safety check; web-only
     # experiments skip it.
+    #
+    # Carve-out for legitimate no-data outcomes: a manifest may declare
+    #   scope.data_required_unless = {"field": "<artifact_field>",
+    #                                  "values": ["<v1>", ...]}
+    # When the artifact's named field carries one of those values (e.g.
+    # meeting_briefing's `briefing_status=awaiting_agenda` placeholder when
+    # the next council meeting's agenda packet hasn't been published yet),
+    # the gate is skipped — no data query is appropriate for that branch.
+    # Broker stays domain-agnostic: it doesn't know what the values mean,
+    # only that the manifest declared them as exemptions.
     if ticket.scope.get("allowed_tables") and tracker.get(ticket.pk) == 0:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"NoDataQueriesSucceeded: experiment '{ticket.experiment_id}' "
-                f"declares scope.allowed_tables but no Databricks query succeeded "
-                f"during this run. Refusing to publish — this prevents synthetic "
-                f"artifacts from being accepted when data sources are unreachable."
-            ),
+        carve_out = ticket.scope.get("data_required_unless")
+        artifact_field_value = (
+            req.artifact.get(carve_out["field"]) if carve_out else None
         )
+        carve_applies = bool(
+            carve_out and artifact_field_value in carve_out.get("values", [])
+        )
+        if not carve_applies:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"NoDataQueriesSucceeded: experiment '{ticket.experiment_id}' "
+                    f"declares scope.allowed_tables but no Databricks query succeeded "
+                    f"during this run. Refusing to publish — this prevents synthetic "
+                    f"artifacts from being accepted when data sources are unreachable."
+                ),
+            )
 
     if os.environ.get("ENABLE_PII_SCANNER", "").strip().lower() in _PII_ENABLED_VALUES:
         pii_matches = scan_artifact(req.artifact)

--- a/broker/endpoints/artifact_publish.py
+++ b/broker/endpoints/artifact_publish.py
@@ -131,12 +131,28 @@ def artifact_publish(
     # Broker stays domain-agnostic: it doesn't know what the values mean,
     # only that the manifest declared them as exemptions.
     if ticket.scope.get("allowed_tables") and tracker.get(ticket.pk) == 0:
+        # carve_out shape is validated by the manifest meta-schema at publish
+        # time in the runbooks repo, but the broker treats it as untrusted dict
+        # input — a malformed `data_required_unless` (missing 'field', missing
+        # 'values', wrong types) must not crash the publish path with a raw
+        # 500. Use .get() everywhere and fail safe: any malformed shape falls
+        # back to today's strict gate behavior.
         carve_out = ticket.scope.get("data_required_unless")
-        artifact_field_value = (
-            req.artifact.get(carve_out["field"]) if carve_out else None
+        carve_field = (
+            carve_out.get("field") if isinstance(carve_out, dict) else None
         )
-        carve_applies = bool(
-            carve_out and artifact_field_value in carve_out.get("values", [])
+        carve_values = (
+            carve_out.get("values") if isinstance(carve_out, dict) else None
+        )
+        artifact_field_value = (
+            req.artifact.get(carve_field)
+            if isinstance(carve_field, str) and isinstance(req.artifact, dict)
+            else None
+        )
+        carve_applies = (
+            isinstance(carve_values, list)
+            and artifact_field_value is not None
+            and artifact_field_value in carve_values
         )
         if not carve_applies:
             raise HTTPException(

--- a/broker/tests/test_artifact_publish.py
+++ b/broker/tests/test_artifact_publish.py
@@ -963,3 +963,58 @@ class TestArtifactPublishDataRequiredUnlessCarveOut:
         assert resp.status_code == 400
         assert "NoDataQueriesSucceeded" in resp.json()["detail"]
         mock_s3.put_object.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "malformed_carve_out",
+        [
+            pytest.param({"values": ["awaiting_agenda"]}, id="missing-field-key"),
+            pytest.param({"field": "briefing_status"}, id="missing-values-key"),
+            pytest.param({"field": None, "values": ["x"]}, id="null-field"),
+            pytest.param({"field": "briefing_status", "values": None}, id="null-values"),
+            pytest.param({"field": 42, "values": ["x"]}, id="non-string-field"),
+            pytest.param({"field": "x", "values": "not-a-list"}, id="non-list-values"),
+            pytest.param("not-a-dict", id="non-dict-carve-out"),
+        ],
+    )
+    def test_malformed_carve_out_does_not_crash_and_falls_back_to_strict_gate(
+        self, malformed_carve_out
+    ):
+        """The carve-out shape is meta-schema-validated upstream in the runbooks
+        repo, but the broker treats `ticket.scope` as untrusted dict input. A
+        malformed `data_required_unless` (missing keys, wrong types, etc.) must
+        not crash the publish path with a raw 500. Fail safe: behave as if no
+        carve-out existed and let the strict gate fire normally."""
+        now = int(time.time())
+        ticket = ScopeTicket(
+            pk=BROKER_TOKEN,
+            run_id="run-malformed-001",
+            organization_slug="org-malformed",
+            experiment_id="meeting_briefing",
+            scope={
+                "allowed_tables": ["goodparty_data_catalog.dbt.int__l2_nationwide_uniform_w_haystaq"],
+                "max_rows": 50000,
+                "data_required_unless": malformed_carve_out,
+            },
+            params={},
+            exp=now + 3600,
+            issued_at=now,
+            issued_by="dispatch-lambda-dev",
+        )
+        app, mock_s3, _, _ = _create_app(ticket=ticket, tracker_count=0)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/artifact/publish",
+            json={"artifact": _awaiting_agenda_artifact()},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        # Critical: NOT a 500 (raw KeyError / AttributeError leak).
+        # Critical: IS a 400 with the structured anti-fabrication reason,
+        # because the malformed carve-out is treated as absent.
+        assert resp.status_code == 400, (
+            f"malformed carve-out crashed the publish path: status={resp.status_code} "
+            f"body={resp.text}"
+        )
+        assert "NoDataQueriesSucceeded" in resp.json()["detail"]
+        mock_s3.put_object.assert_not_called()

--- a/broker/tests/test_artifact_publish.py
+++ b/broker/tests/test_artifact_publish.py
@@ -831,3 +831,135 @@ class TestArtifactPublishAntiFabricationGate:
         assert resp.status_code == 400
         assert "brand_new_experiment_42" in resp.json()["detail"]
         mock_s3.put_object.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Carve-out for legitimate no-data outcomes.
+#
+# The anti-fabrication gate above is correct when the agent SHOULD have queried
+# data and didn't — but some experiment playbooks have legitimate early-exit
+# branches where no data query is appropriate (e.g. meeting_briefing emits an
+# `awaiting_agenda` placeholder when the next council meeting's agenda packet
+# hasn't been published yet). The manifest opts in via:
+#
+#   "scope": {
+#     "allowed_tables": [...],
+#     "data_required_unless": {
+#       "field": "briefing_status",
+#       "values": ["awaiting_agenda", "no_meeting_found", "error"]
+#     }
+#   }
+#
+# When set, the broker checks the artifact's named field; if its value is in
+# the allowlist, the gate is skipped even with zero data queries. Otherwise
+# (full-data branches, or any unconfigured experiment), today's strict
+# behavior is preserved.
+# ---------------------------------------------------------------------------
+
+
+def _make_ticket_with_data_required_unless(
+    field: str = "briefing_status",
+    values: list[str] | None = None,
+    experiment_id: str = "meeting_briefing",
+) -> ScopeTicket:
+    """Ticket whose scope declares allowed_tables AND a data_required_unless
+    carve-out — the gate should skip when artifact[field] in values."""
+    now = int(time.time())
+    return ScopeTicket(
+        pk=BROKER_TOKEN,
+        run_id="run-carve-001",
+        organization_slug="org-carve",
+        experiment_id=experiment_id,
+        scope={
+            "allowed_tables": ["goodparty_data_catalog.dbt.int__l2_nationwide_uniform_w_haystaq"],
+            "max_rows": 50000,
+            "data_required_unless": {
+                "field": field,
+                "values": values or ["awaiting_agenda", "no_meeting_found", "error"],
+            },
+        },
+        params={},
+        exp=now + 3600,
+        issued_at=now,
+        issued_by="dispatch-lambda-dev",
+    )
+
+
+def _awaiting_agenda_artifact() -> dict:
+    """Placeholder artifact the agent emits when the next meeting's agenda
+    packet hasn't been published yet — no Databricks query is appropriate."""
+    return {
+        "briefing_status": "awaiting_agenda",
+        "briefing_type": "city_council_meeting",
+        "summary": "Agenda not yet published for next meeting",
+    }
+
+
+class TestArtifactPublishDataRequiredUnlessCarveOut:
+    def test_carve_out_allows_publish_for_matching_status_with_zero_queries(self):
+        """Manifest declares data_required_unless={briefing_status:
+        [awaiting_agenda, ...]}. Artifact has briefing_status=awaiting_agenda
+        and zero data queries succeeded. The gate skips — this is a legitimate
+        no-data outcome, not a fabricated artifact."""
+        ticket = _make_ticket_with_data_required_unless()
+        app, mock_s3, mock_sender, _ = _create_app(
+            ticket=ticket, tracker_count=0
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/artifact/publish",
+            json={"artifact": _awaiting_agenda_artifact()},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 200
+        assert mock_s3.put_object.call_count >= 1
+        mock_sender.send_result.assert_called_once()
+
+    def test_carve_out_does_not_apply_to_full_output_branch(self):
+        """The carve-out is value-scoped. A full-data artifact
+        (briefing_status=briefing_ready) on the same manifest still requires
+        a successful query — protecting against the original fabrication risk
+        when the agent emits a full briefing without real data backing it."""
+        ticket = _make_ticket_with_data_required_unless()
+        app, mock_s3, mock_sender, _ = _create_app(
+            ticket=ticket, tracker_count=0
+        )
+        client = TestClient(app)
+
+        full_artifact = {
+            "briefing_status": "briefing_ready",
+            "briefing_type": "city_council_meeting",
+            "summary": "Full briefing",
+        }
+        resp = client.post(
+            "/artifact/publish",
+            json={"artifact": full_artifact},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 400
+        assert "NoDataQueriesSucceeded" in resp.json()["detail"]
+        mock_s3.put_object.assert_not_called()
+        mock_sender.send_result.assert_not_called()
+
+    def test_no_carve_out_field_preserves_strict_gate(self):
+        """Existing manifests (no data_required_unless field) keep today's
+        behavior exactly — zero queries with allowed_tables set → 400. This
+        is the backward-compatibility guarantee for district_issue_pulse,
+        district_issue_snapshot, and any future strict-data experiment."""
+        ticket = _make_ticket_with_data_scope(experiment_id="meeting_briefing")
+        # _make_ticket_with_data_scope does NOT set data_required_unless.
+        app, mock_s3, _, _ = _create_app(ticket=ticket, tracker_count=0)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/artifact/publish",
+            json={"artifact": _awaiting_agenda_artifact()},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 400
+        assert "NoDataQueriesSucceeded" in resp.json()["detail"]
+        mock_s3.put_object.assert_not_called()

--- a/broker/tests/test_browser_fetcher.py
+++ b/broker/tests/test_browser_fetcher.py
@@ -250,10 +250,10 @@ class TestConcurrencyCap:
         assert peak == 4, f"expected peak == 4 to confirm cap was binding, got {peak}"
 
     @pytest.mark.asyncio
-    async def test_default_max_concurrent_is_four(self) -> None:
+    async def test_default_max_concurrent_is_eight(self) -> None:
         fetcher = PlaywrightBrowserFetcher()
         assert hasattr(fetcher, "_semaphore"), "must expose a semaphore for concurrency cap"
-        assert fetcher._semaphore._value == 4
+        assert fetcher._semaphore._value == 8
 
 
 class TestUnifiedFetchSignature:

--- a/broker/tests/test_browser_fetcher.py
+++ b/broker/tests/test_browser_fetcher.py
@@ -250,10 +250,10 @@ class TestConcurrencyCap:
         assert peak == 4, f"expected peak == 4 to confirm cap was binding, got {peak}"
 
     @pytest.mark.asyncio
-    async def test_default_max_concurrent_is_eight(self) -> None:
+    async def test_default_max_concurrent_is_twenty(self) -> None:
         fetcher = PlaywrightBrowserFetcher()
         assert hasattr(fetcher, "_semaphore"), "must expose a semaphore for concurrency cap"
-        assert fetcher._semaphore._value == 8
+        assert fetcher._semaphore._value == 20
 
 
 class TestUnifiedFetchSignature:

--- a/broker/tests/test_browser_fetcher.py
+++ b/broker/tests/test_browser_fetcher.py
@@ -250,10 +250,10 @@ class TestConcurrencyCap:
         assert peak == 4, f"expected peak == 4 to confirm cap was binding, got {peak}"
 
     @pytest.mark.asyncio
-    async def test_default_max_concurrent_is_twenty(self) -> None:
+    async def test_default_max_concurrent_is_thirty(self) -> None:
         fetcher = PlaywrightBrowserFetcher()
         assert hasattr(fetcher, "_semaphore"), "must expose a semaphore for concurrency cap"
-        assert fetcher._semaphore._value == 20
+        assert fetcher._semaphore._value == 30
 
 
 class TestUnifiedFetchSignature:

--- a/engineer_agent/Dockerfile
+++ b/engineer_agent/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     ca-certificates \
     xz-utils \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js via official binary (avoids python3 dependency issues)

--- a/pmf_engine/Dockerfile
+++ b/pmf_engine/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     xz-utils \
     poppler-utils \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js (required for Claude CLI) — verify SHA256 against the

--- a/pmf_engine/runner/pmf_runtime/http.py
+++ b/pmf_engine/runner/pmf_runtime/http.py
@@ -1,5 +1,23 @@
 from __future__ import annotations
 
+# Both `get()` and `download()` route through the broker's `/http/fetch`,
+# which is backed by a shared Playwright/Chromium pool (broker/browser_fetcher.py,
+# max_concurrent=4 per broker task, ~100-300 MB resident per browser context).
+# When that pool is degraded — Chromium crashed, target site is hammering
+# Cloudflare's bot wall, broker task scaling out from a cold start, page-load
+# timeouts piling up — the failure mode is 5xx / timeouts / repeated empty
+# bodies, NOT a clean error we can backoff on per-request.
+#
+# DO NOT retry tightly. Short retries make it worse: each retry occupies a
+# concurrency permit on the broker, blocks scale-out, and starves other
+# in-flight agents. If `/http/fetch` looks degraded (3+ consecutive failures
+# on different URLs, or 5xx with no clear per-URL cause), wait MINUTES — not
+# seconds — before retrying. 5-15 minutes is reasonable; the broker autoscaler
+# needs time to add a task and Chromium needs ~10s of warmup on the new pool.
+#
+# Better still: pivot the agent's plan to a deterministic-URL probe or a
+# WebSearch path that doesn't go through Playwright, and only return to
+# `/http/fetch` once you have a single high-value URL to fetch.
 import os
 import re
 import uuid

--- a/pmf_engine/runner/pmf_runtime/http.py
+++ b/pmf_engine/runner/pmf_runtime/http.py
@@ -2,11 +2,16 @@ from __future__ import annotations
 
 # Both `get()` and `download()` route through the broker's `/http/fetch`,
 # which is backed by a shared Playwright/Chromium pool (broker/browser_fetcher.py,
-# max_concurrent=4 per broker task, ~100-300 MB resident per browser context).
-# When that pool is degraded — Chromium crashed, target site is hammering
-# Cloudflare's bot wall, broker task scaling out from a cold start, page-load
-# timeouts piling up — the failure mode is 5xx / timeouts / repeated empty
-# bodies, NOT a clean error we can backoff on per-request.
+# max_concurrent=30 per broker task, ~30-35 MB resident per browser context
+# under typical government-site workloads — measured 2026-05-16 in dev at
+# 300 concurrent requests against Granicus pages: 13% of 8 GB peak memory
+# across all 30 contexts plus baseline, so ~26-32 MB per context). Heavier
+# pages (JS-heavy SPAs, browser-rendered PDFs) can push per-context memory
+# 5-10× higher, so don't treat this number as a hard ceiling. When the pool
+# is degraded — Chromium crashed, target site is hammering Cloudflare's bot
+# wall, broker task scaling out from a cold start, page-load timeouts piling
+# up — the failure mode is 5xx / timeouts / repeated empty bodies, NOT a
+# clean error we can backoff on per-request.
 #
 # DO NOT retry tightly. Short retries make it worse: each retry occupies a
 # concurrency permit on the broker, blocks scale-out, and starves other


### PR DESCRIPTION
## Summary

Yesterday, 52 meeting_briefing runs failed in dev across three modes. Investigation surfaced two distinct code bugs (this PR) and one operational issue (Anthropic credit exhaustion, not in this PR — handled separately).

| Failure mode | Count | Root cause | Fix |
|---|---:|---|---|
| `AgentExecutionError` | 36 | Anthropic API "Credit balance is too low" | Operational — not in this PR |
| `Exception` (subprocess exit 1) | 7 | \`/usr/bin/ps\` missing from container; Claude CLI's KillShell handler spawns \`ps -o pid --no-headers --ppid <pid>\` to walk descendants and crashes uncaught with ENOENT | Add \`procps\` to \`pmf_engine\` + \`engineer_agent\` Dockerfiles |
| `PublishFailed` (NoDataQueriesSucceeded) | 9 | Broker anti-fabrication gate rejected valid \`awaiting_agenda\` placeholders because no Databricks query succeeded — but for that branch no query is appropriate (agenda packet not yet published) | New manifest field \`scope.data_required_unless\` lets experiments declare which artifact values are legitimately no-data |

## Changes

### \`broker/endpoints/artifact_publish.py\` — publish-gate carve-out
Reads optional \`scope.data_required_unless = {field, values[]}\`. When set, the gate skips if \`artifact[field] in values\`. Broker stays consumer-domain-agnostic — the mapping is declared per-experiment in the manifest (mirrors the existing output_schema \`oneOf\` structure). Backward compatible: manifests without the field keep today's strict behavior. Companion manifest change (\`meeting_briefing\` v3) lives in the runbooks repo PR #26.

### \`broker/browser_fetcher.py\` — \`max_concurrent\` 4 → 30
Three incremental bumps, each stress-tested live in dev:
- **4 → 8**: 100-concurrent burst peaked at 30% CPU, 8% memory
- **8 → 20**: 200-concurrent burst peaked at 50% CPU, 9% memory  
- **20 → 30**: 300-concurrent burst peaked at 88% CPU, 13% memory
- **Sustained 30-concurrent**: triggered autoscale, second task came online, ALB load-balanced ~51%/49% across both tasks

At 30 concurrent, peak burst CPU hits the 55% autoscale target reliably under real load — intentional. Memory at every tested level stays well under 70%.

### \`pmf_engine/Dockerfile\` + \`engineer_agent/Dockerfile\` — \`procps\`
Adds \`procps\` (~500 KB) to the apt install line so \`/usr/bin/ps\` is available for the Claude CLI's KillShell handler.

### \`pmf_engine/runner/pmf_runtime/http.py\` — retry-policy comment
Documents the long-retry policy for \`/http/fetch\` (the broker's Playwright endpoint): tight retries on degradation occupy concurrency permits and starve other in-flight agents. Recommends 5-15 min back-off and pivoting the agent's plan to non-Playwright probes when /http/fetch is the suspected fault.

## Test plan

- [x] \`broker/tests/\` — 452 passed, 0 failed (3 new tests in \`TestArtifactPublishDataRequiredUnlessCarveOut\` cover the carve-out activate / not-apply-on-full-branch / preserve-strict-gate cases)
- [x] \`broker/tests/test_browser_fetcher.py\` — \`test_default_max_concurrent_is_thirty\` covers the bump
- [x] Live stress-tested broker-dev across all three concurrency bumps; cap confirmed via timing-band signature (e.g., 40-conc → 2 bands of 20 at the 20 setting, 60-conc → 2 bands of 30 at the 30 setting)
- [x] Live verified autoscale fires under sustained load and ALB round-robins between tasks (51.2% / 48.8% split across 2563 post-scale-out fetches)
- [x] \`procps\` images rebuilt and pushed to ECR (\`pmf-engine-dev\`, \`engineer-agent-dev\`) — next dispatched Fargate task pulls automatically
- [ ] End-to-end smoke test: dispatch a real meeting_briefing run that triggers both fixes (KillShell + awaiting_agenda) — pending Anthropic credit top-up

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts broker publish validation and significantly increases Playwright concurrency, which can impact artifact acceptance rules and production CPU/scale behavior; Docker changes are low risk but affect runtime images.
> 
> **Overview**
> **Broker publish gate now supports a manifest-driven carve-out for legitimate no-data artifacts.** When `scope.allowed_tables` is set but zero Databricks queries succeeded, `/artifact/publish` can now skip the rejection if `scope.data_required_unless` is configured and `artifact[field]` is in the allowlisted values; otherwise the existing strict `NoDataQueriesSucceeded` behavior remains.
> 
> **Playwright fetch capacity is increased by default.** `PlaywrightBrowserFetcher` raises its default `max_concurrent` from 4 to 30 (with updated tests) to improve `/http/fetch` throughput.
> 
> **Runtime/container fixes.** Adds `procps` to `pmf_engine` and `engineer_agent` images (to provide `ps`), and adds documentation in `pmf_runtime/http.py` warning against tight retries when `/http/fetch` is degraded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa66962762ffcb7b504d46bab856d4413c8a2fa1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->