### PR TITLE
fix(broker): distribute Databricks query tracker via DynamoDB

### DIFF
--- a/broker/data_query_tracker.py
+++ b/broker/data_query_tracker.py
@@ -1,35 +1,56 @@
-import threading
+import boto3
 
 
 class DataQueryTracker:
-    """Per-ticket counter of successful Databricks queries.
+    """Per-ticket counter of successful Databricks queries, backed by DynamoDB.
 
-    Process-local. Used by the artifact publish endpoint to gate experiments
-    whose manifest declares `scope.allowed_tables` — if the count is zero we
-    assume the agent fabricated its output (Databricks was unreachable, scope
-    rejected every query, etc.) and reject the publish.
+    The count is stamped onto the run's scope-ticket item (same table, same
+    `pk`), so every broker instance reads and writes the same value. This keeps
+    the broker stateless and horizontally scalable — the previous process-local
+    counter silently broke once the service ran more than one task, because a
+    run's Databricks query and its artifact publish land on different instances.
 
-    The gate keys off scope, NOT a hardcoded experiment list, so the broker
-    stays consumer-domain-agnostic. Any new experiment with allowed_tables
-    automatically gets the safety check; any new web-only experiment skips it.
+    Feeds the artifact_publish anti-fabrication gate: if a manifest declares
+    `scope.allowed_tables` but the count is zero, the agent's data calls all
+    failed (or it never queried), so the output is synthetic and the publish is
+    rejected. The gate keys off scope, not a hardcoded experiment list, so the
+    broker stays consumer-domain-agnostic.
 
