### PR TITLE
Update broker authentication header from Bearer token to X-Broker-Token

### DIFF
--- a/pmf_engine/runner/harness/claude_sdk.py
+++ b/pmf_engine/runner/harness/claude_sdk.py
@@ -79,7 +79,7 @@ def _build_broker_mcp_servers() -> dict:
         _BROKER_MCP_SERVER_NAME: {
             "type": "http",
             "url": broker_url.rstrip("/") + "/agent/mcp",
-            "headers": {"Authorization": f"Bearer {broker_token}"},
+            "headers": {"X-Broker-Token": broker_token},
         }
     }
 

--- a/pmf_engine/runner/main.py
+++ b/pmf_engine/runner/main.py
@@ -220,11 +220,23 @@ _SECRET_PATTERNS = [
 # the secret portion.
 _BEARER_TOKEN_PATTERN = re.compile(r'(?i)(Bearer\s+)([A-Za-z0-9_\-/.+=]{8,})')
 
+# X-Broker-Token redaction. The runner passes BROKER_TOKEN in this header on
+# the MCP server config (claude_sdk._build_broker_mcp_servers), and the SDK
+# can serialize that headers dict into session JSONL. The JSON-quoted shape
+# `"X-Broker-Token": "<token>"` puts a `"` between the keyword and `:`, so
+# _SECRET_PATTERNS' `\s*[=:]` doesn't catch it. Captured separately so the
+# substitution preserves the key + separator (parseable JSON structure)
+# while redacting only the value.
+_BROKER_TOKEN_PATTERN = re.compile(
+    r'(?i)(X-Broker-Token["\']?\s*[=:]\s*["\']?)([A-Za-z0-9_\-/.+=]{8,})'
+)
+
 
 def _redact_line(line: str) -> str:
     for pattern in _SECRET_PATTERNS:
         line = pattern.sub(lambda m: m.group(0)[:8] + "***REDACTED***", line)
     line = _BEARER_TOKEN_PATTERN.sub(lambda m: m.group(1) + "***REDACTED***", line)
+    line = _BROKER_TOKEN_PATTERN.sub(lambda m: m.group(1) + "***REDACTED***", line)
     return line
 
 

--- a/pmf_engine/tests/test_harness_claude_sdk.py
+++ b/pmf_engine/tests/test_harness_claude_sdk.py
@@ -805,7 +805,9 @@ class TestWriteActionManifestFields:
     @pytest.mark.asyncio
     async def test_mcp_servers_configured_when_broker_url_set(self):
         """When BROKER_URL is set, the harness wires the broker's /agent/mcp
-        endpoint into options.mcp_servers with BROKER_TOKEN as bearer.
+        endpoint into options.mcp_servers with BROKER_TOKEN in the
+        X-Broker-Token header (the broker's scope-ticket auth — see
+        broker/main.py:_resolve_ticket_from_request).
         This is what gives a compliance_setup-style agent access to gp-api
         MCP tools."""
         options = await _run_harness_capture_options(
@@ -819,7 +821,7 @@ class TestWriteActionManifestFields:
         broker_cfg = options.mcp_servers["broker"]
         assert broker_cfg["type"] == "http"
         assert broker_cfg["url"] == "https://broker-dev.test/agent/mcp"
-        assert broker_cfg["headers"] == {"Authorization": "Bearer tok-mcp-123"}
+        assert broker_cfg["headers"] == {"X-Broker-Token": "tok-mcp-123"}
 
     @pytest.mark.asyncio
     async def test_mcp_servers_url_strips_trailing_slash(self):
@@ -847,9 +849,9 @@ class TestWriteActionManifestFields:
     @pytest.mark.asyncio
     async def test_mcp_servers_empty_when_broker_token_missing(self):
         """BROKER_URL without BROKER_TOKEN is an incoherent config — skip
-        MCP entirely rather than emit an unauthenticated `Authorization:
-        Bearer ` header the broker would 401 on first tool-use. Keeps the
-        failure mode symmetric with "no broker at all"."""
+        MCP entirely rather than emit an empty `X-Broker-Token` header the
+        broker would 401 on first tool-use. Keeps the failure mode
+        symmetric with "no broker at all"."""
         options = await _run_harness_capture_options(
             monkey_env={"BROKER_URL": "https://broker-dev.test", "BROKER_TOKEN": None},
         )
@@ -884,5 +886,5 @@ class TestWriteActionManifestFields:
         assert options.permission_mode == "default"
         assert options.allowed_tools == [*ALLOWED_TOOLS, "Read"]
         assert options.mcp_servers["broker"]["url"] == "https://broker-dev.test/agent/mcp"
-        assert options.mcp_servers["broker"]["headers"]["Authorization"] == "Bearer tok-all"
+        assert options.mcp_servers["broker"]["headers"]["X-Broker-Token"] == "tok-all"
 

--- a/pmf_engine/tests/test_runner_main.py
+++ b/pmf_engine/tests/test_runner_main.py
@@ -1950,7 +1950,7 @@ async def test_write_action_manifest_flows_through_to_claude_agent_options(
     assert options.mcp_servers["broker"]["type"] == "http"
     assert options.mcp_servers["broker"]["url"] == "https://broker-dev.test/agent/mcp"
     assert options.mcp_servers["broker"]["headers"] == {
-        "Authorization": "Bearer tok-end-to-end"
+        "X-Broker-Token": "tok-end-to-end"
     }
 
 
@@ -2030,4 +2030,77 @@ class TestBearerTokenRedaction:
         assert parsed["event"] == "session_start"
         assert "tok-12345678" not in parsed["headers"]["Authorization"]
         assert parsed["headers"]["Authorization"].startswith("Bearer ")
+
+
+class TestBrokerTokenRedaction:
+    """X-Broker-Token redaction. The runner now passes BROKER_TOKEN in this
+    header (claude_sdk._build_broker_mcp_servers); the SDK can serialize the
+    headers dict into session JSONL that _upload_logs ships to S3. The
+    JSON-quoted shape `"X-Broker-Token": "<token>"` is not caught by
+    _SECRET_PATTERNS because the `"` between the keyword and `:` breaks
+    `\\s*[=:]`. _BROKER_TOKEN_PATTERN handles it."""
+
+    def test_redacts_json_serialized_x_broker_token(self):
+        from pmf_engine.runner.main import _redact_line
+
+        # The exact shape the SDK emits into session JSONL for the MCP
+        # server config — this is what was leaking pre-fix.
+        line = '{"headers": {"X-Broker-Token": "tok-broker-abc-12345"}}\n'
+        redacted = _redact_line(line)
+
+        assert "tok-broker-abc-12345" not in redacted
+        assert "X-Broker-Token" in redacted, "Header name preserved"
+        assert "REDACTED" in redacted
+
+    def test_redacts_curl_style_header(self):
+        from pmf_engine.runner.main import _redact_line
+
+        line = "curl -H 'X-Broker-Token: tok-broker-deadbeef0123'"
+        redacted = _redact_line(line)
+
+        assert "tok-broker-deadbeef0123" not in redacted
+        assert "X-Broker-Token" in redacted
+
+    def test_redacts_env_style_assignment(self):
+        from pmf_engine.runner.main import _redact_line
+
+        line = "X-Broker-Token=tok-broker-deadbeef0123"
+        redacted = _redact_line(line)
+
+        assert "tok-broker-deadbeef0123" not in redacted
+        assert "X-Broker-Token" in redacted
+
+    def test_case_insensitive(self):
+        from pmf_engine.runner.main import _redact_line
+
+        line = '"x-broker-token": "tok-broker-abc-12345"'
+        redacted = _redact_line(line)
+
+        assert "tok-broker-abc-12345" not in redacted
+
+    def test_short_value_below_threshold_not_redacted(self):
+        """Threshold of 8 chars matches the existing convention — short
+        strings aren't credentials worth guarding."""
+        from pmf_engine.runner.main import _redact_line
+
+        line = '"X-Broker-Token": "short"'
+        redacted = _redact_line(line)
+
+        assert redacted == line
+
+    def test_redaction_keeps_json_parseable(self):
+        """The substitution must leave surrounding JSON parseable — the
+        value's closing `"` is outside the captured token, so it stays."""
+        import json as _json
+        from pmf_engine.runner.main import _redact_line
+
+        original = (
+            '{"event": "session_start", '
+            '"headers": {"X-Broker-Token": "tok-broker-abc-12345"}}'
+        )
+        redacted = _redact_line(original)
+
+        parsed = _json.loads(redacted)
+        assert parsed["event"] == "session_start"
+        assert "tok-broker-abc-12345" not in parsed["headers"]["X-Broker-Token"]
 


### PR DESCRIPTION
This commit modifies the authentication mechanism for the broker's MCP server configuration. The header used for authorization has been changed from "Authorization: Bearer {broker_token}" to "X-Broker-Token: {broker_token}". Corresponding updates have been made in the test cases to reflect this change, ensuring that the tests validate the new header format correctly. This adjustment aligns with the broker's scope-ticket authentication requirements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auth header changes can break agent MCP tool access if broker env tokens are misconfigured; scope is small and aligned with existing broker auth.
> 
> **Overview**
> The Claude SDK harness now sends the per-run **`BROKER_TOKEN`** as **`X-Broker-Token`** on the HTTP MCP config for `/agent/mcp`, instead of **`Authorization: Bearer …`**. That matches how the broker validates scope tickets (same header as other broker routes).
> 
> Harness tests were updated to assert the new header shape and to document that missing/empty tokens still skip MCP setup entirely.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e577c31371f3347e09f39ca216e6f12354e0f4b4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->