### PR TITLE
infra(broker): prod broker autoscaling min 5 / max 30

### DIFF
--- a/infrastructure/environments/prod/broker/main.tf
+++ b/infrastructure/environments/prod/broker/main.tf
@@ -98,6 +98,9 @@ module "broker" {
   ecr_repository_url = "333022194791.dkr.ecr.us-west-2.amazonaws.com/gp-ai-projects"
   docker_image_tag   = "broker-prod"
 
+  autoscale_min_capacity = 5
+  autoscale_max_capacity = 30
+
   agent_security_group_id           = try(data.terraform_remote_state.fargate[0].outputs.security_group_id, "")
   dispatch_lambda_security_group_id = try(data.terraform_remote_state.control_plane[0].outputs.dispatch_lambda_sg_id, "")
 

--- a/infrastructure/modules/broker/main.tf
+++ b/infrastructure/modules/broker/main.tf
@@ -741,9 +741,21 @@ resource "aws_ecs_service" "broker" {
 
 # --- Autoscaling ---
 
+variable "autoscale_min_capacity" {
+  description = "Minimum number of broker tasks held by application-autoscaling. Defaults to 1; prod overrides to keep warm capacity."
+  type        = number
+  default     = 1
+}
+
+variable "autoscale_max_capacity" {
+  description = "Maximum number of broker tasks application-autoscaling may scale to under load. Defaults to 10; prod overrides for more burst headroom."
+  type        = number
+  default     = 10
+}
+
 resource "aws_appautoscaling_target" "broker" {
-  min_capacity       = 1
-  max_capacity       = 10
+  min_capacity       = var.autoscale_min_capacity
+  max_capacity       = var.autoscale_max_capacity
   resource_id        = "service/${aws_ecs_cluster.broker.name}/${aws_ecs_service.broker.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"


### PR DESCRIPTION
## What
Raises the **prod** broker ECS service autoscaling from **min 1 / max 10** to **min 5 / max 30**.

Parameterizes `autoscale_min_capacity` and `autoscale_max_capacity` on the broker module (defaults stay **1 / 10**, so **dev and qa are unchanged**) and sets prod to **5 / 30** in `environments/prod/broker/main.tf`.

## Why
The prod broker ran as a single task. Under real load — MCP-proxy SSE streaming plus run-token minting for a large dispatch batch — one task is both a throughput bottleneck (observed ReadTimeouts on the MCP proxy) and a single point of failure. Holding 5 warm tasks gives baseline capacity/availability; max 30 allows bursting under CPU/memory target-tracking.

## Status
Already applied to prod via `terraform apply` (min→5, then max→30, both clean in-place updates; service scaled 1→5 immediately). This PR commits the code so the repo matches deployed state.

## Scope / blast radius
- Module defaults unchanged (1 / 10) → **dev and qa unaffected**.
- Only `aws_appautoscaling_target.broker` min/max change; no resource recreation.

## Note (not addressed here)
This adds broker capacity but does **not** fix the Clerk 429 rate-limit storm seen during the 3000-job batch — that's an upstream Clerk limit, and more brokers can issue more concurrent actor-token mints. The stampede fixes (gate `clerk_user_id` to MCP-only experiments + cap dispatch concurrency) are separate follow-ups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises prod broker floor cost and concurrent capacity under load; scope is limited to autoscaling bounds with module defaults preserving non-prod behavior.
> 
> **Overview**
> **Prod broker ECS autoscaling** is raised from a fixed **1–10** task range to **5–30** by parameterizing `aws_appautoscaling_target` min/max on the broker module (`autoscale_min_capacity` / `autoscale_max_capacity`, defaults **1 / 10**). Only **prod** passes **5 / 30** in `environments/prod/broker/main.tf`; **dev and qa** keep the defaults.
> 
> This is an in-place Terraform change to application autoscaling limits only—no new resources or changes to CPU/memory target-tracking policies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f23f426dfca56c0c090663dc953ec7a6564b8b61. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->