### PR TITLE
Use Gemini Flash 3.5 to braintrust eval.

### DIFF
--- a/braintrust_eval_sandbox/README.md
+++ b/braintrust_eval_sandbox/README.md
@@ -95,7 +95,7 @@ In the `braintrust-eval-sandbox` Braintrust project, Project Settings → Enviro
 
 ## Limitations
 
-- Model hardcoded to `gemini-3-flash-preview`. Per-prompt model picking via the prompt parameter's `options.model` isn't honored — the Gemini client uses its default model. If we need per-eval model selection later, expose a 5th parameter.
+- Model hardcoded to `gemini-3.5-flash`. Per-prompt model picking via the prompt parameter's `options.model` isn't honored — the Gemini client uses its default model. If we need per-eval model selection later, expose a 5th parameter.
 - No derived variables (`today`, `days_remaining`, etc). Whatever the prompt needs has to be in the dataset row.
 - Stage 1 → stage 2 wiring is one direction: `main_prompt_output` only. If stage 2 needs the original row vars too, it gets them — every row key is available in both stages.
 - No scorers shipped. Write them in the Braintrust UI for each use case.

--- a/braintrust_eval_sandbox/evals.py
+++ b/braintrust_eval_sandbox/evals.py
@@ -58,7 +58,7 @@ from shared.braintrust import (
     init_braintrust,
     trace_pipeline,
 )
-from shared.llm_gemini_3 import Gemini3Client
+from shared.llm_gemini_3 import Gemini3Client, GeminiModelType, ThinkingLevel
 
 PROJECT = "braintrust-eval-sandbox"
 DATASET_NAME = "braintrust-eval-sandbox"
@@ -270,7 +270,10 @@ def pipeline_task(input: dict, hooks: Any) -> dict:
     main_prompt_built = params["main_prompt"].build(**input)
     main_prompt_text = flatten_prompt_messages(main_prompt_built)
 
-    llm_client = Gemini3Client()
+    llm_client = Gemini3Client(
+        default_model=GeminiModelType.FLASH_3_5,
+        thinking_level=ThinkingLevel.HIGH,
+    )
 
     with trace_pipeline(
         "pipeline_task",
@@ -377,7 +380,7 @@ EVAL_PARAMETERS: dict[str, Any] = {
                 "type": "chat",
                 "messages": [{"role": "system", "content": ""}],
             },
-            "options": {"model": "gemini-3-flash-preview"},
+            "options": {"model": "gemini-3.5-flash"},
         },
     },
     "structured_output_prompt": {
@@ -401,7 +404,7 @@ EVAL_PARAMETERS: dict[str, Any] = {
                     }
                 ],
             },
-            "options": {"model": "gemini-3-flash-preview"},
+            "options": {"model": "gemini-3.5-flash"},
         },
     },
     "structured_output_schema": _StructuredOutputSchemaParam,

--- a/shared/llm_gemini_3.py
+++ b/shared/llm_gemini_3.py
@@ -18,12 +18,14 @@ load_dotenv()
 GEMINI_3_PRICING = {
     'gemini-3-flash-preview': {'input': 0.50, 'output': 3.00},
     'gemini-3-pro-preview': {'input': 2.50, 'output': 15.00},
+    'gemini-3.5-flash': {'input': 1.50, 'output': 9.00},
 }
 
 
 class GeminiModelType(Enum):
     FLASH_3 = "gemini-3-flash-preview"
     PRO_3 = "gemini-3-pro-preview"
+    FLASH_3_5 = "gemini-3.5-flash"
 
 
 class ThinkingLevel(Enum):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scope is the eval sandbox and shared Gemini client metadata; no auth or production serving paths, but eval cost and LLM behavior will change for playground runs.
> 
> **Overview**
> Switches the **Braintrust eval sandbox** pipeline from **Gemini 3 Flash preview** to **`gemini-3.5-flash`**, with **high** thinking on the shared `Gemini3Client` used for both stages (search/completion and structured output).
> 
> The shared client gains a **`FLASH_3_5`** model enum and **token pricing** for `gemini-3.5-flash`. Playground prompt parameter defaults and README now say the eval is hardcoded to **3.5 Flash** (prompt `options.model` is still not honored at runtime).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86d71f1282bb455ab7cc73967535a26976f9c9e9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->