### PR TITLE
promoting

### DIFF
--- a/broker/data_query_tracker.py
+++ b/broker/data_query_tracker.py
@@ -1,35 +1,56 @@
-import threading
+import boto3
 
 
 class DataQueryTracker:
-    """Per-ticket counter of successful Databricks queries.
+    """Per-ticket counter of successful Databricks queries, backed by DynamoDB.
 
-    Process-local. Used by the artifact publish endpoint to gate experiments
-    whose manifest declares `scope.allowed_tables` — if the count is zero we
-    assume the agent fabricated its output (Databricks was unreachable, scope
-    rejected every query, etc.) and reject the publish.
+    The count is stamped onto the run's scope-ticket item (same table, same
+    `pk`), so every broker instance reads and writes the same value. This keeps
+    the broker stateless and horizontally scalable — the previous process-local
+    counter silently broke once the service ran more than one task, because a
+    run's Databricks query and its artifact publish land on different instances.
 
-    The gate keys off scope, NOT a hardcoded experiment list, so the broker
-    stays consumer-domain-agnostic. Any new experiment with allowed_tables
-    automatically gets the safety check; any new web-only experiment skips it.
+    Feeds the artifact_publish anti-fabrication gate: if a manifest declares
+    `scope.allowed_tables` but the count is zero, the agent's data calls all
+    failed (or it never queried), so the output is synthetic and the publish is
+    rejected. The gate keys off scope, not a hardcoded experiment list, so the
+    broker stays consumer-domain-agnostic.
 