-    Single broker task today means a broker restart during a run clears the
-    counter and the publish would be rejected — strictly safer than the
-    previous behavior of accepting any schema-valid artifact.
+    The counter rides the scope ticket's TTL, so it is cleaned up with the run.
     """
 
-    def __init__(self) -> None:
-        self._counts: dict[str, int] = {}
-        self._lock = threading.Lock()
+    def __init__(self, table_name: str, dynamodb_client=None) -> None:
+        self._table_name = table_name
+        self._client = dynamodb_client or boto3.client("dynamodb")
 
     def increment(self, ticket_pk: str) -> None:
-        with self._lock:
-            self._counts[ticket_pk] = self._counts.get(ticket_pk, 0) + 1
+        # Atomic server-side ADD: concurrent queries from the same run hitting
+        # different broker instances cannot lose updates (no read-modify-write).
+        self._client.update_item(
+            TableName=self._table_name,
+            Key={"pk": {"S": ticket_pk}},
+            UpdateExpression="ADD query_count :one",
+            ExpressionAttributeValues={":one": {"N": "1"}},
+        )
 
     def get(self, ticket_pk: str) -> int:
-        with self._lock:
-            return self._counts.get(ticket_pk, 0)
+        # Strongly consistent: the publish must observe increments that landed
+        # on another instance moments earlier, or the gate misfires and rejects
+        # a legitimately data-backed artifact.
+        response = self._client.get_item(
+            TableName=self._table_name,
+            Key={"pk": {"S": ticket_pk}},
+            ConsistentRead=True,
+        )
+        item = response.get("Item")
+        if not item or "query_count" not in item:
+            return 0
+        return int(item["query_count"]["N"])
 
     def clear(self, ticket_pk: str) -> None:
-        with self._lock:
-            self._counts.pop(ticket_pk, None)
+        # Best-effort hygiene; the ticket item is deleted at end of run anyway.
+        self._client.update_item(
+            TableName=self._table_name,
+            Key={"pk": {"S": ticket_pk}},
+            UpdateExpression="REMOVE query_count",
+        )

--- a/broker/main.py
+++ b/broker/main.py
@@ -132,10 +132,10 @@ async def lifespan(app: FastAPI):
     await browser_fetcher.start()
     callback_sender = CallbackSender(sqs_client=sqs_client, queue_url=secrets.results_queue_url)
     # Per-ticket counter feeding the artifact_publish anti-fabrication gate.
-    # Process-local; broker restart mid-run rejects publish (strictly safer
-    # than accepting a synthetic artifact from an agent whose data calls
-    # all failed).
-    data_query_tracker = DataQueryTracker()
+    # DynamoDB-backed (stamped on the scope-ticket item) so the count is shared
+    # across all broker instances — a run's query and its publish can land on
+    # different tasks behind the ALB.
+    data_query_tracker = DataQueryTracker(table_name=_resolve_table_name())
     artifact_bucket = os.environ.get("ARTIFACT_BUCKET", "gp-agent-artifacts-dev")
     env = os.environ.get("ENVIRONMENT", "dev").strip().lower()
     experiment_metadata_bucket = os.environ.get(

--- a/broker/tests/test_artifact_publish.py
+++ b/broker/tests/test_artifact_publish.py
@@ -85,9 +85,25 @@ def _create_app(
     # Tracker default: simulate one successful Databricks query (count=1) so
     # the anti-fabrication gate doesn't trip on tickets whose scope has
     # allowed_tables. Override to 0 in tests that exercise the gate.
-    from broker.data_query_tracker import DataQueryTracker
+    # These tests verify the gate, not the tracker's storage — the real
+    # DynamoDB-backed tracker is covered in test_data_query_tracker.py — so use
+    # an in-memory double with the same increment/get/clear interface.
     from broker.endpoints.artifact_publish import get_data_query_tracker
-    tracker = DataQueryTracker()
+
+    class _FakeTracker:
+        def __init__(self) -> None:
+            self._counts: dict[str, int] = {}
+
+        def increment(self, pk: str) -> None:
+            self._counts[pk] = self._counts.get(pk, 0) + 1
+
+        def get(self, pk: str) -> int:
+            return self._counts.get(pk, 0)
+
+        def clear(self, pk: str) -> None:
+            self._counts.pop(pk, None)
+
+    tracker = _FakeTracker()
     for _ in range(tracker_count):
         tracker.increment(_ticket.pk)
     app.dependency_overrides[get_data_query_tracker] = lambda: tracker

--- a/broker/tests/test_data_query_tracker.py
+++ b/broker/tests/test_data_query_tracker.py
@@ -1,0 +1,90 @@
+import boto3
+import pytest
+from moto import mock_aws
+
+from broker.data_query_tracker import DataQueryTracker
+
+TABLE = "scope-tickets"
+
+
+@pytest.fixture
+def moto_ddb():
+    with mock_aws():
+        client = boto3.client("dynamodb", region_name="us-west-2")
+        client.create_table(
+            TableName=TABLE,
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield client
+
+
+class RecordingClient:
+    """Delegates to a real (moto) client but records get_item kwargs so the
+    test can assert the publish-time read is strongly consistent."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.get_item_calls = []
+
+    def update_item(self, **kwargs):
+        return self._inner.update_item(**kwargs)
+
+    def get_item(self, **kwargs):
+        self.get_item_calls.append(kwargs)
+        return self._inner.get_item(**kwargs)
+
+
+def test_increment_on_one_instance_is_visible_from_another(moto_ddb):
+    # Two trackers over the same table = two broker instances behind the ALB.
+    broker_a = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+    broker_b = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+
+    broker_a.increment("ticket-1")
+
+    # The query hit broker A; the publish lands on broker B. It MUST see it.
+    assert broker_b.get("ticket-1") == 1
+
+
+def test_increments_accumulate_across_instances(moto_ddb):
+    a = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+    b = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+
+    a.increment("ticket-2")
+    b.increment("ticket-2")
+    a.increment("ticket-2")
+
+    assert b.get("ticket-2") == 3
+
+
+def test_get_unknown_ticket_returns_zero(moto_ddb):
+    t = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+    assert t.get("never-seen") == 0
+
+
+def test_counts_are_isolated_per_ticket(moto_ddb):
+    t = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+    t.increment("ticket-a")
+    t.increment("ticket-a")
+    t.increment("ticket-b")
+
+    assert t.get("ticket-a") == 2
+    assert t.get("ticket-b") == 1
+
+
+def test_clear_resets_count(moto_ddb):
+    t = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+    t.increment("ticket-3")
+    t.clear("ticket-3")
+    assert t.get("ticket-3") == 0
+
+
+def test_get_uses_strongly_consistent_read(moto_ddb):
+    recorder = RecordingClient(moto_ddb)
+    t = DataQueryTracker(table_name=TABLE, dynamodb_client=recorder)
+    t.increment("ticket-4")
+    t.get("ticket-4")
+
+    assert recorder.get_item_calls, "expected a get_item call"
+    assert all(c.get("ConsistentRead") is True for c in recorder.get_item_calls)

