### PR TITLE
Update MCP proxy endpoint to versioned URL

### DIFF
--- a/broker/endpoints/agent_mcp_proxy.py
+++ b/broker/endpoints/agent_mcp_proxy.py
@@ -52,7 +52,7 @@ async def proxy_mcp_root(
     body = await request.body()
     upstream = await http.request(
         method=request.method,
-        url=f"{base_url.rstrip('/')}/agent/mcp",
+        url=f"{base_url.rstrip('/')}/v1/mcp",
         content=body,
         headers={
             "Content-Type": request.headers.get("content-type", "application/json"),

--- a/broker/tests/test_agent_mcp_proxy.py
+++ b/broker/tests/test_agent_mcp_proxy.py
@@ -98,7 +98,7 @@ class TestAgentMcpProxyHappyPath:
         mock_http.request.assert_awaited_once()
         call_kwargs = mock_http.request.call_args.kwargs
         assert call_kwargs["method"] == "POST"
-        assert call_kwargs["url"] == f"{GP_API_BASE_URL}/agent/mcp"
+        assert call_kwargs["url"] == f"{GP_API_BASE_URL}/v1/mcp"
         assert call_kwargs["content"] == request_body
         assert call_kwargs["headers"]["Authorization"] == f"Bearer {FAKE_JWT}"
         assert call_kwargs["headers"]["Content-Type"] == "application/json"


### PR DESCRIPTION
This commit modifies the MCP proxy endpoint in the agent_mcp_proxy.py file to use a versioned URL (`/v1/mcp`) instead of the previous unversioned URL (`/agent/mcp`). Corresponding updates are made in the test file test_agent_mcp_proxy.py to ensure that the tests reflect this change. This enhances the API's versioning strategy for better maintainability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Routing depends on gp-api exposing `/v1/mcp`; if the versioned endpoint is not live in an environment, MCP proxy calls will fail until both sides are aligned.
> 
> **Overview**
> The broker MCP proxy still accepts traffic on **`/agent/mcp`**, but it now forwards requests to gp-api at **`/v1/mcp`** instead of **`/agent/mcp`**.
> 
> The happy-path proxy test was updated to expect the new upstream URL; client-facing broker routes and auth/header behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1da652c1251ca6e7ed0612af9c1b4e868e7279a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->