-    Single broker task today means a broker restart during a run clears the
-    counter and the publish would be rejected — strictly safer than the
-    previous behavior of accepting any schema-valid artifact.
+    The counter rides the scope ticket's TTL, so it is cleaned up with the run.
     """
 
-    def __init__(self) -> None:
-        self._counts: dict[str, int] = {}
-        self._lock = threading.Lock()
+    def __init__(self, table_name: str, dynamodb_client=None) -> None:
+        self._table_name = table_name
+        self._client = dynamodb_client or boto3.client("dynamodb")
 
     def increment(self, ticket_pk: str) -> None:
-        with self._lock:
-            self._counts[ticket_pk] = self._counts.get(ticket_pk, 0) + 1
+        # Atomic server-side ADD: concurrent queries from the same run hitting
+        # different broker instances cannot lose updates (no read-modify-write).
+        self._client.update_item(
+            TableName=self._table_name,
+            Key={"pk": {"S": ticket_pk}},
+            UpdateExpression="ADD query_count :one",
+            ExpressionAttributeValues={":one": {"N": "1"}},
+        )
 
     def get(self, ticket_pk: str) -> int:
-        with self._lock:
-            return self._counts.get(ticket_pk, 0)
+        # Strongly consistent: the publish must observe increments that landed
+        # on another instance moments earlier, or the gate misfires and rejects
+        # a legitimately data-backed artifact.
+        response = self._client.get_item(
+            TableName=self._table_name,
+            Key={"pk": {"S": ticket_pk}},
+            ConsistentRead=True,
+        )
+        item = response.get("Item")
+        if not item or "query_count" not in item:
+            return 0
+        return int(item["query_count"]["N"])
 
     def clear(self, ticket_pk: str) -> None:
-        with self._lock:
-            self._counts.pop(ticket_pk, None)
+        # Best-effort hygiene; the ticket item is deleted at end of run anyway.
+        self._client.update_item(
+            TableName=self._table_name,
+            Key={"pk": {"S": ticket_pk}},
+            UpdateExpression="REMOVE query_count",
+        )

--- a/broker/main.py
+++ b/broker/main.py
@@ -132,10 +132,10 @@ async def lifespan(app: FastAPI):
     await browser_fetcher.start()
     callback_sender = CallbackSender(sqs_client=sqs_client, queue_url=secrets.results_queue_url)
     # Per-ticket counter feeding the artifact_publish anti-fabrication gate.
-    # Process-local; broker restart mid-run rejects publish (strictly safer
-    # than accepting a synthetic artifact from an agent whose data calls
-    # all failed).
-    data_query_tracker = DataQueryTracker()
+    # DynamoDB-backed (stamped on the scope-ticket item) so the count is shared
+    # across all broker instances — a run's query and its publish can land on
+    # different tasks behind the ALB.
+    data_query_tracker = DataQueryTracker(table_name=_resolve_table_name())
     artifact_bucket = os.environ.get("ARTIFACT_BUCKET", "gp-agent-artifacts-dev")
     env = os.environ.get("ENVIRONMENT", "dev").strip().lower()
     experiment_metadata_bucket = os.environ.get(

--- a/broker/tests/test_artifact_publish.py
+++ b/broker/tests/test_artifact_publish.py
@@ -85,9 +85,25 @@ def _create_app(
     # Tracker default: simulate one successful Databricks query (count=1) so
     # the anti-fabrication gate doesn't trip on tickets whose scope has
     # allowed_tables. Override to 0 in tests that exercise the gate.
-    from broker.data_query_tracker import DataQueryTracker
+    # These tests verify the gate, not the tracker's storage — the real
+    # DynamoDB-backed tracker is covered in test_data_query_tracker.py — so use
+    # an in-memory double with the same increment/get/clear interface.
     from broker.endpoints.artifact_publish import get_data_query_tracker
-    tracker = DataQueryTracker()
+
+    class _FakeTracker:
+        def __init__(self) -> None:
+            self._counts: dict[str, int] = {}
+
+        def increment(self, pk: str) -> None:
+            self._counts[pk] = self._counts.get(pk, 0) + 1
+
+        def get(self, pk: str) -> int:
+            return self._counts.get(pk, 0)
+
+        def clear(self, pk: str) -> None:
+            self._counts.pop(pk, None)
+
+    tracker = _FakeTracker()
     for _ in range(tracker_count):
         tracker.increment(_ticket.pk)
     app.dependency_overrides[get_data_query_tracker] = lambda: tracker

--- a/broker/tests/test_data_query_tracker.py
+++ b/broker/tests/test_data_query_tracker.py
@@ -1,0 +1,90 @@
+import boto3
+import pytest
+from moto import mock_aws
+
+from broker.data_query_tracker import DataQueryTracker
+
+TABLE = "scope-tickets"
+
+
+@pytest.fixture
+def moto_ddb():
+    with mock_aws():
+        client = boto3.client("dynamodb", region_name="us-west-2")
+        client.create_table(
+            TableName=TABLE,
+            AttributeDefinitions=[{"AttributeName": "pk", "AttributeType": "S"}],
+            KeySchema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield client
+
+
+class RecordingClient:
+    """Delegates to a real (moto) client but records get_item kwargs so the
+    test can assert the publish-time read is strongly consistent."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.get_item_calls = []
+
+    def update_item(self, **kwargs):
+        return self._inner.update_item(**kwargs)
+
+    def get_item(self, **kwargs):
+        self.get_item_calls.append(kwargs)
+        return self._inner.get_item(**kwargs)
+
+
+def test_increment_on_one_instance_is_visible_from_another(moto_ddb):
+    # Two trackers over the same table = two broker instances behind the ALB.
+    broker_a = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+    broker_b = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+
+    broker_a.increment("ticket-1")
+
+    # The query hit broker A; the publish lands on broker B. It MUST see it.
+    assert broker_b.get("ticket-1") == 1
+
+
+def test_increments_accumulate_across_instances(moto_ddb):
+    a = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+    b = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+
+    a.increment("ticket-2")
+    b.increment("ticket-2")
+    a.increment("ticket-2")
+
+    assert b.get("ticket-2") == 3
+
+
+def test_get_unknown_ticket_returns_zero(moto_ddb):
+    t = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+    assert t.get("never-seen") == 0
+
+
+def test_counts_are_isolated_per_ticket(moto_ddb):
+    t = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+    t.increment("ticket-a")
+    t.increment("ticket-a")
+    t.increment("ticket-b")
+
+    assert t.get("ticket-a") == 2
+    assert t.get("ticket-b") == 1
+
+
+def test_clear_resets_count(moto_ddb):
+    t = DataQueryTracker(table_name=TABLE, dynamodb_client=moto_ddb)
+    t.increment("ticket-3")
+    t.clear("ticket-3")
+    assert t.get("ticket-3") == 0
+
+
+def test_get_uses_strongly_consistent_read(moto_ddb):
+    recorder = RecordingClient(moto_ddb)
+    t = DataQueryTracker(table_name=TABLE, dynamodb_client=recorder)
+    t.increment("ticket-4")
+    t.get("ticket-4")
+
+    assert recorder.get_item_calls, "expected a get_item call"
+    assert all(c.get("ConsistentRead") is True for c in recorder.get_item_calls)

