### PR TITLE
Add Accept header to MCP proxy requests

### DIFF
--- a/broker/endpoints/agent_mcp_proxy.py
+++ b/broker/endpoints/agent_mcp_proxy.py
@@ -1,9 +1,13 @@
+import logging
+
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response, StreamingResponse
 
 from broker.clerk_client import ClerkClient, ClerkClientError
 from broker.dynamodb_client import ScopeTicket
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/agent/mcp", tags=["agent_mcp"])
 
@@ -68,7 +72,21 @@ async def proxy_mcp_root(
             "X-Organization-Slug": ticket.organization_slug,
         },
     )
-    upstream = await http.send(upstream_request, stream=True)
+    try:
+        upstream = await http.send(upstream_request, stream=True)
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "gp-api upstream send error run_id=%s org=%s exc_type=%s",
+            ticket.run_id, ticket.organization_slug, type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "reason": "gp_api_upstream_failed",
+                "err": type(exc).__name__,
+            },
+        )
+
     upstream_content_type = upstream.headers.get("content-type", "application/json")
 
     if "text/event-stream" in upstream_content_type.lower():
@@ -76,6 +94,23 @@ async def proxy_mcp_root(
             try:
                 async for chunk in upstream.aiter_bytes():
                     yield chunk
+            except httpx.HTTPError as exc:
+                logger.error(
+                    "mcp upstream stream truncated run_id=%s org=%s exc_type=%s: %s",
+                    ticket.run_id, ticket.organization_slug,
+                    type(exc).__name__, exc,
+                    exc_info=True,
+                )
+                # 200 status is already on the wire. Without an in-band
+                # error event the downstream MCP client treats a
+                # truncated stream as a complete tool result. Yield a
+                # synthetic SSE error so failure is observable.
+                yield (
+                    b'event: error\n'
+                    b'data: {"type":"error","error":'
+                    b'{"type":"upstream_stream_truncated",'
+                    b'"message":"upstream stream ended unexpectedly"}}\n\n'
+                )
             finally:
                 await upstream.aclose()
 

--- a/broker/endpoints/agent_mcp_proxy.py
+++ b/broker/endpoints/agent_mcp_proxy.py
@@ -89,6 +89,20 @@ async def proxy_mcp_root(
 
     upstream_content_type = upstream.headers.get("content-type", "application/json")
 
+    async def _safe_aclose():
+        # finally-block cleanup. A raise here would replace the in-flight
+        # HTTPException (or in the SSE path, propagate up the generator and
+        # be reported as a stream error after the response was already
+        # sent). The connection is being discarded either way; swallow and
+        # log so the caller's structured error survives.
+        try:
+            await upstream.aclose()
+        except Exception:
+            logger.debug(
+                "upstream aclose error (ignored) run_id=%s org=%s",
+                ticket.run_id, ticket.organization_slug,
+            )
+
     if "text/event-stream" in upstream_content_type.lower():
         async def stream_sse():
             try:
@@ -112,7 +126,7 @@ async def proxy_mcp_root(
                     b'"message":"upstream stream ended unexpectedly"}}\n\n'
                 )
             finally:
-                await upstream.aclose()
+                await _safe_aclose()
 
         return StreamingResponse(
             stream_sse(),
@@ -135,7 +149,7 @@ async def proxy_mcp_root(
             },
         )
     finally:
-        await upstream.aclose()
+        await _safe_aclose()
 
     return Response(
         content=content,

--- a/broker/endpoints/agent_mcp_proxy.py
+++ b/broker/endpoints/agent_mcp_proxy.py
@@ -1,5 +1,6 @@
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import Response, StreamingResponse
 
 from broker.clerk_client import ClerkClient, ClerkClientError
 from broker.dynamodb_client import ScopeTicket
@@ -50,7 +51,7 @@ async def proxy_mcp_root(
         )
 
     body = await request.body()
-    upstream = await http.request(
+    upstream_request = http.build_request(
         method=request.method,
         url=f"{base_url.rstrip('/')}/v1/mcp",
         content=body,
@@ -59,16 +60,38 @@ async def proxy_mcp_root(
             # gp-api's MCP Streamable HTTP transport returns 406 without this
             # exact Accept value (per MCP spec). Hardcoded rather than
             # forwarded because callers (incl. FastAPI TestClient) routinely
-            # send `*/*`, which gp-api would still reject.
+            # send `*/*`, which gp-api would still reject. Inviting SSE here
+            # means the upstream may respond with `text/event-stream`; the
+            # branch below preserves streaming end-to-end.
             "Accept": "application/json, text/event-stream",
             "Authorization": f"Bearer {jwt}",
             "X-Organization-Slug": ticket.organization_slug,
         },
     )
+    upstream = await http.send(upstream_request, stream=True)
+    upstream_content_type = upstream.headers.get("content-type", "application/json")
+
+    if "text/event-stream" in upstream_content_type.lower():
+        async def stream_sse():
+            try:
+                async for chunk in upstream.aiter_bytes():
+                    yield chunk
+            finally:
+                await upstream.aclose()
+
+        return StreamingResponse(
+            stream_sse(),
+            status_code=upstream.status_code,
+            media_type=upstream_content_type,
+        )
+
+    try:
+        content = await upstream.aread()
+    finally:
+        await upstream.aclose()
+
     return Response(
-        content=upstream.content,
+        content=content,
         status_code=upstream.status_code,
-        headers={
-            "content-type": upstream.headers.get("content-type", "application/json")
-        },
+        media_type=upstream_content_type,
     )

--- a/broker/endpoints/agent_mcp_proxy.py
+++ b/broker/endpoints/agent_mcp_proxy.py
@@ -56,6 +56,11 @@ async def proxy_mcp_root(
         content=body,
         headers={
             "Content-Type": request.headers.get("content-type", "application/json"),
+            # gp-api's MCP Streamable HTTP transport returns 406 without this
+            # exact Accept value (per MCP spec). Hardcoded rather than
+            # forwarded because callers (incl. FastAPI TestClient) routinely
+            # send `*/*`, which gp-api would still reject.
+            "Accept": "application/json, text/event-stream",
             "Authorization": f"Bearer {jwt}",
             "X-Organization-Slug": ticket.organization_slug,
         },

--- a/broker/endpoints/agent_mcp_proxy.py
+++ b/broker/endpoints/agent_mcp_proxy.py
@@ -122,6 +122,18 @@ async def proxy_mcp_root(
 
     try:
         content = await upstream.aread()
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "gp-api upstream read error run_id=%s org=%s exc_type=%s",
+            ticket.run_id, ticket.organization_slug, type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail={
+                "reason": "gp_api_upstream_failed",
+                "err": type(exc).__name__,
+            },
+        )
     finally:
         await upstream.aclose()
 

--- a/broker/tests/test_agent_mcp_proxy.py
+++ b/broker/tests/test_agent_mcp_proxy.py
@@ -316,6 +316,8 @@ class TestAgentMcpProxySseResponse:
             upstream_body=sse_body,
             upstream_content_type="text/event-stream",
         )
+        upstream = mock_http.send.return_value
+        upstream.aclose = AsyncMock()
         client = TestClient(app)
 
         resp = client.post(
@@ -333,6 +335,10 @@ class TestAgentMcpProxySseResponse:
         # send() invoked in streaming mode so the upstream body wasn't
         # buffered into memory before the proxy decided what to return.
         assert mock_http.send.call_args.kwargs.get("stream") is True
+        # finally block must close the upstream even on the happy path —
+        # without this assertion, deleting `finally: await aclose()` would
+        # leave every SSE connection leaking in production but tests green.
+        upstream.aclose.assert_awaited_once()
 
     def test_sse_with_charset_in_content_type_still_streams(self):
         # Some servers send `text/event-stream; charset=utf-8`. The branch

--- a/broker/tests/test_agent_mcp_proxy.py
+++ b/broker/tests/test_agent_mcp_proxy.py
@@ -203,8 +203,8 @@ class TestAgentMcpProxyUpstreamErrorPassthrough:
 
 class TestAgentMcpProxyHeaderHygiene:
     """X-Broker-Token is the broker's internal auth — it must never appear on
-    the outbound request to gp-api. Only Content-Type and Authorization should
-    be forwarded."""
+    the outbound request to gp-api. Outbound headers are limited to the set
+    gp-api needs (Content-Type, Accept, Authorization, X-Organization-Slug)."""
 
     def test_x_broker_token_is_not_forwarded_to_gp_api(self):
         app, _, mock_http = _create_app()
@@ -226,5 +226,57 @@ class TestAgentMcpProxyHeaderHygiene:
         assert "x-broker-token" not in lowered, (
             f"X-Broker-Token leaked to gp-api: {outbound_headers}"
         )
-        # Sanity: only the three expected headers should be present.
-        assert set(lowered.keys()) == {"content-type", "authorization", "x-organization-slug"}
+        # Sanity: only the four expected headers should be present.
+        assert set(lowered.keys()) == {
+            "content-type",
+            "accept",
+            "authorization",
+            "x-organization-slug",
+        }
+
+
+class TestAgentMcpProxyAcceptHeader:
+    """gp-api's MCP Streamable HTTP transport returns 406 Not Acceptable
+    without `Accept: application/json, text/event-stream`. The proxy
+    hardcodes this value (rather than forwarding the caller's) because
+    callers — including FastAPI TestClient and httpx — routinely send
+    `*/*`, which gp-api would still reject."""
+
+    def test_sends_mcp_required_accept_regardless_of_caller(self):
+        app, _, mock_http = _create_app()
+        client = TestClient(app)
+
+        # Caller sends */* (the TestClient default); proxy still emits the
+        # MCP-required value upstream.
+        resp = client.post(
+            "/agent/mcp",
+            content=b'{"jsonrpc":"2.0","method":"tools/list","id":1}',
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 200
+        outbound = mock_http.request.call_args.kwargs["headers"]
+        assert outbound["Accept"] == "application/json, text/event-stream"
+
+    def test_caller_supplied_accept_is_overridden(self):
+        app, _, mock_http = _create_app()
+        client = TestClient(app)
+
+        # Even if the caller explicitly sets a different Accept value, the
+        # proxy overrides — the upstream is MCP-specific.
+        resp = client.post(
+            "/agent/mcp",
+            content=b'{"jsonrpc":"2.0"}',
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+                "Accept": "text/html",
+            },
+        )
+
+        assert resp.status_code == 200
+        outbound = mock_http.request.call_args.kwargs["headers"]
+        assert outbound["Accept"] == "application/json, text/event-stream"

--- a/broker/tests/test_agent_mcp_proxy.py
+++ b/broker/tests/test_agent_mcp_proxy.py
@@ -383,6 +383,36 @@ class TestAgentMcpProxySseResponse:
         assert detail["reason"] == "gp_api_upstream_failed"
         assert detail["err"] == "ConnectError"
 
+    def test_non_sse_aread_failure_returns_502(self):
+        """JSON-path body read fails mid-flight (connection drop after
+        headers are in, before body fully read). aread() raises — must
+        surface as a structured 502, not a generic 500. aclose() still
+        runs via the finally."""
+        app, _, mock_http = _create_app(
+            upstream_content_type="application/json",
+        )
+        upstream = mock_http.send.return_value
+        upstream.aread = AsyncMock(
+            side_effect=httpx.ReadError("connection reset by peer")
+        )
+        upstream.aclose = AsyncMock()
+
+        client = TestClient(app)
+        resp = client.post(
+            "/agent/mcp",
+            content=b'{"jsonrpc":"2.0"}',
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 502
+        detail = resp.json()["detail"]
+        assert detail["reason"] == "gp_api_upstream_failed"
+        assert detail["err"] == "ReadError"
+        upstream.aclose.assert_awaited()
+
     def test_sse_mid_stream_truncation_yields_synthetic_error_event(self):
         """Mid-stream network failure during SSE iteration: the proxy must
         emit an `event: error` in-band so the downstream MCP client treats

--- a/broker/tests/test_agent_mcp_proxy.py
+++ b/broker/tests/test_agent_mcp_proxy.py
@@ -359,6 +359,71 @@ class TestAgentMcpProxySseResponse:
         assert "text/event-stream" in resp.headers["content-type"]
         assert resp.content == sse_body
 
+    def test_upstream_send_failure_returns_502(self):
+        """gp-api unreachable (connection refused, DNS, timeout, etc.)
+        surfaces as a structured 502, not a generic 500. Mirrors
+        anthropic_proxy's handling of httpx.HTTPError on send."""
+        app, _, mock_http = _create_app()
+        mock_http.send = AsyncMock(
+            side_effect=httpx.ConnectError("connection refused")
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/agent/mcp",
+            content=b'{"jsonrpc":"2.0"}',
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 502
+        detail = resp.json()["detail"]
+        assert detail["reason"] == "gp_api_upstream_failed"
+        assert detail["err"] == "ConnectError"
+
+    def test_sse_mid_stream_truncation_yields_synthetic_error_event(self):
+        """Mid-stream network failure during SSE iteration: the proxy must
+        emit an `event: error` in-band so the downstream MCP client treats
+        the truncated response as a failure, not a complete tool result.
+        The 200 status was already on the wire when iteration started, so
+        an in-band event is the only failure signal available."""
+        app, _, mock_http = _create_app(
+            upstream_status=200,
+            upstream_body=b"event: message\ndata: {\"chunk\":1}\n\n",
+            upstream_content_type="text/event-stream",
+        )
+
+        # Replace the streamed response with one whose aiter_bytes() yields
+        # one chunk and then raises — simulating a connection drop after
+        # bytes have already left the wire.
+        async def truncating_iter():
+            yield b'event: message\ndata: {"chunk":1}\n\n'
+            raise httpx.ReadError("stream closed unexpectedly")
+
+        upstream = mock_http.send.return_value
+        upstream.aiter_bytes = MagicMock(return_value=truncating_iter())
+        upstream.aclose = AsyncMock()
+
+        client = TestClient(app)
+        resp = client.post(
+            "/agent/mcp",
+            content=b'{"jsonrpc":"2.0","method":"tools/call","id":1}',
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 200  # already on the wire
+        # First chunk passed through; then a synthetic SSE error event.
+        assert b'data: {"chunk":1}' in resp.content
+        assert b"event: error" in resp.content
+        assert b"upstream_stream_truncated" in resp.content
+        # Stream resource closed even on the error path.
+        upstream.aclose.assert_awaited()
+
     def test_json_upstream_still_returns_plain_response(self):
         # Regression guard for the non-SSE path: the branch must still
         # return a fully-buffered Response (not a stream) when upstream

--- a/broker/tests/test_agent_mcp_proxy.py
+++ b/broker/tests/test_agent_mcp_proxy.py
@@ -66,7 +66,18 @@ def _create_app(
         content=upstream_body,
         headers={"content-type": upstream_content_type},
     )
-    mock_http.request = AsyncMock(return_value=upstream_response)
+    # The proxy uses build_request + send(stream=True) so it can branch on
+    # the upstream content-type and preserve SSE framing for streaming
+    # responses (mirrors the anthropic_proxy pattern).
+    mock_http.build_request = MagicMock(
+        side_effect=lambda **kwargs: httpx.Request(
+            method=kwargs["method"],
+            url=kwargs["url"],
+            headers=kwargs.get("headers"),
+            content=kwargs.get("content"),
+        )
+    )
+    mock_http.send = AsyncMock(return_value=upstream_response)
     app.dependency_overrides[get_http_client] = lambda: mock_http
 
     return app, mock_clerk, mock_http
@@ -95,14 +106,18 @@ class TestAgentMcpProxyHappyPath:
 
         mock_clerk.get_session_jwt.assert_awaited_once_with("sess_abc123")
 
-        mock_http.request.assert_awaited_once()
-        call_kwargs = mock_http.request.call_args.kwargs
+        mock_http.build_request.assert_called_once()
+        call_kwargs = mock_http.build_request.call_args.kwargs
         assert call_kwargs["method"] == "POST"
         assert call_kwargs["url"] == f"{GP_API_BASE_URL}/v1/mcp"
         assert call_kwargs["content"] == request_body
         assert call_kwargs["headers"]["Authorization"] == f"Bearer {FAKE_JWT}"
         assert call_kwargs["headers"]["Content-Type"] == "application/json"
         assert call_kwargs["headers"]["X-Organization-Slug"] == "org-42"
+        # send() called with stream=True so the proxy can decide to stream
+        # SSE responses through without buffering.
+        mock_http.send.assert_awaited_once()
+        assert mock_http.send.call_args.kwargs.get("stream") is True
 
     def test_get_method_also_proxied(self):
         app, _, mock_http = _create_app()
@@ -114,7 +129,7 @@ class TestAgentMcpProxyHappyPath:
         )
 
         assert resp.status_code == 200
-        assert mock_http.request.call_args.kwargs["method"] == "GET"
+        assert mock_http.build_request.call_args.kwargs["method"] == "GET"
 
 
 class TestAgentMcpProxyMissingClerkSessionId:
@@ -135,7 +150,7 @@ class TestAgentMcpProxyMissingClerkSessionId:
         assert resp.status_code == 500
         assert resp.json()["detail"]["reason"] == "ticket_missing_clerk_session_id"
         mock_clerk.get_session_jwt.assert_not_awaited()
-        mock_http.request.assert_not_awaited()
+        mock_http.send.assert_not_awaited()
 
 
 class TestAgentMcpProxyClerkMintFailure:
@@ -158,7 +173,7 @@ class TestAgentMcpProxyClerkMintFailure:
         detail = resp.json()["detail"]
         assert detail["reason"] == "clerk_session_jwt_mint_failed"
         assert "upstream 500" in detail["err"]
-        mock_http.request.assert_not_awaited()
+        mock_http.send.assert_not_awaited()
 
 
 class TestAgentMcpProxyUpstreamErrorPassthrough:
@@ -220,7 +235,7 @@ class TestAgentMcpProxyHeaderHygiene:
         )
 
         assert resp.status_code == 200
-        outbound_headers = mock_http.request.call_args.kwargs["headers"]
+        outbound_headers = mock_http.build_request.call_args.kwargs["headers"]
         # Case-insensitive guard: no broker token under any casing.
         lowered = {k.lower(): v for k, v in outbound_headers.items()}
         assert "x-broker-token" not in lowered, (
@@ -258,7 +273,7 @@ class TestAgentMcpProxyAcceptHeader:
         )
 
         assert resp.status_code == 200
-        outbound = mock_http.request.call_args.kwargs["headers"]
+        outbound = mock_http.build_request.call_args.kwargs["headers"]
         assert outbound["Accept"] == "application/json, text/event-stream"
 
     def test_caller_supplied_accept_is_overridden(self):
@@ -278,5 +293,93 @@ class TestAgentMcpProxyAcceptHeader:
         )
 
         assert resp.status_code == 200
-        outbound = mock_http.request.call_args.kwargs["headers"]
+        outbound = mock_http.build_request.call_args.kwargs["headers"]
         assert outbound["Accept"] == "application/json, text/event-stream"
+
+
+class TestAgentMcpProxySseResponse:
+    """gp-api's MCP Streamable HTTP transport can respond with either
+    `application/json` (single envelope) or `text/event-stream` (SSE for
+    streamable tools). The proxy must preserve the streaming shape for SSE
+    so large/long-lived streams aren't buffered fully in memory and SSE
+    framing isn't lost. Mirrors the anthropic_proxy pattern."""
+
+    def test_sse_upstream_returns_streaming_response(self):
+        sse_body = (
+            b"event: message\n"
+            b'data: {"jsonrpc":"2.0","result":{"chunk":1}}\n\n'
+            b"event: message\n"
+            b'data: {"jsonrpc":"2.0","result":{"chunk":2}}\n\n'
+        )
+        app, _, mock_http = _create_app(
+            upstream_status=200,
+            upstream_body=sse_body,
+            upstream_content_type="text/event-stream",
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/agent/mcp",
+            content=b'{"jsonrpc":"2.0","method":"tools/call","id":1}',
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        assert resp.content == sse_body
+        # send() invoked in streaming mode so the upstream body wasn't
+        # buffered into memory before the proxy decided what to return.
+        assert mock_http.send.call_args.kwargs.get("stream") is True
+
+    def test_sse_with_charset_in_content_type_still_streams(self):
+        # Some servers send `text/event-stream; charset=utf-8`. The branch
+        # check is `in upstream_content_type.lower()`, so the charset
+        # suffix must not break detection.
+        sse_body = b'event: message\ndata: {"chunk":1}\n\n'
+        app, _, _ = _create_app(
+            upstream_status=200,
+            upstream_body=sse_body,
+            upstream_content_type="text/event-stream; charset=utf-8",
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/agent/mcp",
+            content=b"{}",
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+        assert resp.content == sse_body
+
+    def test_json_upstream_still_returns_plain_response(self):
+        # Regression guard for the non-SSE path: the branch must still
+        # return a fully-buffered Response (not a stream) when upstream
+        # is application/json.
+        json_body = b'{"jsonrpc":"2.0","result":{"tools":[]}}'
+        app, _, _ = _create_app(
+            upstream_status=200,
+            upstream_body=json_body,
+            upstream_content_type="application/json",
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/agent/mcp",
+            content=b'{"jsonrpc":"2.0","method":"tools/list","id":1}',
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/json")
+        assert resp.content == json_body

--- a/broker/tests/test_agent_mcp_proxy.py
+++ b/broker/tests/test_agent_mcp_proxy.py
@@ -66,6 +66,11 @@ def _create_app(
         content=upstream_body,
         headers={"content-type": upstream_content_type},
     )
+    # aclose is mocked on every upstream so tests can assert cleanup ran
+    # without per-test setup. The proxy's `finally: await _safe_aclose()`
+    # is the only thing keeping connections from leaking on every code
+    # path — the assertion is the regression guard for accidental removal.
+    upstream_response.aclose = AsyncMock()
     # The proxy uses build_request + send(stream=True) so it can branch on
     # the upstream content-type and preserve SSE framing for streaming
     # responses (mirrors the anthropic_proxy pattern).
@@ -118,6 +123,11 @@ class TestAgentMcpProxyHappyPath:
         # SSE responses through without buffering.
         mock_http.send.assert_awaited_once()
         assert mock_http.send.call_args.kwargs.get("stream") is True
+        # finally: aclose must run on the non-SSE happy path — without
+        # this assertion, deleting `finally: await _safe_aclose()` would
+        # leave every non-SSE connection leaking in production but tests
+        # green. Symmetric with the SSE happy path's aclose assertion.
+        mock_http.send.return_value.aclose.assert_awaited_once()
 
     def test_get_method_also_proxied(self):
         app, _, mock_http = _create_app()
@@ -401,7 +411,6 @@ class TestAgentMcpProxySseResponse:
         upstream.aread = AsyncMock(
             side_effect=httpx.ReadError("connection reset by peer")
         )
-        upstream.aclose = AsyncMock()
 
         client = TestClient(app)
         resp = client.post(
@@ -418,6 +427,107 @@ class TestAgentMcpProxySseResponse:
         assert detail["reason"] == "gp_api_upstream_failed"
         assert detail["err"] == "ReadError"
         upstream.aclose.assert_awaited()
+
+    def test_non_sse_aclose_failure_does_not_mask_upstream_error(self):
+        """If aread() raises (-> HTTPException 502) AND aclose() itself
+        also raises (realistic on a connection that just dropped mid-
+        read), the in-flight HTTPException must survive. `_safe_aclose`
+        swallows the aclose exception so FastAPI's HTTPException handler
+        produces the structured 502 instead of an unstructured 500."""
+        app, _, mock_http = _create_app(
+            upstream_content_type="application/json",
+        )
+        upstream = mock_http.send.return_value
+        upstream.aread = AsyncMock(
+            side_effect=httpx.ReadError("connection reset by peer")
+        )
+        upstream.aclose = AsyncMock(
+            side_effect=httpx.NetworkError("aclose also failed")
+        )
+
+        client = TestClient(app)
+        resp = client.post(
+            "/agent/mcp",
+            content=b'{"jsonrpc":"2.0"}',
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        # The structured 502 from aread's HTTPError survives — aclose's
+        # NetworkError was swallowed by _safe_aclose.
+        assert resp.status_code == 502
+        detail = resp.json()["detail"]
+        assert detail["reason"] == "gp_api_upstream_failed"
+        assert detail["err"] == "ReadError"
+        upstream.aclose.assert_awaited()
+
+    def test_non_sse_aclose_failure_on_happy_path_does_not_break_response(self):
+        """On the happy path: aread succeeds, response body is ready, but
+        aclose raises during cleanup. The successful response must still
+        reach the client. `_safe_aclose` swallows the exception so the
+        already-built Response is returned intact."""
+        json_body = b'{"jsonrpc":"2.0","result":{"ok":true}}'
+        app, _, mock_http = _create_app(
+            upstream_status=200,
+            upstream_body=json_body,
+            upstream_content_type="application/json",
+        )
+        upstream = mock_http.send.return_value
+        upstream.aclose = AsyncMock(
+            side_effect=httpx.NetworkError("aclose failed during cleanup")
+        )
+
+        client = TestClient(app)
+        resp = client.post(
+            "/agent/mcp",
+            content=b'{"jsonrpc":"2.0"}',
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        # Happy 200 survives the aclose failure — body intact, status
+        # unchanged. aclose was still attempted.
+        assert resp.status_code == 200
+        assert resp.content == json_body
+        upstream.aclose.assert_awaited_once()
+
+    def test_sse_aclose_failure_does_not_break_streaming_response(self):
+        """SSE path: aclose raises in the generator's finally after the
+        stream content was successfully iterated. Without `_safe_aclose`,
+        the raise would propagate up through the StreamingResponse
+        generator and surface as a stream error (after the chunks already
+        reached the wire). With the swallow, the response completes
+        cleanly."""
+        sse_body = b'event: message\ndata: {"chunk":1}\n\n'
+        app, _, mock_http = _create_app(
+            upstream_status=200,
+            upstream_body=sse_body,
+            upstream_content_type="text/event-stream",
+        )
+        upstream = mock_http.send.return_value
+        upstream.aclose = AsyncMock(
+            side_effect=httpx.NetworkError("aclose failed during cleanup")
+        )
+
+        client = TestClient(app)
+        resp = client.post(
+            "/agent/mcp",
+            content=b"{}",
+            headers={
+                "X-Broker-Token": BROKER_TOKEN,
+                "Content-Type": "application/json",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        # Stream content delivered intact despite aclose failure.
+        assert resp.content == sse_body
+        upstream.aclose.assert_awaited_once()
 
     def test_sse_mid_stream_truncation_yields_synthetic_error_event(self):
         """Mid-stream network failure during SSE iteration: the proxy must
@@ -465,7 +575,7 @@ class TestAgentMcpProxySseResponse:
         # return a fully-buffered Response (not a stream) when upstream
         # is application/json.
         json_body = b'{"jsonrpc":"2.0","result":{"tools":[]}}'
-        app, _, _ = _create_app(
+        app, _, mock_http = _create_app(
             upstream_status=200,
             upstream_body=json_body,
             upstream_content_type="application/json",
@@ -484,3 +594,8 @@ class TestAgentMcpProxySseResponse:
         assert resp.status_code == 200
         assert resp.headers["content-type"].startswith("application/json")
         assert resp.content == json_body
+        # finally: aclose must close the upstream even on the happy path.
+        # Asserting here (in addition to the canonical happy-path test
+        # above) covers this branch specifically, so removing the finally
+        # block fails both tests rather than passing silently.
+        mock_http.send.return_value.aclose.assert_awaited_once()


### PR DESCRIPTION
This commit updates the MCP proxy to include a hardcoded "Accept" header with the value "application/json, text/event-stream". This change ensures compliance with the MCP specification, as the gp-api requires this specific Accept value to avoid 406 errors. Additionally, tests have been added to verify that the proxy correctly overrides any Accept header provided by the caller, maintaining the expected behavior for outbound requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted proxy header change with tests; no auth or data-model changes beyond fixing upstream compatibility.
> 
> **Overview**
> The agent MCP proxy now always sends **`Accept: application/json, text/event-stream`** on upstream calls to gp-api, instead of relying on the caller’s header. That matches MCP Streamable HTTP expectations and avoids **406** responses when clients send defaults like `*/*`.
> 
> Header hygiene tests were updated to expect four outbound headers (including `Accept`), and new tests assert the proxy sets the MCP value even when the caller omits `Accept` or sends a different one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbf16570a10b5c93fe42f6505cbc828e0ba4d520. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->