### PR TITLE
feat(broker,pmf): route Braintrust through broker — egress, artifact-in-trace, per-env projects

### DIFF
--- a/broker/RUNBOOK.md
+++ b/broker/RUNBOOK.md
@@ -72,7 +72,9 @@ New agent tasks automatically pull the latest image with the same tag. No ECS se
 
 After Terraform creates `broker-{env}` and `broker-service-tokens-{env}` they are empty (both use `ignore_changes = [secret_string]`). Populate them before the broker can do work.
 
-Prerequisites: `AI_SECRETS_{ENV_UPPER}` already holds `PMF_ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `TAVILY_API_KEY`, `DATABRICKS_SERVER_HOSTNAME`, `DATABRICKS_HTTP_PATH`, `DATABRICKS_API_KEY`.
+Prerequisites: `AI_SECRETS_{ENV_UPPER}` already holds `PMF_ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `TAVILY_API_KEY`, `BRAINTRUST_API_KEY`, `DATABRICKS_SERVER_HOSTNAME`, `DATABRICKS_HTTP_PATH`, `DATABRICKS_API_KEY`.
+
+> **WARNING:** `BRAINTRUST_API_KEY` MUST be present in the `broker-{env}` secret BEFORE running `terraform apply` on the broker module. The ECS task definition injects it via a Secrets Manager `valueFrom` entry, and ECS fails the entire task at launch with `ResourceInitializationError` if the JSON key is absent — the broker will not start in any env whose secret lacks the key. Dev was already backfilled; qa and prod MUST be backfilled before promoting.
 
 **Ordering matters.** Put the new hash into the broker secret *first*, redeploy broker to pick it up, *then* put the new plaintext into the service-tokens secret, *then* bounce the dispatch Lambda. Reversing the order leaves a window where the Lambda presents the new token to a broker still holding the old hash → `BrokerServiceTokenAuthFailure` alarm fires.
 
@@ -93,11 +95,12 @@ aws secretsmanager put-secret-value \
     --arg a "$(jq -r .PMF_ANTHROPIC_API_KEY   <<<"$AI")" \
     --arg g "$(jq -r .GEMINI_API_KEY          <<<"$AI")" \
     --arg t "$(jq -r .TAVILY_API_KEY          <<<"$AI")" \
+    --arg bt "$(jq -r .BRAINTRUST_API_KEY     <<<"$AI")" \
     --arg h "$(jq -r .DATABRICKS_SERVER_HOSTNAME <<<"$AI")" \
     --arg p "$(jq -r .DATABRICKS_HTTP_PATH    <<<"$AI")" \
     --arg k "$(jq -r .DATABRICKS_API_KEY      <<<"$AI")" \
     --arg s "$HASH" \
-    '{ANTHROPIC_API_KEY:$a, GEMINI_API_KEY:$g, TAVILY_API_KEY:$t, DATABRICKS_SERVER_HOSTNAME:$h, DATABRICKS_HTTP_PATH:$p, DATABRICKS_API_KEY:$k, SERVICE_TOKEN_HASH:$s}')"
+    '{ANTHROPIC_API_KEY:$a, GEMINI_API_KEY:$g, TAVILY_API_KEY:$t, BRAINTRUST_API_KEY:$bt, DATABRICKS_SERVER_HOSTNAME:$h, DATABRICKS_HTTP_PATH:$p, DATABRICKS_API_KEY:$k, SERVICE_TOKEN_HASH:$s}')"
 
 # 2. Force-redeploy broker so it reads the new hash. Wait stable.
 aws ecs update-service \
@@ -150,6 +153,7 @@ aws secretsmanager put-secret-value \
     --arg anthropic "NEW_KEY" \
     --arg gemini "NEW_KEY" \
     --arg tavily "NEW_KEY" \
+    --arg braintrust "NEW_KEY" \
     --arg db_host "HOSTNAME" \
     --arg db_path "HTTP_PATH" \
     --arg db_key "NEW_KEY" \
@@ -158,6 +162,7 @@ aws secretsmanager put-secret-value \
       ANTHROPIC_API_KEY: $anthropic,
       GEMINI_API_KEY: $gemini,
       TAVILY_API_KEY: $tavily,
+      BRAINTRUST_API_KEY: $braintrust,
       DATABRICKS_SERVER_HOSTNAME: $db_host,
       DATABRICKS_HTTP_PATH: $db_path,
       DATABRICKS_API_KEY: $db_key,

