### PR TITLE
fix(pmf_engine): forward data_required_unless carve-out in derive_scope

### DIFF
--- a/pmf_engine/control_plane/scope_derivation.py
+++ b/pmf_engine/control_plane/scope_derivation.py
@@ -42,10 +42,18 @@ def derive_scope(experiment_id: str, params: dict, manifest_scope: dict | None =
     if district:
         _validate_scope_string("district", district)
 
-    return {
+    result: dict = {
         "state": state,
         "cities": [city] if city else [],
         "districts": [district] if district else [],
         "allowed_tables": config.get("allowed_tables", []),
         "max_rows": config.get("max_rows", 50000),
     }
+
+    # Carry broker-domain carve-out fields through verbatim so the anti-fabrication
+    # gate in artifact_publish.py can exempt zero-query artifacts (e.g. meeting_briefing
+    # with briefing_status=awaiting_agenda).
+    if "data_required_unless" in config:
+        result["data_required_unless"] = config["data_required_unless"]
+
+    return result

--- a/pmf_engine/tests/test_scope_derivation.py
+++ b/pmf_engine/tests/test_scope_derivation.py
@@ -2,7 +2,6 @@ import pytest
 
 from pmf_engine.control_plane.scope_derivation import derive_scope
 
-
 SYNTHETIC_MANIFEST_SCOPE = {
     "allowed_tables": ["goodparty_data_catalog.dbt.int__l2_nationwide_uniform_w_haystaq"],
     "max_rows": 50000,
@@ -137,3 +136,35 @@ class TestInputValidation:
     def test_rejects_control_chars_or_excessive_length_district(self, bad_district):
         with pytest.raises(ValueError, match="district"):
             derive_scope("smoke_test", {"state": "NC", "district": bad_district})
+
+
+class TestDataRequiredUnlessForwarding:
+    """data_required_unless is a broker-domain carve-out field declared in the
+    manifest scope. derive_scope must carry it through unchanged so the broker's
+    anti-fabrication gate can exempt legitimate zero-query artifacts (e.g.
+    meeting_briefing with briefing_status=awaiting_agenda)."""
+
+    MEETING_BRIEFING_SCOPE = {
+        "allowed_tables": [],
+        "max_rows": 50000,
+        "data_required_unless": {
+            "field": "briefing_status",
+            "values": ["awaiting_agenda", "no_meeting_found", "error"],
+        },
+    }
+
+    def test_data_required_unless_is_forwarded_when_present(self):
+        scope = derive_scope("meeting_briefing", {"state": "CA"}, manifest_scope=self.MEETING_BRIEFING_SCOPE)
+        assert scope["data_required_unless"] == self.MEETING_BRIEFING_SCOPE["data_required_unless"]
+
+    def test_data_required_unless_absent_when_not_in_manifest(self):
+        scope = derive_scope(
+            "smoke_test",
+            {"state": "NC"},
+            manifest_scope={"allowed_tables": ["some_table"], "max_rows": 1000},
+        )
+        assert "data_required_unless" not in scope
+
+    def test_data_required_unless_absent_when_no_manifest_scope(self):
+        scope = derive_scope("smoke_test", {"state": "NC"})
+        assert "data_required_unless" not in scope


### PR DESCRIPTION
## Why

`derive_scope` built the broker `ScopeTicket` dict from the manifest scope but silently dropped `data_required_unless`. The broker's anti-fabrication gate in `artifact_publish.py` reads `ticket.scope.get("data_required_unless")` to decide whether a zero-query artifact is permitted; getting `None` meant the carve-out never fired. Every `meeting_briefing` artifact with `briefing_status=awaiting_agenda` (or `no_meeting_found`/`error`) — which legitimately runs zero Databricks queries — was being rejected with `NoDataQueriesSucceeded`.

The fix is a one-way carry-through: when `data_required_unless` is present in the manifest scope, copy it verbatim into the returned dict. When absent, the key stays out of the dict (no crash, no implicit grant).

The `meeting_briefing` manifest already declares the correct carve-out:
```json
"data_required_unless": {"field": "briefing_status", "values": ["awaiting_agenda", "no_meeting_found", "error"]}
```
It just was never reaching the broker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches publish-path scope wiring and anti-fabrication exemptions; behavior change is narrow but affects which zero-query artifacts are allowed.
> 
> **Overview**
> `derive_scope` now copies **`data_required_unless`** from the manifest scope into the broker scope ticket when it is declared, instead of dropping it. That lets the anti-fabrication gate in **`artifact_publish.py`** honor manifest carve-outs for zero-query artifacts (e.g. **`meeting_briefing`** with **`briefing_status`** in **`awaiting_agenda`**, **`no_meeting_found`**, or **`error`**), which were previously rejected as **`NoDataQueriesSucceeded`**.
> 
> When the field is not in the manifest, the key is omitted from the returned scope (no default grant). Tests cover forward-on-present and absent-when-missing cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28b2f57c845bb69e2320b2ffb2ad0726168d056. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->