### PR TITLE
ENG-10297: Improve routing and variables.

### DIFF
--- a/broker/ARCHITECTURE.md
+++ b/broker/ARCHITECTURE.md
@@ -219,7 +219,7 @@ Note: runner → broker traffic inside the VPC is HTTP (no TLS). Not a leak — 
 
 1. **Image tagging for CI.** Current manual `docker build && docker push` is fine for dev iteration. QA/prod need CI-driven tagging (e.g. `broker-{env}-{commit_sha}` with service redeployment).
 2. **Braintrust tracing.** Stripped from runner (required IAM the quarantine doesn't allow). If we want per-run Claude API traces visible in Braintrust, route via broker — broker's Anthropic proxy can forward headers / tag requests.
-3. **gp-api integration.** `agent-results-{env}.fifo` is currently unconsumed. gp-api consumer wiring + experiment endpoint schemas are tracked separately.
+3. **gp-api integration.** Done: dispatch-error callbacks now route to the gp-api results queue (`{branch}-Queue.fifo`) and the standalone `agent-results-{env}.fifo` has been retired. Remaining experiment endpoint schema work is tracked separately.
 4. **Dedicated PMF VPC (Phase 3 hardening).** Move PMF to its own VPC so Route53 DNS Firewall can attach with a block-all-except-broker rule. Not blocking for dev/qa/prod MVP.
 5. **SSRF hardening (batch 1b).** `broker/endpoints/http_fetch.py` does SSRF URL validation via `getaddrinfo` then lets httpx re-resolve — DNS rebinding window. Pending: resolve once, pin to safe IP via custom httpx resolver. Also: IPv4-mapped IPv6 (`::ffff:169.254.169.254`) bypasses the private-range check because Python's `is_private` returns False for v6-mapped; need explicit `ip.ipv4_mapped` handling.
 6. **Secret split.** Broker secret currently holds all 6 API keys + `SERVICE_TOKEN_HASH` in one ARN. Splitting `SERVICE_TOKEN_HASH` into its own secret narrows blast radius if the broker container ever leaks its env.

--- a/infrastructure/environments/dev/broker/main.tf
+++ b/infrastructure/environments/dev/broker/main.tf
@@ -97,9 +97,6 @@ module "broker" {
   results_queue_arn = data.aws_sqs_queue.results.arn
   results_queue_url = data.aws_sqs_queue.results.url
 
-  # gp_api_sqs_queue_arn is reference-only in the module; pass a real value for documentation
-  gp_api_sqs_queue_arn = data.aws_sqs_queue.results.arn
-
   sns_topic_arn = try(data.terraform_remote_state.fargate.outputs.sns_topic_arn, "")
 }
 

--- a/infrastructure/environments/dev/pmf-engine-control-plane/main.tf
+++ b/infrastructure/environments/dev/pmf-engine-control-plane/main.tf
@@ -21,14 +21,11 @@ provider "aws" {
   region = "us-west-2"
 }
 
-variable "gp_api_sqs_queue_url" {
-  type        = string
-  description = "URL of the gp-api SQS results queue that receives forwarded callbacks. Set per environment via terraform.tfvars; no default so dev values do not leak into qa/prod."
-}
-
-variable "gp_api_sqs_queue_arn" {
-  type        = string
-  description = "ARN of the gp-api SQS results queue. Set per environment via terraform.tfvars."
+# gp-api's results queue — the same queue the broker sends success results to
+# and gp-api's consumer polls. Looked up by name (not an unversioned tfvar) so
+# the dispatch Lambda's error callbacks land on the exact queue gp-api reads.
+data "aws_sqs_queue" "gp_api_results" {
+  name = "develop-Queue.fifo"
 }
 
 data "terraform_remote_state" "fargate" {
@@ -63,17 +60,17 @@ module "pmf_engine_control_plane" {
 
   environment = "dev"
 
-  ecs_cluster_arn            = data.terraform_remote_state.fargate.outputs.cluster_arn
-  ecs_task_definition_family = data.terraform_remote_state.fargate.outputs.task_definition_family
-  ecs_subnet_ids             = ["subnet-053357b931f0524d4", "subnet-0bb591861f72dcb7f"]
-  ecs_security_group_id      = data.terraform_remote_state.fargate.outputs.security_group_id
+  ecs_cluster_arn             = data.terraform_remote_state.fargate.outputs.cluster_arn
+  ecs_task_definition_family  = data.terraform_remote_state.fargate.outputs.task_definition_family
+  ecs_subnet_ids              = ["subnet-053357b931f0524d4", "subnet-0bb591861f72dcb7f"]
+  ecs_security_group_id       = data.terraform_remote_state.fargate.outputs.security_group_id
   ecs_task_execution_role_arn = data.terraform_remote_state.fargate.outputs.task_execution_role_arn
-  ecs_task_role_arn          = data.terraform_remote_state.fargate.outputs.task_role_arn
+  ecs_task_role_arn           = data.terraform_remote_state.fargate.outputs.task_role_arn
 
   lambda_package_dir = "${path.module}/../../../../pmf_engine/.lambda_build"
 
-  gp_api_sqs_queue_url = var.gp_api_sqs_queue_url
-  gp_api_sqs_queue_arn = var.gp_api_sqs_queue_arn
+  gp_api_sqs_queue_url = data.aws_sqs_queue.gp_api_results.url
+  gp_api_sqs_queue_arn = data.aws_sqs_queue.gp_api_results.arn
 
   broker_url                = data.terraform_remote_state.broker.outputs.broker_url
   service_tokens_secret_arn = data.terraform_remote_state.broker.outputs.service_tokens_secret_arn

--- a/infrastructure/environments/prod/broker/main.tf
+++ b/infrastructure/environments/prod/broker/main.tf
@@ -113,8 +113,6 @@ module "broker" {
   results_queue_arn = data.aws_sqs_queue.results[0].arn
   results_queue_url = data.aws_sqs_queue.results[0].url
 
-  gp_api_sqs_queue_arn = data.aws_sqs_queue.results[0].arn
-
   sns_topic_arn = try(data.terraform_remote_state.fargate[0].outputs.sns_topic_arn, "")
 }
 

--- a/infrastructure/environments/prod/pmf-engine-control-plane/main.tf
+++ b/infrastructure/environments/prod/pmf-engine-control-plane/main.tf
@@ -27,14 +27,11 @@ variable "bootstrap" {
   description = "First-pass apply: skip the broker cross-stack remote_state lookup so control-plane can be applied before broker. Fargate state must already exist (apply order: fargate -> control-plane(bootstrap=true) -> broker -> control-plane re-apply)."
 }
 
-variable "gp_api_sqs_queue_url" {
-  type        = string
-  description = "URL of the gp-api SQS results queue that receives forwarded callbacks. Set per environment via terraform.tfvars; no default so dev values do not leak into qa/prod."
-}
-
-variable "gp_api_sqs_queue_arn" {
-  type        = string
-  description = "ARN of the gp-api SQS results queue. Set per environment via terraform.tfvars."
+# gp-api's results queue — the same queue the broker sends success results to
+# and gp-api's consumer polls. Looked up by name (not an unversioned tfvar) so
+# the dispatch Lambda's error callbacks land on the exact queue gp-api reads.
+data "aws_sqs_queue" "gp_api_results" {
+  name = "master-Queue.fifo"
 }
 
 data "terraform_remote_state" "fargate" {
@@ -89,8 +86,8 @@ module "pmf_engine_control_plane" {
 
   lambda_package_dir = "${path.module}/../../../../pmf_engine/.lambda_build"
 
-  gp_api_sqs_queue_url = var.gp_api_sqs_queue_url
-  gp_api_sqs_queue_arn = var.gp_api_sqs_queue_arn
+  gp_api_sqs_queue_url = data.aws_sqs_queue.gp_api_results.url
+  gp_api_sqs_queue_arn = data.aws_sqs_queue.gp_api_results.arn
 
   broker_url                = var.bootstrap ? "https://broker-bootstrap.placeholder" : try(data.terraform_remote_state.broker[0].outputs.broker_url, "https://broker-bootstrap.placeholder")
   service_tokens_secret_arn = data.aws_secretsmanager_secret.service_tokens.arn

--- a/infrastructure/environments/qa/broker/main.tf
+++ b/infrastructure/environments/qa/broker/main.tf
@@ -110,8 +110,6 @@ module "broker" {
   results_queue_arn = data.aws_sqs_queue.results[0].arn
   results_queue_url = data.aws_sqs_queue.results[0].url
 
-  gp_api_sqs_queue_arn = data.aws_sqs_queue.results[0].arn
-
   sns_topic_arn = try(data.terraform_remote_state.fargate[0].outputs.sns_topic_arn, "")
 }
 

--- a/infrastructure/environments/qa/pmf-engine-control-plane/main.tf
+++ b/infrastructure/environments/qa/pmf-engine-control-plane/main.tf
@@ -27,14 +27,11 @@ variable "bootstrap" {
   description = "First-pass apply: skip the broker cross-stack remote_state lookup so control-plane can be applied before broker. Fargate state must already exist (apply order: fargate -> control-plane(bootstrap=true) -> broker -> control-plane re-apply)."
 }
 
-variable "gp_api_sqs_queue_url" {
-  type        = string
-  description = "URL of the gp-api SQS results queue that receives forwarded callbacks. Set per environment via terraform.tfvars; no default so dev values do not leak into qa/prod."
-}
-
-variable "gp_api_sqs_queue_arn" {
-  type        = string
-  description = "ARN of the gp-api SQS results queue. Set per environment via terraform.tfvars."
+# gp-api's results queue — the same queue the broker sends success results to
+# and gp-api's consumer polls. Looked up by name (not an unversioned tfvar) so
+# the dispatch Lambda's error callbacks land on the exact queue gp-api reads.
+data "aws_sqs_queue" "gp_api_results" {
+  name = "qa-Queue.fifo"
 }
 
 data "terraform_remote_state" "fargate" {
@@ -89,8 +86,8 @@ module "pmf_engine_control_plane" {
 
   lambda_package_dir = "${path.module}/../../../../pmf_engine/.lambda_build"
 
-  gp_api_sqs_queue_url = var.gp_api_sqs_queue_url
-  gp_api_sqs_queue_arn = var.gp_api_sqs_queue_arn
+  gp_api_sqs_queue_url = data.aws_sqs_queue.gp_api_results.url
+  gp_api_sqs_queue_arn = data.aws_sqs_queue.gp_api_results.arn
 
   broker_url                = var.bootstrap ? "https://broker-bootstrap.placeholder" : try(data.terraform_remote_state.broker[0].outputs.broker_url, "https://broker-bootstrap.placeholder")
   service_tokens_secret_arn = data.aws_secretsmanager_secret.service_tokens.arn

--- a/infrastructure/modules/broker/main.tf
+++ b/infrastructure/modules/broker/main.tf
@@ -68,13 +68,8 @@ variable "sns_topic_arn" {
   default     = ""
 }
 
-variable "gp_api_sqs_queue_arn" {
-  description = "ARN of the gp-api results queue (for reference only; broker sends to its own results queue)"
-  type        = string
-}
-
 variable "results_queue_arn" {
-  description = "ARN of the external SQS FIFO queue the broker sends results to (owned by the control-plane stack)"
+  description = "ARN of the external SQS FIFO queue the broker sends results to (the gp-api results queue, {branch}-Queue.fifo)"
   type        = string
 }
 
@@ -166,10 +161,11 @@ resource "aws_dynamodb_table" "scope_tickets" {
 }
 
 # --- SQS: Results Queue ---
-# The results queue itself is owned by the control-plane stack (agent-results-{env}.fifo).
-# Broker's access is granted via the broker task role's IAM policy (task_sqs_results below).
+# The broker sends run results to the gp-api results queue ({branch}-Queue.fifo), passed in
+# as var.results_queue_arn and looked up by the env config. The broker does not own the queue;
+# access is granted via the broker task role's IAM policy (task_sqs_results below).
 # No aws_sqs_queue_policy here — IAM role policy is sufficient and avoids conflicting with
-# any resource policy the control-plane owner may add later.
+# any resource policy the queue owner may add later.
 
 # --- IAM: Task Execution Role ---
 

--- a/infrastructure/modules/pmf-engine-control-plane/main.tf
+++ b/infrastructure/modules/pmf-engine-control-plane/main.tf
@@ -202,37 +202,13 @@ resource "aws_sqs_queue" "dispatch" {
   }
 }
 
-# --- SQS: Results Queue (consumed by gp-api) ---
-
-resource "aws_sqs_queue" "results_dlq" {
-  name                        = "agent-results-dlq-${var.environment}.fifo"
-  fifo_queue                  = true
-  message_retention_seconds   = 604800
-  content_based_deduplication = true
-
-  tags = {
-    Environment = var.environment
-  }
-}
-
-resource "aws_sqs_queue" "results" {
-  name                        = "agent-results-${var.environment}.fifo"
-  fifo_queue                  = true
-  visibility_timeout_seconds  = 300
-  message_retention_seconds   = 604800
-  content_based_deduplication = false
-  deduplication_scope         = "messageGroup"
-  fifo_throughput_limit       = "perMessageGroupId"
-
-  redrive_policy = jsonencode({
-    deadLetterTargetArn = aws_sqs_queue.results_dlq.arn
-    maxReceiveCount     = 3
-  })
-
-  tags = {
-    Environment = var.environment
-  }
-}
+# --- Results Queue ---
+# Agent result/error callbacks go to the gp-api results queue
+# (var.gp_api_sqs_queue_url / _arn) — the same queue the broker sends success
+# results to and gp-api's consumer polls. This module does NOT create its own
+# results queue: a separate queue here is an orphan nothing consumes, which
+# silently swallows dispatch-error callbacks (the run then only fails via the
+# 45-minute stale sweep instead of immediately).
 
 # --- Lambda: Dispatch Handler ---
 
@@ -364,7 +340,7 @@ resource "aws_iam_role_policy" "dispatch_lambda_permissions" {
       {
         Effect   = "Allow"
         Action   = "sqs:SendMessage"
-        Resource = aws_sqs_queue.results.arn
+        Resource = var.gp_api_sqs_queue_arn
       },
       {
         Effect = "Allow"
@@ -390,16 +366,16 @@ resource "aws_lambda_function" "dispatch" {
 
   environment {
     variables = {
-      ENVIRONMENT           = var.environment
-      ECS_CLUSTER_ARN       = var.ecs_cluster_arn
-      ECS_TASK_DEFINITION   = var.ecs_task_definition_family
-      ECS_SUBNET_IDS        = join(",", var.ecs_subnet_ids)
-      ECS_SECURITY_GROUP_ID = var.ecs_security_group_id
-      ARTIFACT_BUCKET       = aws_s3_bucket.artifacts.id
-      CONTAINER_NAME        = "pmf-engine"
+      ENVIRONMENT                = var.environment
+      ECS_CLUSTER_ARN            = var.ecs_cluster_arn
+      ECS_TASK_DEFINITION        = var.ecs_task_definition_family
+      ECS_SUBNET_IDS             = join(",", var.ecs_subnet_ids)
+      ECS_SECURITY_GROUP_ID      = var.ecs_security_group_id
+      ARTIFACT_BUCKET            = aws_s3_bucket.artifacts.id
+      CONTAINER_NAME             = "pmf-engine"
       AI_SECRETS_NAME            = "AI_SECRETS_${upper(var.environment)}"
       BROKER_URL                 = var.broker_url
-      RESULTS_QUEUE_URL          = aws_sqs_queue.results.url
+      RESULTS_QUEUE_URL          = var.gp_api_sqs_queue_url
       SERVICE_TOKEN              = try(jsondecode(data.aws_secretsmanager_secret_version.service_tokens.secret_string)["SERVICE_TOKEN"], "")
       EXPERIMENT_METADATA_BUCKET = var.experiment_metadata_bucket_name
     }
@@ -470,28 +446,6 @@ resource "aws_cloudwatch_metric_alarm" "dispatch_dlq_depth" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "results_dlq_depth" {
-  count               = var.sns_topic_arn != "" ? 1 : 0
-  alarm_name          = "pmf-engine-results-dlq-${var.environment}"
-  alarm_description   = "Messages in PMF Engine results DLQ"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 1
-  metric_name         = "ApproximateNumberOfMessagesVisible"
-  namespace           = "AWS/SQS"
-  period              = 300
-  statistic           = "Sum"
-  threshold           = 0
-  alarm_actions       = [var.sns_topic_arn]
-
-  dimensions = {
-    QueueName = aws_sqs_queue.results_dlq.name
-  }
-
-  tags = {
-    Environment = var.environment
-  }
-}
-
 resource "aws_cloudwatch_metric_alarm" "param_screening_bypassed" {
   count               = var.sns_topic_arn != "" ? 1 : 0
   alarm_name          = "pmf-engine-param-screening-bypassed-${var.environment}"
@@ -546,16 +500,6 @@ output "dispatch_queue_url" {
 output "dispatch_queue_arn" {
   value       = aws_sqs_queue.dispatch.arn
   description = "ARN of the agent dispatch FIFO queue"
-}
-
-output "results_queue_url" {
-  value       = aws_sqs_queue.results.url
-  description = "URL of the agent results FIFO queue (consumed by gp-api)"
-}
-
-output "results_queue_arn" {
-  value       = aws_sqs_queue.results.arn
-  description = "ARN of the agent results FIFO queue"
 }
 
 output "artifact_bucket_name" {


### PR DESCRIPTION
Route PMF dispatch-error callbacks to the gp-api queue, not agent-results. Then, resolve gp-api results queue by name lookup, not an unversioned tfvar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes experiment result/error delivery path and destroys module-managed results queues; wrong queue name or apply order could drop callbacks until verified in each environment.
> 
> **Overview**
> **PMF dispatch error callbacks** now go to **gp-api’s existing results FIFO** (`develop-Queue.fifo` / `qa-Queue.fifo` / `master-Queue.fifo`) instead of a **module-owned `agent-results-*` queue** that nothing consumed.
> 
> In **dev/qa/prod control-plane** stacks, **`gp_api_sqs_queue_url` / `_arn` tfvars are removed** in favor of **`data.aws_sqs_queue.gp_api_results`** by environment-specific queue name. The **control-plane module** drops creation of results/results-DLQ queues, wires the dispatch Lambda’s **`RESULTS_QUEUE_URL`** and **`sqs:SendMessage`** IAM to **`var.gp_api_sqs_queue_*`**, and removes **results queue outputs** and the **results DLQ depth alarm**.
> 
> Apply will **destroy** the orphaned `agent-results-*` queues if they still exist in state; confirm gp-api is already polling the named queues before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b316ca210d11a5f963e59d3150431502a1db3791. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->