### PR TITLE
dispatch_handler: add QA_JUDGES env var for runbooks qa-spine

### DIFF
--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -389,6 +389,13 @@ def build_container_overrides(
         {"name": "ANTHROPIC_API_KEY", "value": broker_token},
         {"name": "PARAMS_JSON", "value": params_json},
         {"name": "TIMEOUT_SECONDS", "value": str(experiment.get("timeout_seconds", 600))},
+        # QA_JUDGES configures the runbooks qa-spine pluggable LLM judge registry
+        # (format: name:provider:model,...). Routes through the same broker proxy
+        # the runner already uses for the agent — no new Secrets Manager entries,
+        # no new egress. Same-family Phase 1/2 (Sonnet + Opus with adversarial
+        # system prompt) is the documented in-Fargate path; cross-family (e.g.
+        # Gemini Phase 2) is deferred until/if a broker route for Google exists.
+        {"name": "QA_JUDGES", "value": "claude:anthropic:claude-sonnet-4-6,opus:anthropic:claude-opus-4-7"},
     ]
     # Pin the runner to the exact S3 object versions Lambda fetched at routing
     # time. Without this, a publish during the dispatch→start window could


### PR DESCRIPTION
Adds one env var (QA_JUDGES) to build_container_overrides so the Fargate runner can invoke the runbooks qa-spine LLM phases. The qa-spine ships as a manifest attachment (qa_validate.py at /workspace/) and reads QA_JUDGES to populate its pluggable Judge registry.

Without this env var, the qa-spine's Phase 1 + Phase 2 LLM audit steps skip with "judge 'claude' unavailable" — only the deterministic verdict ships in qa_bundle.json. With it, both phases route through the existing broker proxy (the runner already has ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY set to the broker token), so no new Secrets Manager entries and no new egress are needed.

Default value uses same-family Anthropic for both phases:
  - Phase 1: claude-sonnet-4-6 (per-claim triage)
  - Phase 2: claude-opus-4-7   (adversarial escalation on high-weight Phase-1-not-OK)

The runbooks meeting_briefing_product_spec.json's judges.phase1/phase2 references the "claude" / "opus" names from this registry. Cross-family Phase 2 (e.g. Gemini) is deferred — would require a broker route for Google or direct egress + a Google API key in env.

Verified locally: the runbooks qa-spine ran against the kemah-thorne-cloud-1 artifact with the same QA_JUDGES value and produced a clean bundle (release_verdict: ok, 5/5 claims Accurate per Sonnet Phase 1, no Phase 2 needed).

Test coverage: 92/92 dispatch tests pass (88 in test_dispatch_handler.py + 4 in test_dispatch_runner_env_roundtrip.py).

Context: runbooks PRs that depend on this —
- https://github.com/thegoodparty/runbooks/tree/briefing-tone-style-content
- https://github.com/thegoodparty/runbooks/tree/qa-spine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single static env var to ECS container overrides; main impact is enabling additional LLM-based QA steps, with minimal operational/security surface since it reuses the existing broker proxy/token.
> 
> **Overview**
> Enables runbooks `qa-spine` LLM audit phases in the Fargate runner by adding a `QA_JUDGES` environment variable to `build_container_overrides` in `dispatch_handler.py`.
> 
> `QA_JUDGES` is prepopulated with an Anthropic Sonnet/Opus judge registry string and is documented to route through the existing broker proxy configuration (no new secrets or egress paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 136fa9a837bb24454ba59c3ec53947fd600629f1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->