### PR TITLE
Include polling instructions for fan out process.

### DIFF
--- a/pmf_engine/runner/harness/claude_sdk.py
+++ b/pmf_engine/runner/harness/claude_sdk.py
@@ -257,7 +257,16 @@ def _fanout_prompt_section(cap: int) -> str:
         "WebSearch, same permissions) and returns structured findings. Only dispatch "
         "for genuinely independent work — sequential or dependent steps stay on the "
         "main agent. You remain responsible for assembling all findings into the "
-        "single output artifact; subagents never write the artifact themselves."
+        "single output artifact; subagents never write the artifact themselves.\n\n"
+        "WAITING FOR SUBAGENTS — do NOT sleep. Collect each subagent's findings as "
+        "the dispatch tool returns them. Never run a `Bash sleep`, idle a turn, or "
+        "otherwise block to 'wait for them to finish', and never wait on a completion "
+        "signal unbounded: a subagent that finishes in the gap before you start "
+        "waiting can be missed, hanging the whole run until its turn budget is spent. "
+        "If you genuinely must wait, poll every ~5 seconds for completed work (e.g. "
+        "list the result files the subagents write) until all expected items are "
+        "present, and bound any single wait to ~30 seconds (signal-or-30s, whichever "
+        "is first) then re-check — never an unbounded wait."
     )
 
 


### PR DESCRIPTION
Trying to prevent flaky behavior Collin observed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only extends agent system-prompt text for parallel subagent runs; no execution, auth, or broker logic changes.
> 
> **Overview**
> Adds **WAITING FOR SUBAGENTS** guidance to the parallel-research section of the Claude SDK harness system prompt (`_fanout_prompt_section` in `claude_sdk.py`).
> 
> When fan-out is enabled, the parent agent is now told not to use `Bash sleep` or idle turns, to collect findings as dispatch returns, and to avoid unbounded completion waits (which can miss early-finishing subagents and burn the turn budget). If it must wait, it should poll about every 5 seconds (e.g. list subagent result files) and cap any single wait at ~30 seconds before re-checking.
> 
> This is **prompt-only**; no harness or SDK behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d10bf730fb637f4610949b01271528301300cb3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->