--- a/broker/tests/test_databricks_query.py
+++ b/broker/tests/test_databricks_query.py
@@ -67,9 +67,8 @@ def _create_app(
         mock_db.execute.return_value = (columns, rows)
     app.dependency_overrides[get_databricks_client] = lambda: mock_db
 
-    from broker.data_query_tracker import DataQueryTracker
     from broker.endpoints.databricks_query import get_data_query_tracker
-    app.dependency_overrides[get_data_query_tracker] = lambda: DataQueryTracker()
+    app.dependency_overrides[get_data_query_tracker] = lambda: MagicMock()
 
     return app, mock_db
 
@@ -465,9 +464,8 @@ class TestEventLoopNotBlockedByDatabricks:
         mock_db = MagicMock(spec=DatabricksClient)
         mock_db.execute.side_effect = _slow_execute
         app.dependency_overrides[get_databricks_client] = lambda: mock_db
-        from broker.data_query_tracker import DataQueryTracker
         from broker.endpoints.databricks_query import get_data_query_tracker
-        app.dependency_overrides[get_data_query_tracker] = lambda: DataQueryTracker()
+        app.dependency_overrides[get_data_query_tracker] = lambda: MagicMock()
 
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:

--- a/broker/tests/test_run_status.py
+++ b/broker/tests/test_run_status.py
@@ -62,9 +62,8 @@ def _create_app(
     app.dependency_overrides[get_broker_token_raw] = lambda: BROKER_TOKEN
     app.dependency_overrides[get_artifact_bucket] = lambda: "gp-agent-artifacts-dev"
 
-    from broker.data_query_tracker import DataQueryTracker
     from broker.endpoints.run_status import get_data_query_tracker
-    app.dependency_overrides[get_data_query_tracker] = lambda: DataQueryTracker()
+    app.dependency_overrides[get_data_query_tracker] = lambda: MagicMock()
 
     return app, mock_s3, mock_sender, mock_store
 
@@ -342,9 +341,8 @@ class TestRunStatusClearsRunLock:
             app.dependency_overrides[get_ticket_store] = lambda: real_store
             app.dependency_overrides[get_broker_token_raw] = lambda: BROKER_TOKEN
             app.dependency_overrides[get_artifact_bucket] = lambda: "bucket"
-            from broker.data_query_tracker import DataQueryTracker
             from broker.endpoints.run_status import get_data_query_tracker
-            app.dependency_overrides[get_data_query_tracker] = lambda: DataQueryTracker()
+            app.dependency_overrides[get_data_query_tracker] = lambda: MagicMock()
 
             client = TestClient(app)
             resp = client.post(

--- a/infrastructure/modules/broker/main.tf
+++ b/infrastructure/modules/broker/main.tf
@@ -244,6 +244,7 @@ resource "aws_iam_role_policy" "task_dynamodb" {
         Action = [
           "dynamodb:GetItem",
           "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
           "dynamodb:DeleteItem",
           "dynamodb:Query"
         ]

--- a/pmf_engine/control_plane/scope_derivation.py
+++ b/pmf_engine/control_plane/scope_derivation.py
@@ -18,7 +18,12 @@ def derive_scope(experiment_id: str, params: dict, manifest_scope: dict | None =
     """Build the broker scope ticket fields.
 
     `manifest_scope` is the `scope` block from the experiment manifest in S3.
-    When present, its `allowed_tables` and `max_rows` are passed through verbatim.
+    When present, its `allowed_tables`, `max_rows`, and `data_required_unless`
+    are passed through verbatim. `data_required_unless` MUST be carried through:
+    the broker's NoDataQueriesSucceeded publish guard reads it from the ticket
+    scope to exempt legitimate no-data placeholder runs (e.g. meeting_briefing's
+    `briefing_status=awaiting_agenda`). Dropping it here causes those runs to be
+    rejected at publish even though no Databricks query is appropriate.
 
     Permissive defaults are intentional: when `manifest_scope` is None or empty
     (e.g. web-research-only experiments with no Databricks access), we default
@@ -42,10 +47,13 @@ def derive_scope(experiment_id: str, params: dict, manifest_scope: dict | None =
     if district:
         _validate_scope_string("district", district)
 
-    return {
+    scope = {
         "state": state,
         "cities": [city] if city else [],
         "districts": [district] if district else [],
         "allowed_tables": config.get("allowed_tables", []),
         "max_rows": config.get("max_rows", 50000),
     }
+    if "data_required_unless" in config:
+        scope["data_required_unless"] = config["data_required_unless"]
+    return scope

--- a/pmf_engine/tests/test_scope_derivation.py
+++ b/pmf_engine/tests/test_scope_derivation.py
@@ -137,3 +137,31 @@ class TestInputValidation:
     def test_rejects_control_chars_or_excessive_length_district(self, bad_district):
         with pytest.raises(ValueError, match="district"):
             derive_scope("smoke_test", {"state": "NC", "district": bad_district})
+
+
+class TestDataRequiredUnlessPassthrough:
+    """Regression: the broker's NoDataQueriesSucceeded publish guard reads
+    `data_required_unless` from the ticket scope. derive_scope must carry it
+    through from the manifest, or legitimate no-data placeholder runs (e.g.
+    meeting_briefing's awaiting_agenda / no_meeting_found) get rejected at
+    publish even though no Databricks query is appropriate for that branch."""
+
+    def test_data_required_unless_is_carried_through(self):
+        manifest_scope = {
+            "allowed_tables": ["goodparty_data_catalog.dbt.int__l2_nationwide_uniform_w_haystaq"],
+            "max_rows": 50000,
+            "data_required_unless": {
+                "field": "briefing_status",
+                "values": ["awaiting_agenda", "no_meeting_found", "error"],
+            },
+        }
+        scope = derive_scope("meeting_briefing", {"state": "NC"}, manifest_scope=manifest_scope)
+
+        assert scope["data_required_unless"] == {
+            "field": "briefing_status",
+            "values": ["awaiting_agenda", "no_meeting_found", "error"],
+        }
+
+    def test_data_required_unless_absent_when_manifest_omits_it(self):
+        scope = derive_scope("web_only_experiment", {"state": "NC"}, manifest_scope={"max_rows": 50000})
+        assert scope.get("data_required_unless") is None


### PR DESCRIPTION
promoting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes publish-time safety logic and DynamoDB writes on the scope-tickets table; misconfiguration or consistency bugs could wrongly allow synthetic artifacts or reject valid publishes.
> 
> **Overview**
> **Moves the Databricks success counter off in-memory state onto the scope-ticket row in DynamoDB**, so artifact publish’s anti-fabrication gate stays correct when queries and publish hit different broker tasks behind the ALB. Increments use atomic `ADD query_count`; reads use strongly consistent `get_item`.
> 
> **Control plane:** `derive_scope` now forwards manifest `data_required_unless` into ticket scope so legitimate no-data publishes (e.g. `meeting_briefing` placeholders) are not blocked when query count is zero.
> 
> **Ops/tests:** Broker task IAM gains `dynamodb:UpdateItem`; new moto tests cover cross-instance visibility; endpoint tests use fakes/mocks instead of the real tracker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdab40548f4e09a7ecfd23856c063175964fc8d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->