### PR TITLE
fix(pmf-engine): carry data_required_unless through derive_scope

### DIFF
--- a/pmf_engine/control_plane/scope_derivation.py
+++ b/pmf_engine/control_plane/scope_derivation.py
@@ -18,7 +18,12 @@ def derive_scope(experiment_id: str, params: dict, manifest_scope: dict | None =
     """Build the broker scope ticket fields.
 
     `manifest_scope` is the `scope` block from the experiment manifest in S3.
-    When present, its `allowed_tables` and `max_rows` are passed through verbatim.
+    When present, its `allowed_tables`, `max_rows`, and `data_required_unless`
+    are passed through verbatim. `data_required_unless` MUST be carried through:
+    the broker's NoDataQueriesSucceeded publish guard reads it from the ticket
+    scope to exempt legitimate no-data placeholder runs (e.g. meeting_briefing's
+    `briefing_status=awaiting_agenda`). Dropping it here causes those runs to be
+    rejected at publish even though no Databricks query is appropriate.
 
     Permissive defaults are intentional: when `manifest_scope` is None or empty
     (e.g. web-research-only experiments with no Databricks access), we default
@@ -42,10 +47,13 @@ def derive_scope(experiment_id: str, params: dict, manifest_scope: dict | None =
     if district:
         _validate_scope_string("district", district)
 
-    return {
+    scope = {
         "state": state,
         "cities": [city] if city else [],
         "districts": [district] if district else [],
         "allowed_tables": config.get("allowed_tables", []),
         "max_rows": config.get("max_rows", 50000),
     }
+    if "data_required_unless" in config:
+        scope["data_required_unless"] = config["data_required_unless"]
+    return scope

--- a/pmf_engine/tests/test_scope_derivation.py
+++ b/pmf_engine/tests/test_scope_derivation.py
@@ -137,3 +137,31 @@ class TestInputValidation:
     def test_rejects_control_chars_or_excessive_length_district(self, bad_district):
         with pytest.raises(ValueError, match="district"):
             derive_scope("smoke_test", {"state": "NC", "district": bad_district})
+
+
+class TestDataRequiredUnlessPassthrough:
+    """Regression: the broker's NoDataQueriesSucceeded publish guard reads
+    `data_required_unless` from the ticket scope. derive_scope must carry it
+    through from the manifest, or legitimate no-data placeholder runs (e.g.
+    meeting_briefing's awaiting_agenda / no_meeting_found) get rejected at
+    publish even though no Databricks query is appropriate for that branch."""
+
+    def test_data_required_unless_is_carried_through(self):
+        manifest_scope = {
+            "allowed_tables": ["goodparty_data_catalog.dbt.int__l2_nationwide_uniform_w_haystaq"],
+            "max_rows": 50000,
+            "data_required_unless": {
+                "field": "briefing_status",
+                "values": ["awaiting_agenda", "no_meeting_found", "error"],
+            },
+        }
+        scope = derive_scope("meeting_briefing", {"state": "NC"}, manifest_scope=manifest_scope)
+
+        assert scope["data_required_unless"] == {
+            "field": "briefing_status",
+            "values": ["awaiting_agenda", "no_meeting_found", "error"],
+        }
+
+    def test_data_required_unless_absent_when_manifest_omits_it(self):
+        scope = derive_scope("web_only_experiment", {"state": "NC"}, manifest_scope={"max_rows": 50000})
+        assert scope.get("data_required_unless") is None


### PR DESCRIPTION
## Problem
~50% of prod `meeting_briefing` runs are exiting 1, rejected at publish with:
```
NoDataQueriesSucceeded: experiment 'meeting_briefing' declares scope.allowed_tables
but no Databricks query succeeded during this run.
```
These are **not real failures** — they're legitimate placeholder runs (officials with no upcoming meeting / no posted agenda → `briefing_status: awaiting_agenda` / `no_meeting_found`). The agent correctly skips Databricks per its instruction and emits a valid placeholder, but the broker throws it away.

## Root cause
The broker's `NoDataQueriesSucceeded` guard (broker/endpoints/artifact_publish.py) reads the carve-out from the **ticket scope**: `ticket.scope.get("data_required_unless")`. But `derive_scope()` (which builds the ticket scope at dispatch) only passed through `allowed_tables` and `max_rows` — it **dropped `data_required_unless`**. So the carve-out lived in the manifest but never reached the guard, and every no-data placeholder run was rejected.

The guard feature (commit 4607d08) was wired on the broker **read** side but not the dispatch **write** side. Confirmed end-to-end in prod: a failed run's artifact has `briefing_status: "awaiting_agenda"` at the root (✅ matches carve-out), the deployed manifest declares the carve-out (✅), but the ticket scope omits it (❌).

## Fix
Pass `data_required_unless` through verbatim in `derive_scope` when the manifest declares it. The broker already fails-safe on `None`/malformed, so absent stays absent.

## Tests (red→green)
- `test_data_required_unless_is_carried_through` — fails before the fix (`KeyError`), passes after.
- `test_data_required_unless_absent_when_manifest_omits_it` — web-only experiments don't get a spurious key.
- Full suite: 124 pmf_engine scope+dispatch tests pass.

## Impact
Converts ~50% apparent failure rate → ~100% success: the rejected placeholder runs will publish as valid `awaiting_agenda`/`no_meeting_found` artifacts (so the dashboard shows 'check back later' instead of nothing). Unrelated to the SDK upgrade, Clerk JWT change, or broker scaling — purely a produce/consume wiring gap in the no-data guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted scope-derivation change with regression tests; no auth or data-path changes beyond fixing publish exemptions already defined in manifests.
> 
> **Overview**
> **`derive_scope`** now copies **`data_required_unless`** from the experiment manifest into the broker ticket scope when the manifest defines it, alongside the existing **`allowed_tables`** / **`max_rows`** passthrough.
> 
> That closes a dispatch vs. publish gap: the broker’s **NoDataQueriesSucceeded** guard already honors this carve-out on the ticket, but dispatch was dropping it—so **`meeting_briefing`** runs that legitimately skip Databricks (e.g. **`briefing_status`** `awaiting_agenda` / `no_meeting_found`) were rejected at publish. Experiments without the field in the manifest still omit it on the ticket.
> 
> Regression tests assert passthrough for **`meeting_briefing`**-style manifests and no spurious key when the manifest omits it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e5972e32fd446336e271c16975f380f2e2e449d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->