--- a/broker/tests/test_databricks_query.py
+++ b/broker/tests/test_databricks_query.py
@@ -67,9 +67,8 @@ def _create_app(
         mock_db.execute.return_value = (columns, rows)
     app.dependency_overrides[get_databricks_client] = lambda: mock_db
 
-    from broker.data_query_tracker import DataQueryTracker
     from broker.endpoints.databricks_query import get_data_query_tracker
-    app.dependency_overrides[get_data_query_tracker] = lambda: DataQueryTracker()
+    app.dependency_overrides[get_data_query_tracker] = lambda: MagicMock()
 
     return app, mock_db
 
@@ -465,9 +464,8 @@ class TestEventLoopNotBlockedByDatabricks:
         mock_db = MagicMock(spec=DatabricksClient)
         mock_db.execute.side_effect = _slow_execute
         app.dependency_overrides[get_databricks_client] = lambda: mock_db
-        from broker.data_query_tracker import DataQueryTracker
         from broker.endpoints.databricks_query import get_data_query_tracker
-        app.dependency_overrides[get_data_query_tracker] = lambda: DataQueryTracker()
+        app.dependency_overrides[get_data_query_tracker] = lambda: MagicMock()
 
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:

--- a/broker/tests/test_run_status.py
+++ b/broker/tests/test_run_status.py
@@ -62,9 +62,8 @@ def _create_app(
     app.dependency_overrides[get_broker_token_raw] = lambda: BROKER_TOKEN
     app.dependency_overrides[get_artifact_bucket] = lambda: "gp-agent-artifacts-dev"
 
-    from broker.data_query_tracker import DataQueryTracker
     from broker.endpoints.run_status import get_data_query_tracker
-    app.dependency_overrides[get_data_query_tracker] = lambda: DataQueryTracker()
+    app.dependency_overrides[get_data_query_tracker] = lambda: MagicMock()
 
     return app, mock_s3, mock_sender, mock_store
 
@@ -342,9 +341,8 @@ class TestRunStatusClearsRunLock:
             app.dependency_overrides[get_ticket_store] = lambda: real_store
             app.dependency_overrides[get_broker_token_raw] = lambda: BROKER_TOKEN
             app.dependency_overrides[get_artifact_bucket] = lambda: "bucket"
-            from broker.data_query_tracker import DataQueryTracker
             from broker.endpoints.run_status import get_data_query_tracker
-            app.dependency_overrides[get_data_query_tracker] = lambda: DataQueryTracker()
+            app.dependency_overrides[get_data_query_tracker] = lambda: MagicMock()
 
             client = TestClient(app)
             resp = client.post(

--- a/infrastructure/modules/broker/main.tf
+++ b/infrastructure/modules/broker/main.tf
@@ -244,6 +244,7 @@ resource "aws_iam_role_policy" "task_dynamodb" {
         Action = [
           "dynamodb:GetItem",
           "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
           "dynamodb:DeleteItem",
           "dynamodb:Query"
         ]


### PR DESCRIPTION
## Problem
The anti-fabrication `DataQueryTracker` (artifact_publish's `NoDataQueriesSucceeded` gate) was **process-local in-memory** — correct only with a single broker task. After the broker scaled to multiple instances, a run's Databricks query (`increment`) and its artifact publish (read) land on **different tasks behind the ALB**, so the publish saw count 0 and rejected legitimately data-backed artifacts.

Observed in prod: a ~128-run batch had **meeting_briefing succeed at only ~16%** (≈ 1/5, matching the chance a publish co-locates with its query across 5 brokers), while web-only **meeting_schedule was unaffected** (no `allowed_tables`, so the gate never runs).

## Fix
Back the counter with **DynamoDB**, stamped on the run's existing scope-ticket item (same table + `pk`):
- `increment()` → atomic `UpdateExpression="ADD query_count :one"` (race-safe across instances).
- `get()` → `get_item` with **`ConsistentRead=True`** (publish sees increments from other instances).
- Rides the ticket TTL/delete — no separate lifecycle.

The broker stays **stateless and horizontally scalable**, and the anti-fabrication trust boundary is preserved (the broker still independently witnesses real `/databricks/query` calls; the agent can't forge them). Interface (`increment`/`get`/`clear`) is unchanged, so the call sites don't move.

## IAM (don't miss this)
`increment()` uses `dynamodb:UpdateItem`; the broker task role previously had only `Get/Put/Delete/Query`. Added `dynamodb:UpdateItem` to `modules/broker`. Without it, `increment` would `AccessDenied` in prod and **every** Databricks experiment would fail NoData. **Already applied to prod** via `terraform apply` (in-place IAM update); this commits the code to match.

## Tests
- New `test_data_query_tracker.py` (moto): cross-instance visibility (the bug), atomic accumulation, per-ticket isolation, clear, consistent-read assertion, unknown→0.
- Call-site tests (`artifact_publish`, `databricks_query`, `run_status`) updated to a fake/MagicMock tracker since the constructor now takes a table name. 86 passing.

## Deploy ordering
IAM grant must land **before** the new broker image (already applied to prod). Then the broker image rollout picks up the code.

## Related (separate)
- min5/max30 broker autoscaling (#109, merged) — what exposed this.
- `data_required_unless` carve-out for legitimate no-agenda placeholder runs (broker support already in develop; `fix/derive-scope-data-required-unless` carries it through pmf-engine dispatch) — complementary, not in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production behavior for artifact publish gating and adds a DynamoDB dependency; deploy order requires IAM UpdateItem before the new image.
> 
> **Overview**
> **Moves the per-run Databricks query counter from process-local memory to DynamoDB** on the existing scope-ticket row (`query_count` via atomic `ADD`, strongly consistent `get_item` for publish). That fixes the multi-instance broker bug where `/databricks/query` and `/artifact/publish` could hit different ALB tasks and the anti-fabrication gate saw count 0.
> 
> `main.py` now constructs `DataQueryTracker(table_name=_resolve_table_name())`. **Terraform** grants `dynamodb:UpdateItem` on the scope-tickets table (required for `increment`).
> 
> **Tests:** new `test_data_query_tracker.py` (moto) for cross-instance visibility and consistent reads; endpoint tests use an in-memory fake or `MagicMock` instead of the real tracker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65235e5d0552827f451877f9bafc42704598e746. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->