### PR TITLE
Use gemini flash over pro, follow best practice for temperature, and increase reasoning.

### DIFF
--- a/braintrust_eval_sandbox/evals.py
+++ b/braintrust_eval_sandbox/evals.py
@@ -272,6 +272,7 @@ def pipeline_task(input: dict, hooks: Any) -> dict:
 
     llm_client = Gemini3Client(
         default_model=GeminiModelType.FLASH_3_5,
+        default_temperature=1.0,
         thinking_level=ThinkingLevel.HIGH,
     )
 
@@ -321,7 +322,7 @@ def pipeline_task(input: dict, hooks: Any) -> dict:
             structured = llm_client.generate_structured_content(
                 prompt=struct_text,
                 response_schema=gemini_schema,
-                temperature=0.0,
+                temperature=1.0,
             )
             struct_span.log(output={"structured": structured})
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the eval’s model/temperature defaults, which will materially affect output determinism and increase token cost for all runs using this sandbox.
> 
> **Overview**
> Updates the Braintrust sandbox eval to default to **Gemini 3 Pro** instead of Flash, both in the UI parameter defaults and in the runtime `Gemini3Client` configuration.
> 
> The pipeline now runs with `default_temperature=1.0`, `thinking_level=HIGH`, and uses a non-zero temperature (`1.0`) for `generate_structured_content`, changing the variability of both freeform and structured outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d983eb1f448d0e037d598cfe19103945b6f1aab. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->