--- a/broker/endpoints/braintrust_proxy.py
+++ b/broker/endpoints/braintrust_proxy.py
@@ -1,0 +1,113 @@
+import logging
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import Response
+
+from broker.auth import AuthError, BrokerTokenAuth
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/braintrust", tags=["braintrust"])
+
+# The Braintrust SDK splits across two hosts: the control plane (app) handles
+# login + metadata, the data plane (api) receives /logs3 trace ingest. The
+# runner sets BRAINTRUST_APP_URL=${broker}/braintrust/app and
+# BRAINTRUST_API_URL=${broker}/braintrust/api so both legs route through here.
+_UPSTREAM_HOSTS = {
+    "app": "https://www.braintrust.dev",
+    "api": "https://api.braintrust.dev",
+}
+
+# Hop-by-hop and host-scoped headers that must not be forwarded verbatim — the
+# upstream host/length/auth are all set by the proxy, not the client.
+_STRIP_REQUEST_HEADERS = {"host", "authorization", "content-length", "connection"}
+
+
+def get_broker_auth() -> BrokerTokenAuth:
+    raise NotImplementedError("must be overridden via dependency_overrides")  # pragma: no cover
+
+
+def get_upstream_client() -> httpx.AsyncClient:
+    raise NotImplementedError("must be overridden via dependency_overrides")  # pragma: no cover
+
+
+def get_braintrust_api_key() -> str:
+    raise NotImplementedError("must be overridden via dependency_overrides")  # pragma: no cover
+
+
+@router.api_route(
+    "/{leg}/{path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+)
+async def proxy_braintrust(
+    leg: str,
+    path: str,
+    request: Request,
+    broker_auth: BrokerTokenAuth = Depends(get_broker_auth),
+    upstream_client: httpx.AsyncClient = Depends(get_upstream_client),
+    api_key: str = Depends(get_braintrust_api_key),
+):
+    upstream_base = _UPSTREAM_HOSTS.get(leg)
+    if upstream_base is None:
+        raise HTTPException(status_code=404, detail="unknown_braintrust_leg")
+
+    # The Braintrust SDK authenticates with `Authorization: Bearer <key>`. In
+    # the PMF runner that key is the per-run broker token, so we verify it here
+    # and swap in the real Braintrust key before forwarding — the runner never
+    # holds the real credential.
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+    broker_token = auth_header[len("Bearer ") :]
+
+    try:
+        ticket = broker_auth.verify(broker_token)
+    except AuthError as exc:
+        logger.warning(
+            "braintrust auth failure reason_code=%s token_prefix=%s",
+            exc.reason_code,
+            broker_token[:8] if broker_token else "empty",
+        )
+        raise HTTPException(status_code=401, detail="Invalid or expired broker token")
+
+    if not api_key:
+        # Fail closed when the broker has no Braintrust key configured. The SDK
+        # treats a failed login/ingest as non-fatal (logging just disables), so
+        # the agent run continues — we just don't capture traces.
+        logger.warning("braintrust proxy hit but BRAINTRUST_API_KEY not configured; refusing")
+        raise HTTPException(status_code=503, detail="braintrust_not_configured")
+
+    body = await request.body()
+    headers = {k: v for k, v in request.headers.items() if k.lower() not in _STRIP_REQUEST_HEADERS}
+    headers["authorization"] = f"Bearer {api_key}"
+
+    upstream_request = upstream_client.build_request(
+        request.method,
+        f"{upstream_base}/{path}",
+        headers=headers,
+        params=request.query_params,
+        content=body,
+    )
+
+    try:
+        upstream_response = await upstream_client.send(upstream_request)
+        response_body = await upstream_response.aread()
+    except httpx.HTTPError as e:
+        logger.warning(
+            "braintrust upstream error run_id=%s leg=%s path=%s exc_type=%s",
+            ticket.run_id,
+            leg,
+            path,
+            type(e).__name__,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=f"braintrust upstream failed: {type(e).__name__}",
+        )
+
+    return Response(
+        content=response_body,
+        status_code=upstream_response.status_code,
+        media_type=upstream_response.headers.get("content-type"),
+    )

--- a/broker/endpoints/braintrust_proxy.py
+++ b/broker/endpoints/braintrust_proxy.py
@@ -21,7 +21,11 @@ _UPSTREAM_HOSTS = {
 
 # Hop-by-hop and host-scoped headers that must not be forwarded verbatim — the
 # upstream host/length/auth are all set by the proxy, not the client.
-_STRIP_REQUEST_HEADERS = {"host", "authorization", "content-length", "connection"}
+# transfer-encoding is stripped because we read the full body and forward it as
+# bytes; httpx then sets content-length, and a request carrying both
+# transfer-encoding and content-length is a framing contradiction (RFC 7230
+# §3.3.3) that upstreams reject with 400.
+_STRIP_REQUEST_HEADERS = {"host", "authorization", "content-length", "connection", "transfer-encoding"}
 
 
 def get_broker_auth() -> BrokerTokenAuth:

--- a/broker/endpoints/braintrust_proxy.py
+++ b/broker/endpoints/braintrust_proxy.py
@@ -75,7 +75,11 @@ async def proxy_braintrust(
         # Fail closed when the broker has no Braintrust key configured. The SDK
         # treats a failed login/ingest as non-fatal (logging just disables), so
         # the agent run continues — we just don't capture traces.
-        logger.warning("braintrust proxy hit but BRAINTRUST_API_KEY not configured; refusing")
+        logger.warning(
+            "braintrust proxy hit but BRAINTRUST_API_KEY not configured; refusing run_id=%s leg=%s",
+            ticket.run_id,
+            leg,
+        )
         raise HTTPException(status_code=503, detail="braintrust_not_configured")
 
     body = await request.body()
@@ -100,6 +104,7 @@ async def proxy_braintrust(
             leg,
             path,
             type(e).__name__,
+            exc_info=True,
         )
         raise HTTPException(
             status_code=502,

--- a/broker/main.py
+++ b/broker/main.py
@@ -131,10 +131,15 @@ async def lifespan(app: FastAPI):
     upstream_client = httpx.AsyncClient(base_url="https://api.anthropic.com", timeout=300)
     s3_client = boto3.client("s3")
     sqs_client = boto3.client("sqs")
-    # Shared async client used by anthropic_proxy and agent_mcp_proxy. The
-    # unified /http/fetch endpoint routes through PlaywrightBrowserFetcher
-    # below — plain httpx is 403'd by Cloudflare's JS challenge on muni sites.
+    # Shared async client used by agent_mcp_proxy and the /http/fetch endpoint's
+    # non-browser paths. 30s suits short gp-api/MCP calls; the /http/fetch
+    # endpoint routes through PlaywrightBrowserFetcher below — plain httpx is
+    # 403'd by Cloudflare's JS challenge on muni sites.
     http_client = httpx.AsyncClient(timeout=30)
+    # Dedicated client for the Braintrust proxy. A 30s cap is too tight for the
+    # end-of-run /logs3 trace flush (batched spans); a timeout there 502s and
+    # silently loses telemetry with no retry. 300s matches the anthropic client.
+    braintrust_client = httpx.AsyncClient(timeout=300)
     browser_fetcher = PlaywrightBrowserFetcher()
     await browser_fetcher.start()
     callback_sender = CallbackSender(sqs_client=sqs_client, queue_url=secrets.results_queue_url)
@@ -171,7 +176,7 @@ async def lifespan(app: FastAPI):
     app.dependency_overrides[get_anthropic_api_key] = lambda: secrets.anthropic_api_key
 
     app.dependency_overrides[braintrust_get_broker_auth] = lambda: broker_auth
-    app.dependency_overrides[braintrust_get_upstream_client] = lambda: http_client
+    app.dependency_overrides[braintrust_get_upstream_client] = lambda: braintrust_client
     app.dependency_overrides[get_braintrust_api_key] = lambda: secrets.braintrust_api_key
 
     app.dependency_overrides[publish_get_scope_ticket] = _resolve_ticket_from_request
@@ -232,6 +237,7 @@ async def lifespan(app: FastAPI):
     finally:
         await upstream_client.aclose()
         await http_client.aclose()
+        await braintrust_client.aclose()
         await browser_fetcher.aclose()
 
 

--- a/broker/main.py
+++ b/broker/main.py
@@ -24,6 +24,12 @@ from broker.endpoints.anthropic_proxy import (
     get_upstream_client,
     router as anthropic_router,
 )
+from broker.endpoints.braintrust_proxy import (
+    get_braintrust_api_key,
+    get_broker_auth as braintrust_get_broker_auth,
+    get_upstream_client as braintrust_get_upstream_client,
+    router as braintrust_router,
+)
 from broker.endpoints.artifact_publish import (
     get_artifact_bucket as publish_get_artifact_bucket,
     get_broker_token_raw as publish_get_broker_token_raw,
@@ -164,6 +170,10 @@ async def lifespan(app: FastAPI):
     app.dependency_overrides[get_upstream_client] = lambda: upstream_client
     app.dependency_overrides[get_anthropic_api_key] = lambda: secrets.anthropic_api_key
 
+    app.dependency_overrides[braintrust_get_broker_auth] = lambda: broker_auth
+    app.dependency_overrides[braintrust_get_upstream_client] = lambda: http_client
+    app.dependency_overrides[get_braintrust_api_key] = lambda: secrets.braintrust_api_key
+
     app.dependency_overrides[publish_get_scope_ticket] = _resolve_ticket_from_request
     app.dependency_overrides[publish_get_s3_client] = lambda: s3_client
     app.dependency_overrides[publish_get_callback_sender] = lambda: callback_sender
@@ -239,6 +249,7 @@ async def auth_error_handler(request: Request, exc: AuthError):
 app.include_router(mint_router)
 app.include_router(delete_router)
 app.include_router(anthropic_router)
+app.include_router(braintrust_router)
 app.include_router(publish_router)
 app.include_router(read_router)
 app.include_router(status_router)

--- a/broker/secrets.py
+++ b/broker/secrets.py
@@ -21,6 +21,7 @@ _OPTIONAL_FIELDS = {
     "DATABRICKS_HTTP_PATH": "databricks_http_path",
     "DATABRICKS_API_KEY": "databricks_api_key",
     "RESULTS_QUEUE_URL": "results_queue_url",
+    "BRAINTRUST_API_KEY": "braintrust_api_key",
 }
 
 _FIELD_MAP = {**_REQUIRED_FIELDS, **_OPTIONAL_FIELDS}
@@ -40,6 +41,7 @@ class BrokerSecrets:
     databricks_http_path: str = ""
     databricks_api_key: str = ""
     results_queue_url: str = ""
+    braintrust_api_key: str = ""
 
 
 def _parse_secrets(raw: dict[str, str]) -> BrokerSecrets:

--- a/broker/tests/test_braintrust_proxy.py
+++ b/broker/tests/test_braintrust_proxy.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from unittest.mock import MagicMock
 
@@ -18,7 +19,7 @@ FAKE_BT_KEY = "sk-bt-real-braintrust-key"
 VALID_BROKER_TOKEN = "valid-broker-token-abc"
 
 
-def _make_ticket(expired: bool = False) -> ScopeTicket:
+def _make_ticket() -> ScopeTicket:
     now = int(time.time())
     return ScopeTicket(
         pk=VALID_BROKER_TOKEN,
@@ -27,7 +28,7 @@ def _make_ticket(expired: bool = False) -> ScopeTicket:
         experiment_id="voter_targeting",
         scope={"databricks": ["SELECT"]},
         params={"state": "CA"},
-        exp=now + (-3600 if expired else 3600),
+        exp=now + 3600,
         issued_at=now,
         issued_by="dispatch_lambda",
     )
@@ -172,3 +173,54 @@ class TestBraintrustProxyAuth:
 
         assert resp.status_code == 503
         assert calls == []
+
+    def test_unconfigured_key_warning_includes_run_id_correlation(self, caplog):
+        app = _create_test_app(api_key="")
+        client = TestClient(app)
+
+        with caplog.at_level(logging.WARNING, logger="broker.endpoints.braintrust_proxy"):
+            resp = client.post(
+                "/braintrust/api/logs3",
+                content=b"{}",
+                headers={"authorization": f"Bearer {VALID_BROKER_TOKEN}"},
+            )
+
+        assert resp.status_code == 503
+        warnings = [r for r in caplog.records if "not configured" in r.getMessage()]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "run-001" in message
+        assert "leg=api" in message
+
+
+class TestBraintrustProxyRouting:
+    def test_unknown_leg_returns_404_and_skips_upstream(self):
+        calls: list[httpx.Request] = []
+        app = _create_test_app(calls=calls)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/braintrust/bogus/x",
+            content=b"{}",
+            headers={"authorization": f"Bearer {VALID_BROKER_TOKEN}"},
+        )
+
+        assert resp.status_code == 404
+        assert calls == []
+
+
+class TestBraintrustProxyUpstreamErrors:
+    def test_upstream_error_returns_502(self):
+        def failing_handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("boom")
+
+        app = _create_test_app(upstream_transport=httpx.MockTransport(failing_handler))
+        client = TestClient(app)
+
+        resp = client.post(
+            "/braintrust/api/logs3",
+            content=b"{}",
+            headers={"authorization": f"Bearer {VALID_BROKER_TOKEN}"},
+        )
+
+        assert resp.status_code == 502

--- a/broker/tests/test_braintrust_proxy.py
+++ b/broker/tests/test_braintrust_proxy.py
@@ -132,6 +132,30 @@ class TestBraintrustProxyForwarding:
         assert calls[0].url.host == "www.braintrust.dev"
         assert calls[0].url.path == "/api/project"
 
+    def test_strips_transfer_encoding_so_no_framing_contradiction(self):
+        # We read the body and forward it as bytes, so httpx sets content-length.
+        # A forwarded request carrying both transfer-encoding and content-length
+        # is an RFC 7230 framing contradiction upstreams reject — so the proxy
+        # must drop a client-supplied transfer-encoding.
+        calls: list[httpx.Request] = []
+        app = _create_test_app(calls=calls)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/braintrust/api/logs3",
+            content=b'{"rows":[]}',
+            headers={
+                "authorization": f"Bearer {VALID_BROKER_TOKEN}",
+                "transfer-encoding": "chunked",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert len(calls) == 1
+        fwd = {k.lower() for k in calls[0].headers.keys()}
+        assert "transfer-encoding" not in fwd
+        assert "content-length" in fwd
+
 
 class TestBraintrustProxyAuth:
     def test_invalid_broker_token_returns_401_and_skips_upstream(self):

--- a/broker/tests/test_braintrust_proxy.py
+++ b/broker/tests/test_braintrust_proxy.py
@@ -1,0 +1,174 @@
+import time
+from unittest.mock import MagicMock
+
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from broker.auth import BrokerTokenAuth
+from broker.dynamodb_client import ScopeTicket, ScopeTicketStore
+from broker.endpoints.braintrust_proxy import (
+    get_braintrust_api_key,
+    get_broker_auth,
+    get_upstream_client,
+    router,
+)
+
+FAKE_BT_KEY = "sk-bt-real-braintrust-key"
+VALID_BROKER_TOKEN = "valid-broker-token-abc"
+
+
+def _make_ticket(expired: bool = False) -> ScopeTicket:
+    now = int(time.time())
+    return ScopeTicket(
+        pk=VALID_BROKER_TOKEN,
+        run_id="run-001",
+        organization_slug="org-42",
+        experiment_id="voter_targeting",
+        scope={"databricks": ["SELECT"]},
+        params={"state": "CA"},
+        exp=now + (-3600 if expired else 3600),
+        issued_at=now,
+        issued_by="dispatch_lambda",
+    )
+
+
+def _recording_handler(calls: list[httpx.Request]):
+    """Upstream handler that records every request it receives and asserts the
+    real Braintrust key was swapped in. Routes by host: api.braintrust.dev is
+    the data plane (/logs3 ingest), www.braintrust.dev is the control plane
+    (login/metadata)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        assert request.headers["authorization"] == f"Bearer {FAKE_BT_KEY}"
+        if request.url.host == "api.braintrust.dev":
+            return httpx.Response(200, json={"ok": True})
+        if request.url.host == "www.braintrust.dev":
+            return httpx.Response(
+                200,
+                json={"org_info": [{"id": "o1", "name": "gp", "api_url": "https://api.braintrust.dev"}]},
+            )
+        return httpx.Response(404)
+
+    return handler
+
+
+def _create_test_app(
+    broker_auth: BrokerTokenAuth | None = None,
+    upstream_transport: httpx.MockTransport | None = None,
+    api_key: str = FAKE_BT_KEY,
+    calls: list[httpx.Request] | None = None,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+
+    if broker_auth is None:
+        store = MagicMock(spec=ScopeTicketStore)
+        store.get_ticket.return_value = _make_ticket()
+        broker_auth = BrokerTokenAuth(store=store)
+
+    transport = upstream_transport or httpx.MockTransport(_recording_handler(calls if calls is not None else []))
+    # No base_url: the proxy builds absolute URLs to two fixed Braintrust hosts.
+    upstream_client = httpx.AsyncClient(transport=transport)
+
+    app.dependency_overrides[get_broker_auth] = lambda: broker_auth
+    app.dependency_overrides[get_upstream_client] = lambda: upstream_client
+    app.dependency_overrides[get_braintrust_api_key] = lambda: api_key
+
+    return app
+
+
+class TestBraintrustProxyForwarding:
+    def test_forwards_logs_ingest_to_data_plane_with_swapped_auth(self):
+        calls: list[httpx.Request] = []
+        app = _create_test_app(calls=calls)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/braintrust/api/logs3",
+            content=b'{"rows":[{"span":"x"}]}',
+            headers={"authorization": f"Bearer {VALID_BROKER_TOKEN}", "content-type": "application/json"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        assert len(calls) == 1
+        assert calls[0].url.host == "api.braintrust.dev"
+        assert calls[0].url.path == "/logs3"
+        assert calls[0].content == b'{"rows":[{"span":"x"}]}'
+
+    def test_forwards_login_to_control_plane(self):
+        calls: list[httpx.Request] = []
+        app = _create_test_app(calls=calls)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/braintrust/app/api/apikey/login",
+            content=b"{}",
+            headers={"authorization": f"Bearer {VALID_BROKER_TOKEN}"},
+        )
+
+        assert resp.status_code == 200
+        assert "org_info" in resp.json()
+        assert len(calls) == 1
+        assert calls[0].url.host == "www.braintrust.dev"
+        assert calls[0].url.path == "/api/apikey/login"
+
+    def test_forwards_get_request(self):
+        calls: list[httpx.Request] = []
+        app = _create_test_app(calls=calls)
+        client = TestClient(app)
+
+        resp = client.get(
+            "/braintrust/app/api/project",
+            headers={"authorization": f"Bearer {VALID_BROKER_TOKEN}"},
+        )
+
+        assert resp.status_code == 200
+        assert len(calls) == 1
+        assert calls[0].method == "GET"
+        assert calls[0].url.host == "www.braintrust.dev"
+        assert calls[0].url.path == "/api/project"
+
+
+class TestBraintrustProxyAuth:
+    def test_invalid_broker_token_returns_401_and_skips_upstream(self):
+        store = MagicMock(spec=ScopeTicketStore)
+        store.get_ticket.return_value = None
+        calls: list[httpx.Request] = []
+        app = _create_test_app(broker_auth=BrokerTokenAuth(store=store), calls=calls)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/braintrust/api/logs3",
+            content=b"{}",
+            headers={"authorization": "Bearer bogus-token"},
+        )
+
+        assert resp.status_code == 401
+        assert calls == []
+
+    def test_missing_authorization_returns_401(self):
+        calls: list[httpx.Request] = []
+        app = _create_test_app(calls=calls)
+        client = TestClient(app)
+
+        resp = client.post("/braintrust/api/logs3", content=b"{}")
+
+        assert resp.status_code == 401
+        assert calls == []
+
+    def test_unconfigured_braintrust_key_returns_503_and_skips_upstream(self):
+        calls: list[httpx.Request] = []
+        app = _create_test_app(api_key="", calls=calls)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/braintrust/api/logs3",
+            content=b"{}",
+            headers={"authorization": f"Bearer {VALID_BROKER_TOKEN}"},
+        )
+
+        assert resp.status_code == 503
+        assert calls == []

--- a/broker/tests/test_braintrust_proxy_contract.py
+++ b/broker/tests/test_braintrust_proxy_contract.py
@@ -1,0 +1,278 @@
+"""Real-SDK contract test for the Braintrust broker proxy.
+
+Integration-test finding 8: prove the *actual* installed Braintrust SDK
+(`braintrust` 0.17.0) routes login + log ingest through our broker proxy
+correctly, exercising the SDK's genuine URL resolution, path-join, header/auth
+behavior, and control-plane vs data-plane connection selection.
+
+The existing `test_braintrust_proxy.py` drives the proxy with a hand-authored
+HTTP client and asserts against an assumed SDK contract. That can silently
+drift from the real SDK (e.g. if a future SDK version changes the login path,
+the env-var override names, or how it splits app/api hosts). This test closes
+that gap by driving the genuine `braintrust.init_logger(...)` -> span.log ->
+flush path and asserting the proxy saw exactly the requests the real SDK emits.
+
+Hermetic design (must NOT touch real braintrust.dev):
+
+  real braintrust SDK (sync `requests`)
+        |  set_http_adapter(_ASGIRequestsAdapter)
+        v
+  _ASGIRequestsAdapter.send()         # translates requests.PreparedRequest
+        |  httpx.ASGITransport          into an in-process ASGI call
+        v
+  FastAPI app mounting braintrust_router
+        |  get_upstream_client override
+        v
+  httpx.AsyncClient(MockTransport(_fake_braintrust))   # fakes braintrust.dev
+
+The SDK uses the synchronous `requests` library, so we cannot hand it an httpx
+client directly. Instead we inject a `requests.adapters.HTTPAdapter` subclass
+via the SDK's public `braintrust.set_http_adapter(...)` hook. That adapter
+bridges every `requests` call the SDK makes into the in-process broker ASGI app
+through `httpx.ASGITransport` (the sync analogue of the `_SyncASGIBridge`
+pattern in `test_http_head_contract.py`, adapted to the `requests` interface
+the SDK's `HTTPConnection` actually calls).
+
+Env wiring (the runner's real production config):
+  BRAINTRUST_APP_URL = http://broker/braintrust/app  -> proxy leg "app"
+  BRAINTRUST_API_URL = http://broker/braintrust/api  -> proxy leg "api"
+  BRAINTRUST_API_KEY = <per-run broker token>        -> proxy verifies + swaps
+  BRAINTRUST_ORG_NAME = test-org                      -> org selected from login
+
+The repo's autouse conftest sets BRAINTRUST_API_KEY="" to disable telemetry;
+per the repo convention we override it inside this test only (monkeypatch) and
+reset both the SDK global state and `shared.braintrust.BraintrustClient`.
+"""
+
+import asyncio
+import time
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import requests
+from fastapi import FastAPI
+
+from broker.auth import BrokerTokenAuth
+from broker.dynamodb_client import ScopeTicket, ScopeTicketStore
+from broker.endpoints.braintrust_proxy import (
+    get_braintrust_api_key,
+    get_broker_auth,
+    get_upstream_client,
+    router,
+)
+
+# The fake "real" upstream Braintrust key the proxy swaps in. The SDK never
+# sees this — it only ever holds VALID_BROKER_TOKEN. If the proxy forwarded the
+# client's token instead of swapping, the assertions below would fail.
+REAL_UPSTREAM_KEY = "sk-bt-REAL-upstream-key"
+VALID_BROKER_TOKEN = "valid-broker-token-abc"
+
+
+def _make_ticket() -> ScopeTicket:
+    now = int(time.time())
+    return ScopeTicket(
+        pk=VALID_BROKER_TOKEN,
+        run_id="run-bt-contract-001",
+        organization_slug="org-42",
+        experiment_id="voter_targeting",
+        scope={"databricks": ["SELECT"]},
+        params={"state": "CA"},
+        exp=now + 3600,
+        issued_at=now,
+        issued_by="dispatch_lambda",
+    )
+
+
+class _RecordedRequest:
+    __slots__ = ("method", "host", "path", "authorization")
+
+    def __init__(self, request: httpx.Request):
+        self.method = request.method
+        self.host = request.url.host
+        self.path = request.url.path
+        self.authorization = request.headers.get("authorization")
+
+
+def _fake_braintrust(calls: list[_RecordedRequest]):
+    """MockTransport handler standing in for the real braintrust.dev hosts.
+
+    Records (method, host, path, authorization) for every forwarded request and
+    returns the minimal responses the SDK needs to complete a login + project
+    register + logs3 ingest round trip.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(_RecordedRequest(request))
+        path = request.url.path
+
+        if request.method == "POST" and path == "/api/apikey/login":
+            return httpx.Response(
+                200,
+                json={
+                    "org_info": [
+                        {
+                            "id": "o1",
+                            "name": "test-org",
+                            "api_url": "https://api.braintrust.dev",
+                            "proxy_url": "https://api.braintrust.dev",
+                        }
+                    ]
+                },
+            )
+        if request.method == "POST" and path == "/api/project/register":
+            return httpx.Response(
+                200,
+                json={"project": {"id": "p1", "name": "pmf-engine-test"}},
+            )
+        if request.method == "POST" and path == "/logs3":
+            return httpx.Response(200, json={})
+        # ping / anything else the SDK may probe
+        return httpx.Response(200, json={})
+
+    return handler
+
+
+def _build_broker_app(calls: list[_RecordedRequest]) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+
+    store = MagicMock(spec=ScopeTicketStore)
+
+    def _get_ticket(token: str):
+        return _make_ticket() if token == VALID_BROKER_TOKEN else None
+
+    store.get_ticket.side_effect = _get_ticket
+    broker_auth = BrokerTokenAuth(store=store)
+
+    upstream_client = httpx.AsyncClient(transport=httpx.MockTransport(_fake_braintrust(calls)))
+
+    app.dependency_overrides[get_broker_auth] = lambda: broker_auth
+    app.dependency_overrides[get_upstream_client] = lambda: upstream_client
+    app.dependency_overrides[get_braintrust_api_key] = lambda: REAL_UPSTREAM_KEY
+    return app
+
+
+class _ASGIRequestsAdapter(requests.adapters.HTTPAdapter):
+    """Routes the SDK's synchronous `requests` calls into the in-process broker
+    ASGI app via httpx.ASGITransport, so the genuine Braintrust SDK reaches our
+    proxy without any network I/O.
+
+    The SDK's HTTPConnection mounts this adapter on its requests.Session for
+    both http:// and https://. We translate the outgoing requests.PreparedRequest
+    into an httpx.Request against the ASGITransport, run it on a fresh event
+    loop, and translate the httpx.Response back into a requests.Response.
+    """
+
+    def __init__(self, app: FastAPI):
+        super().__init__()
+        self._transport = httpx.ASGITransport(app=app)
+
+    def send(self, request, **kwargs):  # type: ignore[override]
+        body = request.body
+        if isinstance(body, str):
+            body = body.encode("utf-8")
+        httpx_request = httpx.Request(
+            method=request.method,
+            url=request.url,
+            headers=dict(request.headers),
+            content=body,
+        )
+
+        async def _run() -> httpx.Response:
+            resp = await self._transport.handle_async_request(httpx_request)
+            await resp.aread()
+            return resp
+
+        httpx_resp = asyncio.run(_run())
+
+        resp = requests.models.Response()
+        resp.status_code = httpx_resp.status_code
+        resp._content = httpx_resp.content
+        resp.url = str(httpx_request.url)
+        resp.headers = requests.structures.CaseInsensitiveDict(httpx_resp.headers)
+        resp.request = request
+        resp.encoding = "utf-8"
+        return resp
+
+
+@pytest.fixture
+def _reset_braintrust_state():
+    """Reset both the SDK global login state and the shared client singleton so
+    no prior test's login leaks in and our login actually fires through the
+    proxy."""
+    import braintrust.logger as bt_logger
+
+    from shared.braintrust import BraintrustClient
+
+    BraintrustClient.reset_instance()
+    bt_logger._internal_reset_global_state()
+    prior_adapter = bt_logger._http_adapter
+    yield
+    bt_logger._http_adapter = prior_adapter
+    bt_logger._internal_reset_global_state()
+    BraintrustClient.reset_instance()
+
+
+class TestBraintrustRealSDKContract:
+    def test_real_sdk_routes_login_and_ingest_through_proxy_with_swapped_key(
+        self, monkeypatch, _reset_braintrust_state
+    ):
+        import braintrust
+
+        calls: list[_RecordedRequest] = []
+        app = _build_broker_app(calls)
+
+        # Point the genuine SDK at the in-process broker proxy. The runner sets
+        # exactly these two env vars in production.
+        monkeypatch.setenv("BRAINTRUST_APP_URL", "http://broker/braintrust/app")
+        monkeypatch.setenv("BRAINTRUST_API_URL", "http://broker/braintrust/api")
+        # Override conftest's BRAINTRUST_API_KEY="" — the SDK sends this broker
+        # token; the proxy verifies it and swaps in REAL_UPSTREAM_KEY.
+        monkeypatch.setenv("BRAINTRUST_API_KEY", VALID_BROKER_TOKEN)
+        monkeypatch.setenv("BRAINTRUST_ORG_NAME", "test-org")
+        # Avoid any unrelated public-url probing during permalink/metadata.
+        monkeypatch.delenv("BRAINTRUST_APP_PUBLIC_URL", raising=False)
+        monkeypatch.delenv("BRAINTRUST_PROXY_URL", raising=False)
+
+        braintrust.set_http_adapter(_ASGIRequestsAdapter(app))
+
+        # Synchronous flush so the logs3 ingest completes before we assert.
+        logger = braintrust.init_logger(project="pmf-engine-test", async_flush=False)
+        with logger.start_span(name="contract-span", type="task") as span:
+            span.log(input={"q": "hello"}, output={"a": "world"})
+        logger.flush()
+
+        by_path = {(c.method, c.host, c.path): c for c in calls}
+
+        # 1. Login went to the control plane host (www.braintrust.dev) via leg "app".
+        login = next(
+            (c for c in calls if c.method == "POST" and c.path == "/api/apikey/login"),
+            None,
+        )
+        assert login is not None, f"no login call recorded; calls={[(c.method, c.host, c.path) for c in calls]}"
+        assert login.host == "www.braintrust.dev"
+        assert login.authorization == f"Bearer {REAL_UPSTREAM_KEY}"
+
+        # 2. logs3 ingest went to the data plane host (api.braintrust.dev) via leg "api".
+        ingest = next(
+            (c for c in calls if c.method == "POST" and c.path == "/logs3"),
+            None,
+        )
+        assert ingest is not None, f"no logs3 ingest recorded; calls={[(c.method, c.host, c.path) for c in calls]}"
+        assert ingest.host == "api.braintrust.dev"
+        assert ingest.authorization == f"Bearer {REAL_UPSTREAM_KEY}"
+
+        # 3. EVERY forwarded request carried the swapped real key, never the
+        #    broker token. This is the core security contract: the runner's
+        #    per-run token never reaches Braintrust.
+        for c in calls:
+            assert c.authorization == f"Bearer {REAL_UPSTREAM_KEY}", (
+                f"request {c.method} {c.host}{c.path} forwarded "
+                f"unexpected auth {c.authorization!r}"
+            )
+        assert all(c.authorization != f"Bearer {VALID_BROKER_TOKEN}" for c in calls)
+
+        # Sanity: the control-plane register call (proof the SDK completed the
+        # full lazy-login metadata path against the proxy, not just a stub).
+        assert ("POST", "www.braintrust.dev", "/api/project/register") in by_path

--- a/broker/tests/test_secrets.py
+++ b/broker/tests/test_secrets.py
@@ -19,6 +19,7 @@ FULL_SECRET = {
     "AGENT_FLEET_CLERK_ID": "user_agent_fleet_test",
     "AGENT_MCP_TOKEN_SECRET": "test-agent-mcp-secret",
     "RESULTS_QUEUE_URL": "https://sqs.us-west-2.amazonaws.com/123/results.fifo",
+    "BRAINTRUST_API_KEY": "sk-bt-test",
 }
 
 
@@ -46,6 +47,18 @@ class TestLoadSecrets:
         assert result.agent_fleet_clerk_id == "user_agent_fleet_test"
         assert result.agent_mcp_token_secret == "test-agent-mcp-secret"
         assert result.results_queue_url == "https://sqs.us-west-2.amazonaws.com/123/results.fifo"
+        assert result.braintrust_api_key == "sk-bt-test"
+
+    def test_braintrust_api_key_is_optional(self):
+        without_bt = {k: v for k, v in FULL_SECRET.items() if k != "BRAINTRUST_API_KEY"}
+        mock_client = MagicMock()
+        mock_client.get_secret_value.return_value = {"SecretString": json.dumps(without_bt)}
+
+        with patch("broker.secrets.boto3") as mock_boto3:
+            mock_boto3.client.return_value = mock_client
+            result = load_secrets("AI_SECRETS_DEV")
+
+        assert result.braintrust_api_key == ""
 
     def test_missing_required_field_raises_valueerror(self):
         incomplete = {k: v for k, v in FULL_SECRET.items() if k != "ANTHROPIC_API_KEY"}

--- a/infrastructure/modules/broker/main.tf
+++ b/infrastructure/modules/broker/main.tf
@@ -123,7 +123,7 @@ resource "aws_cloudwatch_log_group" "broker" {
 
 resource "aws_secretsmanager_secret" "broker" {
   name        = "broker-${var.environment}"
-  description = "Secrets for PMF broker service. Operator populates: ANTHROPIC_API_KEY, GEMINI_API_KEY, TAVILY_API_KEY, DATABRICKS_SERVER_HOSTNAME, DATABRICKS_HTTP_PATH, DATABRICKS_API_KEY, SERVICE_TOKEN_HASH, CLERK_SECRET_KEY, CLERK_FRONTEND_API_BASE, GP_API_BASE_URL, AGENT_FLEET_CLERK_ID, AGENT_MCP_TOKEN_SECRET"
+  description = "Secrets for PMF broker service. Operator populates: ANTHROPIC_API_KEY, GEMINI_API_KEY, TAVILY_API_KEY, DATABRICKS_SERVER_HOSTNAME, DATABRICKS_HTTP_PATH, DATABRICKS_API_KEY, SERVICE_TOKEN_HASH, CLERK_SECRET_KEY, CLERK_FRONTEND_API_BASE, GP_API_BASE_URL, AGENT_FLEET_CLERK_ID, AGENT_MCP_TOKEN_SECRET, BRAINTRUST_API_KEY"
 
   tags = {
     Environment = var.environment
@@ -695,6 +695,10 @@ resource "aws_ecs_task_definition" "broker" {
         {
           name      = "AGENT_MCP_TOKEN_SECRET"
           valueFrom = "${aws_secretsmanager_secret.broker.arn}:AGENT_MCP_TOKEN_SECRET::"
+        },
+        {
+          name      = "BRAINTRUST_API_KEY"
+          valueFrom = "${aws_secretsmanager_secret.broker.arn}:BRAINTRUST_API_KEY::"
         }
       ]
     }

--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -387,6 +387,14 @@ def build_container_overrides(
         {"name": "BROKER_URL", "value": broker_url},
         {"name": "ANTHROPIC_BASE_URL", "value": f"{broker_url}/anthropic"},
         {"name": "ANTHROPIC_API_KEY", "value": broker_token},
+        # Braintrust SDK routes through the broker like Anthropic does: the task
+        # SG only allows broker egress, so direct api.braintrust.dev calls are
+        # blocked. APP_URL/API_URL force the SDK's control-plane (login) and
+        # data-plane (/logs3 ingest) legs through the broker proxy; the runner
+        # authenticates with the broker token, the broker swaps in the real key.
+        {"name": "BRAINTRUST_API_KEY", "value": broker_token},
+        {"name": "BRAINTRUST_APP_URL", "value": f"{broker_url}/braintrust/app"},
+        {"name": "BRAINTRUST_API_URL", "value": f"{broker_url}/braintrust/api"},
         {"name": "PARAMS_JSON", "value": params_json},
         {"name": "TIMEOUT_SECONDS", "value": str(experiment.get("timeout_seconds", 600))},
         # QA_JUDGES configures the runbooks qa-spine pluggable LLM judge registry

--- a/pmf_engine/runner/main.py
+++ b/pmf_engine/runner/main.py
@@ -385,7 +385,7 @@ async def run_experiment(
         harness = get_harness(config.harness)
 
     bt = BraintrustClient.get_instance()
-    bt.init("pmf-engine")
+    bt.init(f"pmf-engine-{config.environment}")
 
     workspace_dir = os.environ.get("WORKSPACE_DIR", "/workspace")
     start_time = time.monotonic()

--- a/pmf_engine/runner/main.py
+++ b/pmf_engine/runner/main.py
@@ -178,6 +178,39 @@ def _send_failed_to_sqs_directly(
         return False
 
 
+def _report_failed_or_fallback(
+    *,
+    run_id: str,
+    experiment_id: str,
+    reason_code: str,
+    detail: str,
+    duration_seconds: float,
+) -> None:
+    """Send a terminal "failed" status via the broker; if the broker is
+    unreachable (report_status raises), fall back to a direct SQS failed
+    envelope so the gp-api run row flips PENDING → FAILED instead of hanging
+    forever. Mirrors the config-load failure path so every terminal handler
+    in main() is broker-down-safe."""
+    try:
+        publish.report_status(
+            "failed",
+            reason_code=reason_code,
+            detail=detail,
+            duration_seconds=duration_seconds,
+        )
+    except Exception as report_err:
+        logger.exception(
+            "failed_callback_send_failed errorType=ReportStatusError "
+            f"run_id={run_id} error={report_err}"
+        )
+        _send_failed_to_sqs_directly(
+            run_id=run_id,
+            experiment_id=experiment_id,
+            reason_code=reason_code,
+            detail=detail,
+        )
+
+
 def _exit_on_pre_task_shutdown(
     *,
     run_id: str,
@@ -833,8 +866,9 @@ async def main():
                     exc_info=True,
                 )
         _upload_logs(workspace_dir, run_id=config.run_id, experiment_id=config.experiment_id)
-        publish.report_status(
-            "failed",
+        _report_failed_or_fallback(
+            run_id=config.run_id,
+            experiment_id=config.experiment_id,
             reason_code="Timeout",
             detail=f"Experiment timed out after {config.timeout_seconds}s",
             duration_seconds=time.monotonic() - main_start_time,
@@ -844,8 +878,9 @@ async def main():
     except asyncio.CancelledError:
         logger.warning(f"Experiment task cancelled by signal for run {config.run_id}")
         _upload_logs(workspace_dir, run_id=config.run_id, experiment_id=config.experiment_id)
-        publish.report_status(
-            "failed",
+        _report_failed_or_fallback(
+            run_id=config.run_id,
+            experiment_id=config.experiment_id,
             reason_code="Signal",
             detail="Task terminated by signal",
             duration_seconds=time.monotonic() - main_start_time,
@@ -858,8 +893,9 @@ async def main():
     except Exception as e:
         if _shutdown_requested:
             logger.warning(f"Task terminated by signal for run {config.run_id}")
-            publish.report_status(
-                "failed",
+            _report_failed_or_fallback(
+                run_id=config.run_id,
+                experiment_id=config.experiment_id,
                 reason_code="Signal",
                 detail="Task terminated by signal",
                 duration_seconds=time.monotonic() - main_start_time,
@@ -868,8 +904,9 @@ async def main():
 
         logger.exception(f"Unhandled error in main for run {config.run_id}: {e}")
         if not _is_callback_already_sent():
-            publish.report_status(
-                "failed",
+            _report_failed_or_fallback(
+                run_id=config.run_id,
+                experiment_id=config.experiment_id,
                 reason_code=type(e).__name__,
                 detail=f"Unhandled error: {e}",
                 duration_seconds=time.monotonic() - main_start_time,

--- a/pmf_engine/runner/main.py
+++ b/pmf_engine/runner/main.py
@@ -423,13 +423,18 @@ async def run_experiment(
                 duration = time.monotonic() - start_time
                 logger.exception(f"Harness failed for run {config.run_id}: {e}")
                 _upload_logs(workspace_dir, run_id=config.run_id, experiment_id=config.experiment_id)
+                # Flush the span BEFORE report_status: a terminal status deletes
+                # this run's broker scope ticket, which invalidates the token the
+                # Braintrust proxy authenticates with. Logging/flushing after it
+                # drops the rollup batch with a 401.
+                span.log(output={"status": "failed", "error": str(e), "duration_seconds": duration})
+                bt.flush()
                 publish.report_status(
                     "failed",
                     reason_code=type(e).__name__,
                     detail=str(e),
                     duration_seconds=duration,
                 )
-                span.log(output={"status": "failed", "error": str(e), "duration_seconds": duration})
                 _mark_callback_sent()
                 raise
 
@@ -463,6 +468,16 @@ async def run_experiment(
                     # None / empty bytes case — preserve the empty marker
                     # for downstream tooling that branches on truncation.
                     rejected = {"_raw_bytes": "", "_truncated": False}
+                # Flush before report_status deletes the broker scope ticket
+                # (see harness-failure branch above).
+                span.log(output={
+                    "status": "contract_violation",
+                    "error": str(e),
+                    "cost_usd": result.cost_usd,
+                    "num_turns": result.num_turns,
+                    "duration_seconds": duration,
+                })
+                bt.flush()
                 publish.report_status(
                     "contract_violation",
                     rejected_artifact=rejected,
@@ -471,18 +486,15 @@ async def run_experiment(
                     cost_usd=result.cost_usd,
                 )
                 _mark_callback_sent()
-                span.log(output={
-                    "status": "contract_violation",
-                    "error": str(e),
-                    "cost_usd": result.cost_usd,
-                    "num_turns": result.num_turns,
-                    "duration_seconds": duration,
-                })
                 return
             except Exception as e:
                 duration = time.monotonic() - start_time
                 logger.exception(f"Validator error for run {config.run_id}: {e}")
                 _upload_logs(workspace_dir, run_id=config.run_id, experiment_id=config.experiment_id)
+                # Flush before report_status deletes the broker scope ticket
+                # (see harness-failure branch above).
+                span.log(output={"status": "failed", "error": str(e), "duration_seconds": duration})
+                bt.flush()
                 publish.report_status(
                     "failed",
                     reason_code=type(e).__name__,
@@ -490,7 +502,6 @@ async def run_experiment(
                     duration_seconds=duration,
                     cost_usd=result.cost_usd,
                 )
-                span.log(output={"status": "failed", "error": str(e), "duration_seconds": duration})
                 _mark_callback_sent()
                 raise
 
@@ -500,6 +511,16 @@ async def run_experiment(
                 duration = time.monotonic() - start_time
                 logger.exception(f"Artifact not valid JSON for run {config.run_id}: {e}")
                 _upload_logs(workspace_dir, run_id=config.run_id, experiment_id=config.experiment_id)
+                # Flush before report_status deletes the broker scope ticket
+                # (see harness-failure branch above).
+                span.log(output={
+                    "status": "failed",
+                    "error": str(e),
+                    "cost_usd": result.cost_usd,
+                    "num_turns": result.num_turns,
+                    "duration_seconds": duration,
+                })
+                bt.flush()
                 publish.report_status(
                     "failed",
                     reason_code="InvalidJSON",
@@ -513,6 +534,17 @@ async def run_experiment(
             _upload_logs(workspace_dir, run_id=config.run_id, experiment_id=config.experiment_id)
 
             duration = time.monotonic() - start_time
+            # Log + flush the root span BEFORE publish: publish deletes this
+            # run's broker scope ticket (anti-replay), which invalidates the
+            # token the Braintrust proxy authenticates with. Flushing after
+            # publish drops the run-level rollup with a 401.
+            span.log(output={
+                "status": "success",
+                "cost_usd": result.cost_usd,
+                "num_turns": result.num_turns,
+                "duration_seconds": duration,
+            })
+            bt.flush()
             try:
                 publish.publish(
                     artifact,
@@ -544,14 +576,9 @@ async def run_experiment(
                         f"for run {config.run_id}: {report_err}"
                     )
                 raise
-
-            span.log(output={
-                "status": "success",
-                "cost_usd": result.cost_usd,
-                "num_turns": result.num_turns,
-                "duration_seconds": duration,
-            })
     finally:
+        # Safety net for unexpected exits; terminal branches already flush the
+        # root span before the broker call that deletes the scope ticket.
         bt.flush()
 
 

--- a/pmf_engine/runner/main.py
+++ b/pmf_engine/runner/main.py
@@ -534,6 +534,12 @@ async def run_experiment(
             _upload_logs(workspace_dir, run_id=config.run_id, experiment_id=config.experiment_id)
 
             duration = time.monotonic() - start_time
+            # Intentional trace/status divergence: the trace records "success"
+            # and flushes HERE, before publish runs. Because publish deletes the
+            # scope ticket that authenticates the Braintrust proxy, if publish
+            # then fails and gp-api gets a "failed" status, this run's Braintrust
+            # trace will still read "success". That stale trace is a deliberate
+            # tradeoff of flush-before-delete, not a bug.
             # Log + flush the root span BEFORE publish: publish deletes this
             # run's broker scope ticket (anti-replay), which invalidates the
             # token the Braintrust proxy authenticates with. Flushing after

--- a/pmf_engine/runner/main.py
+++ b/pmf_engine/runner/main.py
@@ -540,6 +540,7 @@ async def run_experiment(
             # publish drops the run-level rollup with a 401.
             span.log(output={
                 "status": "success",
+                "artifact": artifact,
                 "cost_usd": result.cost_usd,
                 "num_turns": result.num_turns,
                 "duration_seconds": duration,

--- a/pmf_engine/tests/test_dispatch_runner_env_roundtrip.py
+++ b/pmf_engine/tests/test_dispatch_runner_env_roundtrip.py
@@ -127,6 +127,9 @@ def test_dispatch_env_roundtrips_to_runner_config():
         "ANTHROPIC_API_KEY",
         "PARAMS_JSON",
         "TIMEOUT_SECONDS",
+        "BRAINTRUST_API_KEY",
+        "BRAINTRUST_APP_URL",
+        "BRAINTRUST_API_URL",
     ):
         assert critical in env_map, (
             f"dispatch_handler no longer sets {critical} — "
@@ -137,6 +140,11 @@ def test_dispatch_env_roundtrips_to_runner_config():
     assert env_map["BROKER_URL"] == "https://broker.example.com"
     assert env_map["ANTHROPIC_BASE_URL"] == "https://broker.example.com/anthropic"
     assert env_map["ANTHROPIC_API_KEY"] == "tok-test-123"
+    # Braintrust SDK routes both legs through the broker: the runner holds only
+    # the per-run broker token, the broker swaps in the real Braintrust key.
+    assert env_map["BRAINTRUST_API_KEY"] == "tok-test-123"
+    assert env_map["BRAINTRUST_APP_URL"] == "https://broker.example.com/braintrust/app"
+    assert env_map["BRAINTRUST_API_URL"] == "https://broker.example.com/braintrust/api"
 
     envelope = _broker_envelope(manifest, instruction)
 

--- a/pmf_engine/tests/test_runner_main.py
+++ b/pmf_engine/tests/test_runner_main.py
@@ -963,6 +963,9 @@ async def test_run_experiment_traces_success_to_braintrust(mock_publish, _mock_l
     assert log_kwargs["output"]["cost_usd"] == 0.05
     assert log_kwargs["output"]["num_turns"] == 3
     assert log_kwargs["output"]["duration_seconds"] > 0
+    # The final artifact JSON is pushed into the trace output so Braintrust
+    # shows input(params)→output(artifact), not just rollup metadata.
+    assert log_kwargs["output"]["artifact"] == {"greeting": "hello"}
 
     # flushed twice now: once in the terminal branch (before the broker call
     # that deletes the scope ticket) + once in the finally safety net.

--- a/pmf_engine/tests/test_runner_main.py
+++ b/pmf_engine/tests/test_runner_main.py
@@ -964,7 +964,9 @@ async def test_run_experiment_traces_success_to_braintrust(mock_publish, _mock_l
     assert log_kwargs["output"]["num_turns"] == 3
     assert log_kwargs["output"]["duration_seconds"] > 0
 
-    mock_bt.flush.assert_called_once()
+    # flushed twice now: once in the terminal branch (before the broker call
+    # that deletes the scope ticket) + once in the finally safety net.
+    mock_bt.flush.assert_called()
 
 
 @pytest.mark.asyncio
@@ -985,7 +987,9 @@ async def test_run_experiment_traces_failure_to_braintrust(mock_publish, _mock_l
     assert log_kwargs["output"]["status"] == "failed"
     assert "Agent crashed" in log_kwargs["output"]["error"]
 
-    mock_bt.flush.assert_called_once()
+    # flushed twice now: once in the terminal branch (before the broker call
+    # that deletes the scope ticket) + once in the finally safety net.
+    mock_bt.flush.assert_called()
 
 
 @pytest.mark.asyncio
@@ -1011,7 +1015,72 @@ async def test_run_experiment_traces_contract_violation_to_braintrust(mock_publi
     assert log_kwargs["output"]["status"] == "contract_violation"
     assert "greeting" in log_kwargs["output"]["error"]
 
-    mock_bt.flush.assert_called_once()
+    # flushed twice now: once in the terminal branch (before the broker call
+    # that deletes the scope ticket) + once in the finally safety net.
+    mock_bt.flush.assert_called()
+
+
+@pytest.mark.asyncio
+@patch("pmf_engine.runner.main._upload_logs")
+@patch("pmf_engine.runner.main.publish")
+async def test_braintrust_flushes_before_publish_deletes_scope_ticket(mock_publish, _mock_logs):
+    """The broker deletes this run's scope ticket on publish (anti-replay),
+    which invalidates the token the Braintrust proxy authenticates with. So the
+    root span output must be logged AND flushed BEFORE publish — otherwise the
+    run-level rollup batch is dropped with a 401. Lock the ordering."""
+    config = _make_config()
+    fake_result = HarnessResult(
+        artifact_bytes=b'{"greeting": "hello"}',
+        content_type="application/json",
+        cost_usd=0.05,
+        num_turns=3,
+        session_id="sess-abc",
+    )
+    mock_harness = AsyncMock()
+    mock_harness.run.return_value = fake_result
+    mock_bt, mock_span = _make_mock_bt()
+
+    manager = MagicMock()
+    manager.attach_mock(mock_span.log, "span_log")
+    manager.attach_mock(mock_bt.flush, "flush")
+    manager.attach_mock(mock_publish.publish, "publish")
+
+    with patch("pmf_engine.runner.main.BraintrustClient.get_instance", return_value=mock_bt):
+        await run_experiment(config, harness=mock_harness)
+
+    order = [c[0] for c in manager.mock_calls]
+    assert "publish" in order and "span_log" in order and "flush" in order
+    assert order.index("span_log") < order.index("publish"), (
+        "root span output must be logged before publish deletes the scope ticket"
+    )
+    assert order.index("flush") < order.index("publish"), (
+        "Braintrust must flush before publish deletes the scope ticket"
+    )
+
+
+@pytest.mark.asyncio
+@patch("pmf_engine.runner.main._upload_logs")
+@patch("pmf_engine.runner.main.publish")
+async def test_braintrust_flushes_before_report_status_on_failure(mock_publish, _mock_logs):
+    """Terminal report_status also deletes the scope ticket. The failure-path
+    span output + flush must precede it for the same reason."""
+    config = _make_config()
+    mock_harness = AsyncMock()
+    mock_harness.run.side_effect = RuntimeError("Agent crashed")
+    mock_bt, mock_span = _make_mock_bt()
+
+    manager = MagicMock()
+    manager.attach_mock(mock_span.log, "span_log")
+    manager.attach_mock(mock_bt.flush, "flush")
+    manager.attach_mock(mock_publish.report_status, "report_status")
+
+    with patch("pmf_engine.runner.main.BraintrustClient.get_instance", return_value=mock_bt):
+        with pytest.raises(RuntimeError, match="Agent crashed"):
+            await run_experiment(config, harness=mock_harness)
+
+    order = [c[0] for c in manager.mock_calls]
+    assert order.index("span_log") < order.index("report_status")
+    assert order.index("flush") < order.index("report_status")
 
 
 class TestMainErrorPaths:

--- a/pmf_engine/tests/test_runner_main.py
+++ b/pmf_engine/tests/test_runner_main.py
@@ -946,7 +946,9 @@ async def test_run_experiment_traces_success_to_braintrust(mock_publish, _mock_l
     with patch("pmf_engine.runner.main.BraintrustClient.get_instance", return_value=mock_bt):
         await run_experiment(config, harness=mock_harness)
 
-    mock_bt.init.assert_called_once_with("pmf-engine")
+    # Per-environment Braintrust project keeps prod a clean eval corpus,
+    # separate from dev/qa smoke noise. config.environment is "dev" here.
+    mock_bt.init.assert_called_once_with("pmf-engine-dev")
 
     call_kwargs = mock_bt.traced_span.call_args[1]
     assert call_kwargs["name"] == "experiment:hello_world"

--- a/pmf_engine/tests/test_runner_main.py
+++ b/pmf_engine/tests/test_runner_main.py
@@ -977,6 +977,68 @@ async def test_run_experiment_traces_success_to_braintrust(mock_publish, _mock_l
 @pytest.mark.asyncio
 @patch("pmf_engine.runner.main._upload_logs")
 @patch("pmf_engine.runner.main.publish")
+async def test_run_experiment_publishes_when_braintrust_flush_raises(mock_publish, _mock_logs):
+    """Graceful degradation: Braintrust being fully unavailable must not block
+    the run. When the broker returns 503/401 for the Braintrust proxy, the
+    client's flush() can raise. The run is a success regardless of whether
+    telemetry made it out the door — Braintrust is best-effort observability,
+    not part of the experiment's terminal contract.
+
+    Contract: even if bt.flush() raises (proxy down), run_experiment still
+    calls publish.publish(...) with the artifact and does NOT propagate the
+    Braintrust failure to the caller.
+    """
+    config = _make_config()
+    fake_result = HarnessResult(
+        artifact_bytes=b'{"greeting": "hello"}',
+        content_type="application/json",
+        cost_usd=0.05,
+        num_turns=3,
+        session_id="sess-abc",
+    )
+    mock_harness = AsyncMock()
+    mock_harness.run.return_value = fake_result
+    mock_bt, _mock_span = _make_mock_bt()
+    # Simulate the Braintrust proxy being unreachable. In production the
+    # underlying batch logger's flush raises (proxy 401/503), but
+    # BraintrustClient.flush swallows it (logs .error, returns None) so the
+    # run is never blocked by telemetry. Model that swallow here: the public
+    # flush() the runner calls absorbs the proxy error instead of propagating.
+    flush_attempts = {"count": 0}
+
+    def swallowing_flush():
+        flush_attempts["count"] += 1
+        try:
+            raise RuntimeError("braintrust proxy 503")
+        except Exception:
+            # Matches BraintrustClient.flush: log + swallow, never re-raise.
+            return None
+
+    mock_bt.flush.side_effect = swallowing_flush
+
+    with patch("pmf_engine.runner.main.BraintrustClient.get_instance", return_value=mock_bt):
+        # MUST NOT raise — Braintrust failure is non-fatal to the run.
+        await run_experiment(config, harness=mock_harness)
+
+    assert flush_attempts["count"] >= 1, "expected the runner to attempt a Braintrust flush"
+
+    # The artifact still reaches the broker.
+    mock_publish.publish.assert_called_once()
+    call_args = mock_publish.publish.call_args
+    assert call_args[0] == ({"greeting": "hello"},)
+    assert call_args.kwargs.get("cost_usd") == pytest.approx(0.05)
+    # The run is NOT reported as failed just because telemetry couldn't flush.
+    failed_calls = [
+        c for c in mock_publish.report_status.call_args_list if c[0][0] == "failed"
+    ]
+    assert not failed_calls, (
+        f"Braintrust flush failure must not produce a failed status; got: {failed_calls!r}"
+    )
+
+
+@pytest.mark.asyncio
+@patch("pmf_engine.runner.main._upload_logs")
+@patch("pmf_engine.runner.main.publish")
 async def test_run_experiment_traces_failure_to_braintrust(mock_publish, _mock_logs):
     config = _make_config()
     mock_harness = AsyncMock()

--- a/pmf_engine/tests/test_runner_main.py
+++ b/pmf_engine/tests/test_runner_main.py
@@ -232,6 +232,35 @@ async def test_publish_failure_then_report_status_failure_leaves_callback_unsent
 
 
 @pytest.mark.asyncio
+async def test_main_falls_back_to_sqs_when_outer_report_status_fails():
+    """Broker fully down: run_experiment raises (no callback marked), then main()'s
+    outer handler calls report_status which ALSO raises. Without an SQS fallback
+    the exception escapes main() and the gp-api run row hangs PENDING forever.
+    main() must fall back to _send_failed_to_sqs_directly, matching the config-load
+    failure path."""
+    from pmf_engine.runner.main import _reset_callback_marker
+
+    _reset_callback_marker()
+    config = _make_config(instruction="Do stuff", timeout_seconds=30)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch.dict(os.environ, {"WORKSPACE_DIR": tmpdir}):
+            with patch("pmf_engine.runner.main.RunnerConfig.from_env", return_value=config):
+                with patch("pmf_engine.runner.main.init_config"):
+                    with patch("pmf_engine.runner.main.publish") as mock_publish:
+                        with patch("pmf_engine.runner.main.run_experiment", new_callable=AsyncMock) as mock_run:
+                            with patch("pmf_engine.runner.main._send_failed_to_sqs_directly") as mock_sqs:
+                                mock_run.side_effect = RuntimeError("kaboom")
+                                mock_publish.report_status.side_effect = Exception("broker down")
+                                with pytest.raises(Exception):
+                                    await main()
+
+    mock_sqs.assert_called_once()
+    assert mock_sqs.call_args.kwargs["run_id"] == config.run_id
+    assert mock_sqs.call_args.kwargs["experiment_id"] == config.experiment_id
+
+
+@pytest.mark.asyncio
 async def test_main_writes_instruction_to_workspace():
     with tempfile.TemporaryDirectory() as tmpdir:
         config = _make_config(instruction="# Test Instruction\n\nDo the thing.")


### PR DESCRIPTION
## What & why

PMF Fargate agents are network-quarantined to **broker-only egress**, and they were never given a `BRAINTRUST_API_KEY` — so the harness's Braintrust span instrumentation silently no-opped and **no traces ever left the runner**. This routes Braintrust through the broker (like the existing Anthropic proxy), so PMF runs log full traces without the runner ever holding the real key or gaining new egress.

## Changes

- **Broker Braintrust reverse-proxy** (`broker/endpoints/braintrust_proxy.py`): two legs — `/braintrust/app` → `www.braintrust.dev` (login/metadata), `/braintrust/api` → `api.braintrust.dev` (`/logs3` ingest). Verifies the per-run broker token, swaps in the real `BRAINTRUST_API_KEY` (held only by the broker), forwards to two **fixed** hosts. Fails closed (401 bad token / 503 unconfigured / 404 unknown leg / 502 upstream).
- **Secrets/IaC**: `BRAINTRUST_API_KEY` added as an optional `BrokerSecrets` field and to the broker task-def `secrets` `valueFrom` block. Dispatch injects `BRAINTRUST_API_KEY` (= the per-run broker token), `BRAINTRUST_APP_URL`, `BRAINTRUST_API_URL` per run — no new env-var plumbing (reuses `ENVIRONMENT`).
- **Flush ordering** (`pmf_engine/runner/main.py`): the broker deletes the run's scope ticket on publish/terminal-`report_status` (anti-replay), which invalidates the token the proxy authenticates with. So the root span is now logged + `bt.flush()`-ed **before** that call in every terminal branch (success, harness-fail, contract-violation, validator-error, invalid-JSON); the `finally` flush stays as a safety net.
- **Artifact in trace**: the final output artifact is included in the root-span output, giving a full `input(params)` → `output(artifact)` pair for evals, not just cost/turns metadata.
- **Per-environment projects**: traces go to `pmf-engine-{dev,qa,prod}` instead of one shared project, keeping prod a clean eval corpus separate from dev/qa smoke.

## Testing

- broker **485 passed**, pmf_engine **542 passed**.
- New coverage proven via mutation (each test confirmed to fail against a deliberate break, then reverted): 404/502 proxy branches, flush-before-delete ordering, artifact-in-output, per-env project name.
- New **real-SDK contract test** (`broker/tests/test_braintrust_proxy_contract.py`): drives the genuine `braintrust` 0.17 SDK through the proxy (sync→ASGI bridge, mocked upstream), asserting login→`/logs3` routing + the real-key swap — guards against the unit mocks drifting from the SDK's actual URL-resolution behavior.
- Ran a multi-agent critic review; all findings addressed in the final commit.

## Verified live in dev

Traces flow through the broker into `pmf-engine-dev`; full briefing artifact visible in the Braintrust UI; confirmed across `district_issue_snapshot`, `opposition_research`, and a real `meeting_briefing` (`briefing_ready`, 25 agenda items).

## Reviewer notes / before promoting past dev

1. **qa/prod broker secrets** — `BRAINTRUST_API_KEY` has been backfilled into `broker-{dev,qa,prod}` (from `AI_SECRETS_{env}`), so the new `valueFrom` entry won't fail task startup on promotion. The RUNBOOK now includes the key in the population + rotation blocks so a future rotation doesn't drop it.
2. **`meeting_briefing max_turns 100→200`** lives in the **runbooks repo**, not here — tracked separately. (100 was just-too-low for dense agendas; a real Burnsville briefing needed 105 turns.)
3. **Data handling**: full artifacts now ship to Braintrust (external SaaS). The experiments exercised emit aggregate/public output (briefings, district counts). Confirm no experiment artifact carries individual-level voter records before this serves prod.
4. **Braintrust continuity**: prod will start a fresh `pmf-engine-prod` project; any dashboard/eval pinned to the old shared `pmf-engine` won't receive new prod traces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches broker auth/credential swapping and ECS secret injection (startup failure if keys missing); runner now sends full artifacts to external Braintrust SaaS and trace status can diverge from gp-api if publish fails after flush.
> 
> **Overview**
> Adds a **broker Braintrust reverse proxy** (`/braintrust/app` and `/braintrust/api`) so Fargate runners can send traces without holding the real API key or opening new egress: the runner uses the **per-run broker token** as `BRAINTRUST_API_KEY`, the broker verifies it and forwards to Braintrust with the real key from secrets.
> 
> **Dispatch** now injects `BRAINTRUST_API_KEY`, `BRAINTRUST_APP_URL`, and `BRAINTRUST_API_URL` (mirroring the Anthropic-via-broker pattern). **Secrets/IaC/runbook** add optional `BRAINTRUST_API_KEY` on the broker task and document backfilling before apply so ECS does not fail on a missing JSON key.
> 
> **Runner** changes: Braintrust project **`pmf-engine-{environment}`**; root span output includes the **final artifact**; **`span.log` + `bt.flush()` run before** terminal `publish` / `report_status` so trace ingest is not lost when the scope ticket is deleted. Tests cover proxy auth/routing, a real SDK contract path, dispatch env round-trip, flush ordering, and non-fatal telemetry when flush fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d52d92148f784f95464dd96014fe485f899e019. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->