### PR TITLE
Prod <- QA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ CLAUDE-*.md
 *smac3_output*/
 input*
 !meeting_qa/qa/inputs/
+!broker/endpoints/inputs_read.py
+!pmf_engine/runner/input_files.py
 *.zip
 enhanced_data/
 

--- a/broker/dynamodb_client.py
+++ b/broker/dynamodb_client.py
@@ -3,7 +3,7 @@ import time
 
 import boto3
 from botocore.exceptions import ClientError
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 RUN_LOCK_PK_PREFIX = "run:"
@@ -15,6 +15,16 @@ def _run_lock_pk(run_id: str) -> str:
 
 class TicketAlreadyExistsError(Exception):
     pass
+
+
+class InputFileRef(BaseModel):
+    bucket: str = Field(..., min_length=1, max_length=255)
+    key: str = Field(..., min_length=1, max_length=1024)
+    # Path-traversal defense: dest is written under /workspace/input/<dest>,
+    # so it must be a simple filename — no separators, no parent refs, no
+    # leading dot (which would mark a hidden file the agent's directory
+    # walks could miss).
+    dest: str = Field(..., pattern=r"^[A-Za-z0-9_][A-Za-z0-9._-]*$", max_length=255)
 
 
 class ScopeTicket(BaseModel):
@@ -29,6 +39,7 @@ class ScopeTicket(BaseModel):
     issued_by: str
     prior_artifact_versions: dict[str, str] | None = None
     clerk_user_id: str | None = None
+    input_files: list[InputFileRef] | None = None
 
 
 class ScopeTicketStore:
@@ -52,6 +63,10 @@ class ScopeTicketStore:
             item["prior_artifact_versions"] = {"S": json.dumps(ticket.prior_artifact_versions)}
         if ticket.clerk_user_id is not None:
             item["clerk_user_id"] = {"S": ticket.clerk_user_id}
+        if ticket.input_files is not None:
+            item["input_files"] = {
+                "S": json.dumps([f.model_dump() for f in ticket.input_files])
+            }
 
         run_lock_item = {
             "pk": {"S": _run_lock_pk(ticket.run_id)},
@@ -113,6 +128,12 @@ class ScopeTicketStore:
         if "clerk_user_id" in item:
             clerk_user_id = item["clerk_user_id"]["S"]
 
+        input_files = None
+        if "input_files" in item:
+            input_files = [
+                InputFileRef(**f) for f in json.loads(item["input_files"]["S"])
+            ]
+
         return ScopeTicket(
             pk=item["pk"]["S"],
             run_id=item["run_id"]["S"],
@@ -125,6 +146,7 @@ class ScopeTicketStore:
             issued_by=item["issued_by"]["S"],
             prior_artifact_versions=prior,
             clerk_user_id=clerk_user_id,
+            input_files=input_files,
         )
 
     def delete_ticket(self, broker_token: str) -> None:

--- a/broker/endpoints/inputs_read.py
+++ b/broker/endpoints/inputs_read.py
@@ -1,0 +1,98 @@
+import logging
+
+from botocore.exceptions import ClientError
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import Response
+from pydantic import BaseModel, Field
+
+from broker.dynamodb_client import ScopeTicket
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/inputs", tags=["inputs"])
+
+# Mirrors gp-api's user-agenda MAX_UPLOAD_BYTES (75 MB). Defense-in-depth:
+# anything bigger than the upload-time cap shouldn't exist in the input bucket,
+# but rejecting here keeps a misconfigured upstream from OOM-ing the runner.
+MAX_INPUT_BYTES = 75 * 1024 * 1024
+
+
+class InputsReadRequest(BaseModel):
+    bucket: str = Field(..., min_length=1, max_length=255)
+    key: str = Field(..., min_length=1, max_length=1024)
+
+
+def get_scope_ticket() -> ScopeTicket:  # pragma: no cover
+    raise NotImplementedError("Must be overridden via dependency_overrides")
+
+
+def get_s3_client():  # pragma: no cover
+    raise NotImplementedError("Must be overridden via dependency_overrides")
+
+
+@router.post("/read")
+def inputs_read(
+    req: InputsReadRequest,
+    ticket: ScopeTicket = Depends(get_scope_ticket),
+    s3_client=Depends(get_s3_client),
+):
+    if not ticket.input_files:
+        raise HTTPException(
+            status_code=403,
+            detail="No input files authorized for this run",
+        )
+    if not any(
+        f.bucket == req.bucket and f.key == req.key for f in ticket.input_files
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="Input file not authorized for this run",
+        )
+
+    try:
+        s3_response = s3_client.get_object(Bucket=req.bucket, Key=req.key)
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "")
+        if error_code in ("NoSuchKey", "404"):
+            raise HTTPException(
+                status_code=404,
+                detail=f"Input file not found: s3://{req.bucket}/{req.key}",
+            )
+        logger.error(
+            "S3 inputs_read failed run_id=%s bucket=%r key=%r code=%s",
+            ticket.run_id,
+            req.bucket,
+            req.key,
+            error_code,
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="S3 read error")
+
+    content_length = s3_response.get("ContentLength")
+    if content_length is not None and content_length > MAX_INPUT_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"Input file exceeds {MAX_INPUT_BYTES}-byte cap "
+                f"(size={content_length})"
+            ),
+        )
+
+    body = s3_response["Body"].read()
+    if len(body) > MAX_INPUT_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"Input file exceeds {MAX_INPUT_BYTES}-byte cap "
+                f"(size={len(body)})"
+            ),
+        )
+
+    logger.info(
+        "inputs_read ok run_id=%s bucket=%r key=%r bytes=%d",
+        ticket.run_id,
+        req.bucket,
+        req.key,
+        len(body),
+    )
+    return Response(content=body, media_type="application/octet-stream")

--- a/broker/endpoints/inputs_read.py
+++ b/broker/endpoints/inputs_read.py
@@ -78,13 +78,19 @@ def inputs_read(
             ),
         )
 
-    body = s3_response["Body"].read()
+    # Bound the in-memory load even when the ContentLength header is missing
+    # — boto3's StreamingBody.read(amt) reads at most amt bytes. We read
+    # MAX_INPUT_BYTES + 1 so that any object exceeding the cap by even one
+    # byte produces a body longer than the cap and we can reject without
+    # loading the rest. Defends against an OOM via an oversized object that
+    # somehow slipped past the upload-time cap and lacks Content-Length.
+    body = s3_response["Body"].read(MAX_INPUT_BYTES + 1)
     if len(body) > MAX_INPUT_BYTES:
         raise HTTPException(
             status_code=413,
             detail=(
                 f"Input file exceeds {MAX_INPUT_BYTES}-byte cap "
-                f"(size={len(body)})"
+                f"(size>={len(body)})"
             ),
         )
 

--- a/broker/endpoints/mint_run_token.py
+++ b/broker/endpoints/mint_run_token.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 import uuid
 
@@ -65,6 +66,43 @@ class MintResponse(BaseModel):
     params_clean: dict
 
 
+def _expected_inputs_bucket() -> str:
+    """The only S3 bucket `input_files` refs may name in this environment.
+
+    The broker task role also holds GetObject on the artifact and
+    experiment-metadata buckets, so without this gate a caller with a valid
+    SERVICE_TOKEN could mint a ticket whose input_files point /inputs/read at
+    those buckets and read another run's data. Mirrors the dispatch handler's
+    `_expected_inputs_bucket` and the agent-run-inputs Terraform bucket name.
+    Defaults to `dev` when ENVIRONMENT is unset, matching the broker's other
+    env-derived bucket names (see main.py); a wrong default only ever rejects
+    a mismatched ref, never widens access.
+    """
+    env = os.environ.get("ENVIRONMENT", "dev").strip().lower()
+    return f"gp-agent-run-inputs-{env}"
+
+
+def _validate_input_files_bucket(request_input_files, run_id: str) -> None:
+    if not request_input_files:
+        return
+    expected_bucket = _expected_inputs_bucket()
+    for ref in request_input_files:
+        if ref.bucket != expected_bucket:
+            logger.warning(
+                "mint_run_token input_file_bucket_rejected run_id=%s bucket=%r expected=%r",
+                run_id,
+                ref.bucket,
+                expected_bucket,
+            )
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"input_files bucket {ref.bucket!r} not allowed; "
+                    f"only {expected_bucket!r} may be referenced for this run"
+                ),
+            )
+
+
 def get_ticket_store():
     raise NotImplementedError("must be overridden via dependency_overrides")  # pragma: no cover
 
@@ -87,6 +125,8 @@ async def mint_run_token(
             getattr(request, "experiment_id", "unknown"),
         )
         raise HTTPException(status_code=401, detail="Invalid service token")
+
+    _validate_input_files_bucket(request.input_files, request.run_id)
 
     broker_token = str(uuid.uuid4())
     now = int(time.time())

--- a/broker/endpoints/mint_run_token.py
+++ b/broker/endpoints/mint_run_token.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 from broker.auth import get_service_token, verify_service_token
 from broker.dynamodb_client import (
+    InputFileRef,
     ScopeTicket,
     ScopeTicketStore,
     TicketAlreadyExistsError,
@@ -49,6 +50,13 @@ class MintRequest(BaseModel):
     # dispatched against, preserving the STALE invariant for any experiment
     # with downstream dependencies.
     prior_artifact_versions: dict[str, str] | None = None
+    # Optional — enumerated S3 refs the runner is authorized to pre-fetch on
+    # behalf of the agent (e.g. user-uploaded agenda PDFs). Each entry is a
+    # {bucket, key, dest} ref; /inputs/read enforces exact (bucket, key) match
+    # against this list. Refs travel through gp-api's dispatch and dispatch
+    # handler strips the `_input_files` envelope key from params before
+    # validating against the manifest input_schema.
+    input_files: list[InputFileRef] | None = None
 
 
 class MintResponse(BaseModel):
@@ -137,6 +145,7 @@ async def mint_run_token(
         issued_by="dispatch_lambda",
         prior_artifact_versions=request.prior_artifact_versions,
         clerk_user_id=request.clerk_user_id,
+        input_files=request.input_files,
     )
 
     try:

--- a/broker/main.py
+++ b/broker/main.py
@@ -46,6 +46,11 @@ from broker.endpoints.artifact_read import (
     get_scope_ticket as read_get_scope_ticket,
     router as read_router,
 )
+from broker.endpoints.inputs_read import (
+    get_s3_client as inputs_get_s3_client,
+    get_scope_ticket as inputs_get_scope_ticket,
+    router as inputs_router,
+)
 from broker.endpoints.databricks_query import (
     get_data_query_tracker as dbx_get_data_query_tracker,
     get_databricks_client as dbx_get_databricks_client,
@@ -191,6 +196,9 @@ async def lifespan(app: FastAPI):
     app.dependency_overrides[read_get_s3_client] = lambda: s3_client
     app.dependency_overrides[read_get_artifact_bucket] = lambda: artifact_bucket
 
+    app.dependency_overrides[inputs_get_scope_ticket] = _resolve_ticket_from_request
+    app.dependency_overrides[inputs_get_s3_client] = lambda: s3_client
+
     app.dependency_overrides[status_get_scope_ticket] = _resolve_ticket_from_request
     app.dependency_overrides[status_get_s3_client] = lambda: s3_client
     app.dependency_overrides[status_get_callback_sender] = lambda: callback_sender
@@ -258,6 +266,7 @@ app.include_router(anthropic_router)
 app.include_router(braintrust_router)
 app.include_router(publish_router)
 app.include_router(read_router)
+app.include_router(inputs_router)
 app.include_router(status_router)
 app.include_router(databricks_router)
 app.include_router(upload_router)

--- a/broker/tests/test_dynamodb_client.py
+++ b/broker/tests/test_dynamodb_client.py
@@ -6,6 +6,7 @@ import pytest
 from moto import mock_aws
 
 from broker.dynamodb_client import (
+    InputFileRef,
     ScopeTicket,
     ScopeTicketStore,
     TicketAlreadyExistsError,
@@ -58,6 +59,37 @@ class TestScopeTicketModel:
     def test_prior_artifact_versions_set(self):
         ticket = _make_ticket(prior_artifact_versions={"district_intel": "v2"})
         assert ticket.prior_artifact_versions == {"district_intel": "v2"}
+
+    def test_input_files_optional(self):
+        ticket = _make_ticket()
+        assert ticket.input_files is None
+
+    def test_input_files_set(self):
+        refs = [InputFileRef(bucket="gp-agent-run-inputs-dev", key="u/abc", dest="agenda.pdf")]
+        ticket = _make_ticket(input_files=refs)
+        assert ticket.input_files == refs
+
+
+class TestInputFileRefValidation:
+    def test_dest_rejects_separator(self):
+        with pytest.raises(ValueError):
+            InputFileRef(bucket="b", key="k", dest="sub/file.pdf")
+
+    def test_dest_rejects_parent_ref(self):
+        with pytest.raises(ValueError):
+            InputFileRef(bucket="b", key="k", dest="..")
+
+    def test_dest_rejects_leading_dot(self):
+        with pytest.raises(ValueError):
+            InputFileRef(bucket="b", key="k", dest=".hidden")
+
+    def test_dest_rejects_empty(self):
+        with pytest.raises(ValueError):
+            InputFileRef(bucket="b", key="k", dest="")
+
+    def test_dest_accepts_typical_filename(self):
+        ref = InputFileRef(bucket="b", key="k", dest="agenda.pdf")
+        assert ref.dest == "agenda.pdf"
 
 
 class TestPutAndGetRoundTrip:
@@ -263,3 +295,37 @@ class TestRunIdIdempotency:
             Key={"pk": {"S": "run:run-RETRY"}},
         )
         assert run_lock["Item"]["broker_token"]["S"] == "token-2"
+
+
+class TestInputFilesRoundTrip:
+    def test_input_files_roundtrip_through_dynamodb(self, moto_ddb):
+        store = ScopeTicketStore("scope-tickets", dynamodb_client=moto_ddb)
+        refs = [
+            InputFileRef(
+                bucket="gp-agent-run-inputs-dev",
+                key="uploads/org/abc/agenda.pdf",
+                dest="agenda.pdf",
+            ),
+            InputFileRef(
+                bucket="gp-agent-run-inputs-dev",
+                key="uploads/org/abc/appendix.pdf",
+                dest="appendix.pdf",
+            ),
+        ]
+        ticket = _make_ticket(pk="token-if", run_id="run-IF", input_files=refs)
+
+        store.put_ticket(ticket)
+
+        result = store.get_ticket("token-if")
+        assert result is not None
+        assert result.input_files == refs
+
+    def test_input_files_absent_roundtrip(self, moto_ddb):
+        store = ScopeTicketStore("scope-tickets", dynamodb_client=moto_ddb)
+        ticket = _make_ticket(pk="token-noif", run_id="run-NOIF")
+
+        store.put_ticket(ticket)
+
+        result = store.get_ticket("token-noif")
+        assert result is not None
+        assert result.input_files is None

--- a/broker/tests/test_inputs_read.py
+++ b/broker/tests/test_inputs_read.py
@@ -1,0 +1,322 @@
+import time
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from broker.dynamodb_client import InputFileRef, ScopeTicket
+from broker.endpoints.inputs_read import (
+    MAX_INPUT_BYTES,
+    get_s3_client,
+    get_scope_ticket,
+    router,
+)
+
+BROKER_TOKEN = "broker-token-test-abc123"
+INPUT_BUCKET = "gp-agent-run-inputs-dev"
+INPUT_KEY = "uploads/org-42/run-001/agenda.pdf"
+
+
+def _make_ticket(input_files: list[InputFileRef] | None = None) -> ScopeTicket:
+    now = int(time.time())
+    return ScopeTicket(
+        pk=BROKER_TOKEN,
+        run_id="run-001",
+        organization_slug="org-42",
+        experiment_id="meeting_briefing",
+        scope={},
+        params={},
+        exp=now + 3600,
+        issued_at=now,
+        issued_by="dispatch-lambda-dev",
+        input_files=input_files,
+    )
+
+
+def _make_s3_response(body_bytes: bytes, content_length: int | None = None) -> dict:
+    body = MagicMock()
+    body.read.return_value = body_bytes
+    resp = {"Body": body}
+    if content_length is not None:
+        resp["ContentLength"] = content_length
+    return resp
+
+
+def _create_app(
+    ticket: ScopeTicket | None = None,
+    s3_response: dict | None = None,
+    s3_error: Exception | None = None,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+
+    _ticket = ticket or _make_ticket(
+        input_files=[
+            InputFileRef(bucket=INPUT_BUCKET, key=INPUT_KEY, dest="agenda.pdf")
+        ]
+    )
+    app.dependency_overrides[get_scope_ticket] = lambda: _ticket
+
+    mock_s3 = MagicMock()
+    if s3_error:
+        mock_s3.get_object.side_effect = s3_error
+    elif s3_response:
+        mock_s3.get_object.return_value = s3_response
+    else:
+        mock_s3.get_object.return_value = _make_s3_response(
+            b"%PDF-1.4 dummy content", content_length=22
+        )
+    app.dependency_overrides[get_s3_client] = lambda: mock_s3
+
+    return app
+
+
+class TestInputsReadSuccess:
+    def test_returns_bytes_for_authorized_ref(self):
+        body_bytes = b"%PDF-1.4 fake agenda body"
+        app = _create_app(
+            s3_response=_make_s3_response(body_bytes, content_length=len(body_bytes))
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/inputs/read",
+            json={"bucket": INPUT_BUCKET, "key": INPUT_KEY},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 200
+        assert resp.content == body_bytes
+        assert resp.headers["content-type"] == "application/octet-stream"
+
+    def test_get_object_called_with_request_bucket_and_key(self):
+        app = _create_app()
+        from broker.endpoints import inputs_read as mod
+
+        mock_s3 = app.dependency_overrides[mod.get_s3_client]()
+        client = TestClient(app)
+
+        client.post(
+            "/inputs/read",
+            json={"bucket": INPUT_BUCKET, "key": INPUT_KEY},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        mock_s3.get_object.assert_called_once_with(Bucket=INPUT_BUCKET, Key=INPUT_KEY)
+
+
+class TestInputsReadAuth:
+    def test_ticket_without_input_files_returns_403(self):
+        ticket = _make_ticket(input_files=None)
+        app = _create_app(ticket=ticket)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/inputs/read",
+            json={"bucket": INPUT_BUCKET, "key": INPUT_KEY},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 403
+        assert "no input files authorized" in resp.json()["detail"].lower()
+
+    def test_ticket_with_empty_input_files_returns_403(self):
+        ticket = _make_ticket(input_files=[])
+        app = _create_app(ticket=ticket)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/inputs/read",
+            json={"bucket": INPUT_BUCKET, "key": INPUT_KEY},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 403
+
+    def test_wrong_bucket_returns_403(self):
+        ticket = _make_ticket(
+            input_files=[
+                InputFileRef(bucket=INPUT_BUCKET, key=INPUT_KEY, dest="agenda.pdf")
+            ]
+        )
+        app = _create_app(ticket=ticket)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/inputs/read",
+            json={"bucket": "some-other-bucket", "key": INPUT_KEY},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 403
+
+    def test_wrong_key_returns_403(self):
+        ticket = _make_ticket(
+            input_files=[
+                InputFileRef(bucket=INPUT_BUCKET, key=INPUT_KEY, dest="agenda.pdf")
+            ]
+        )
+        app = _create_app(ticket=ticket)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/inputs/read",
+            json={
+                "bucket": INPUT_BUCKET,
+                "key": "uploads/other-org/other-run/agenda.pdf",
+            },
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 403
+
+    def test_does_not_call_s3_when_unauthorized(self):
+        ticket = _make_ticket(input_files=None)
+        app = _create_app(ticket=ticket)
+        from broker.endpoints import inputs_read as mod
+
+        mock_s3 = app.dependency_overrides[mod.get_s3_client]()
+        client = TestClient(app)
+
+        client.post(
+            "/inputs/read",
+            json={"bucket": INPUT_BUCKET, "key": INPUT_KEY},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        mock_s3.get_object.assert_not_called()
+
+
+class TestInputsReadS3Errors:
+    def test_s3_not_found_returns_404(self):
+        from botocore.exceptions import ClientError
+
+        error = ClientError(
+            {"Error": {"Code": "NoSuchKey", "Message": "Not found"}},
+            "GetObject",
+        )
+        app = _create_app(s3_error=error)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/inputs/read",
+            json={"bucket": INPUT_BUCKET, "key": INPUT_KEY},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 404
+
+    def test_other_s3_error_returns_500(self):
+        from botocore.exceptions import ClientError
+
+        error = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+            "GetObject",
+        )
+        app = _create_app(s3_error=error)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/inputs/read",
+            json={"bucket": INPUT_BUCKET, "key": INPUT_KEY},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 500
+
+    def test_non_404_s3_error_is_logged(self, caplog):
+        import logging
+
+        from botocore.exceptions import ClientError
+
+        error = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+            "GetObject",
+        )
+        app = _create_app(s3_error=error)
+        client = TestClient(app)
+
+        with caplog.at_level(logging.ERROR, logger="broker.endpoints.inputs_read"):
+            resp = client.post(
+                "/inputs/read",
+                json={"bucket": INPUT_BUCKET, "key": INPUT_KEY},
+                headers={"X-Broker-Token": BROKER_TOKEN},
+            )
+
+        assert resp.status_code == 500
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records, "expected ERROR log for non-404 S3 failure"
+        assert any("run-001" in r.getMessage() for r in error_records)
+
+
+class TestInputsReadSizeCap:
+    def test_content_length_above_cap_returns_413_without_reading(self):
+        oversize = MAX_INPUT_BYTES + 1
+        # Body read should never be called when ContentLength tripwires the cap.
+        body = MagicMock()
+        body.read.side_effect = AssertionError("should not be read when oversize")
+        app = _create_app(
+            s3_response={"Body": body, "ContentLength": oversize}
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/inputs/read",
+            json={"bucket": INPUT_BUCKET, "key": INPUT_KEY},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 413
+
+    def test_body_length_above_cap_returns_413_when_content_length_absent(self):
+        oversize_body = b"x" * (MAX_INPUT_BYTES + 1)
+        app = _create_app(
+            s3_response=_make_s3_response(oversize_body, content_length=None)
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/inputs/read",
+            json={"bucket": INPUT_BUCKET, "key": INPUT_KEY},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 413
+
+
+class TestInputsReadRequestValidation:
+    def test_rejects_missing_bucket(self):
+        app = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/inputs/read",
+            json={"key": INPUT_KEY},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 422
+
+    def test_rejects_empty_bucket(self):
+        app = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/inputs/read",
+            json={"bucket": "", "key": INPUT_KEY},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 422
+
+    def test_rejects_empty_key(self):
+        app = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/inputs/read",
+            json={"bucket": INPUT_BUCKET, "key": ""},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+
+        assert resp.status_code == 422

--- a/broker/tests/test_mint_run_token.py
+++ b/broker/tests/test_mint_run_token.py
@@ -425,16 +425,65 @@ class TestMintRunTokenInputFiles:
 
         resp = client.post(
             "/internal/mint-run-token",
-            json=_mint_payload(
-                input_files=[
-                    {"bucket": "b", "key": "k", "dest": "../etc/passwd"}
-                ]
-            ),
+            json=_mint_payload(input_files=[{"bucket": "b", "key": "k", "dest": "../etc/passwd"}]),
             headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
         )
 
         assert resp.status_code == 422
         store.put_ticket.assert_not_called()
+
+    def test_input_files_rejects_foreign_bucket(self, monkeypatch):
+        """The broker task role can GetObject on the artifact and metadata
+        buckets too, so a ticket must only ever authorize the env's own inputs
+        bucket. A ref naming any other bucket is rejected at mint so it can
+        never reach /inputs/read.
+        """
+        monkeypatch.setenv("ENVIRONMENT", "dev")
+        store = MagicMock(spec=ScopeTicketStore)
+        app = _create_test_app(store=store)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/internal/mint-run-token",
+            json=_mint_payload(
+                input_files=[
+                    {
+                        "bucket": "gp-agent-artifacts-dev",
+                        "key": "other-org/run-9/artifact.json",
+                        "dest": "agenda.pdf",
+                    }
+                ]
+            ),
+            headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
+        )
+
+        assert resp.status_code == 400
+        assert "bucket" in resp.json()["detail"].lower()
+        store.put_ticket.assert_not_called()
+
+    def test_input_files_honors_environment_bucket(self, monkeypatch):
+        """A ref naming the env's own inputs bucket passes the gate."""
+        monkeypatch.setenv("ENVIRONMENT", "qa")
+        store = MagicMock(spec=ScopeTicketStore)
+        app = _create_test_app(store=store)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/internal/mint-run-token",
+            json=_mint_payload(
+                input_files=[
+                    {
+                        "bucket": "gp-agent-run-inputs-qa",
+                        "key": "uploads/org/abc/agenda.pdf",
+                        "dest": "agenda.pdf",
+                    }
+                ]
+            ),
+            headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
+        )
+
+        assert resp.status_code == 200
+        store.put_ticket.assert_called_once()
 
 
 class TestMintRunTokenClerkUserIdOnTicket:

--- a/broker/tests/test_mint_run_token.py
+++ b/broker/tests/test_mint_run_token.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from broker.auth import hash_service_token
 from broker.dynamodb_client import (
+    InputFileRef,
     ScopeTicket,
     ScopeTicketStore,
     TicketAlreadyExistsError,
@@ -364,6 +365,76 @@ class TestMintRunTokenPriorArtifactVersions:
         assert resp.status_code == 200
         ticket: ScopeTicket = store.put_ticket.call_args[0][0]
         assert ticket.prior_artifact_versions is None
+
+
+class TestMintRunTokenInputFiles:
+    """User-uploaded inputs (e.g. agenda PDFs) flow as enumerated S3 refs:
+    dispatch supplies `input_files` on mint; the ticket persists the list so
+    /inputs/read can enforce that the runner only fetches refs gp-api
+    authorized for this run.
+    """
+
+    def test_input_files_roundtrips_to_ticket(self):
+        store = MagicMock(spec=ScopeTicketStore)
+        app = _create_test_app(store=store)
+        client = TestClient(app)
+
+        refs = [
+            {
+                "bucket": "gp-agent-run-inputs-dev",
+                "key": "uploads/org/abc/agenda.pdf",
+                "dest": "agenda.pdf",
+            }
+        ]
+        resp = client.post(
+            "/internal/mint-run-token",
+            json=_mint_payload(input_files=refs),
+            headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
+        )
+
+        assert resp.status_code == 200
+        store.put_ticket.assert_called_once()
+        ticket: ScopeTicket = store.put_ticket.call_args[0][0]
+        assert ticket.input_files == [
+            InputFileRef(
+                bucket="gp-agent-run-inputs-dev",
+                key="uploads/org/abc/agenda.pdf",
+                dest="agenda.pdf",
+            )
+        ]
+
+    def test_input_files_optional(self):
+        store = MagicMock(spec=ScopeTicketStore)
+        app = _create_test_app(store=store)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/internal/mint-run-token",
+            json=_mint_payload(),
+            headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
+        )
+
+        assert resp.status_code == 200
+        ticket: ScopeTicket = store.put_ticket.call_args[0][0]
+        assert ticket.input_files is None
+
+    def test_input_files_rejects_unsafe_dest(self):
+        store = MagicMock(spec=ScopeTicketStore)
+        app = _create_test_app(store=store)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/internal/mint-run-token",
+            json=_mint_payload(
+                input_files=[
+                    {"bucket": "b", "key": "k", "dest": "../etc/passwd"}
+                ]
+            ),
+            headers={"Authorization": f"Bearer {SERVICE_TOKEN}"},
+        )
+
+        assert resp.status_code == 422
+        store.put_ticket.assert_not_called()
 
 
 class TestMintRunTokenClerkUserIdOnTicket:

--- a/infrastructure/environments/dev/agent-run-inputs/.terraform.lock.hcl
+++ b/infrastructure/environments/dev/agent-run-inputs/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/environments/dev/agent-run-inputs/main.tf
+++ b/infrastructure/environments/dev/agent-run-inputs/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "agent-run-inputs/dev/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "agent_run_inputs" {
+  source = "../../../modules/agent-run-inputs"
+
+  environment = "dev"
+}
+
+output "bucket_name" {
+  value = module.agent_run_inputs.bucket_name
+}
+
+output "bucket_arn" {
+  value = module.agent_run_inputs.bucket_arn
+}
+
+output "read_policy_arn" {
+  value = module.agent_run_inputs.read_policy_arn
+}

--- a/infrastructure/environments/dev/broker/main.tf
+++ b/infrastructure/environments/dev/broker/main.tf
@@ -21,6 +21,17 @@ provider "aws" {
   region = "us-west-2"
 }
 
+# Bootstrap toggle for the agent_run_inputs cross-stack lookup. Lets a fresh
+# dev environment plan/apply this stack before agent-run-inputs/dev exists,
+# matching the pattern qa and prod use. Other cross-stack lookups in this
+# file (fargate, control_plane, agent_experiment_metadata) predate this
+# variable; tightening them similarly is out of scope here.
+variable "bootstrap_agent_run_inputs" {
+  type        = bool
+  default     = false
+  description = "Skip the agent_run_inputs remote_state lookup so plan succeeds before that stack exists. The broker module's count-guarded attachment leaves the IAM grant unset until the variable flips back to false on the second apply."
+}
+
 data "terraform_remote_state" "fargate" {
   backend = "s3"
   config = {
@@ -57,6 +68,8 @@ data "terraform_remote_state" "agent_experiment_metadata" {
 }
 
 data "terraform_remote_state" "agent_run_inputs" {
+  count = var.bootstrap_agent_run_inputs ? 0 : 1
+
   backend = "s3"
   config = {
     bucket = "goodparty-terraform-state-us-west-2"
@@ -111,7 +124,7 @@ module "broker" {
 
   sns_topic_arn = try(data.terraform_remote_state.fargate.outputs.sns_topic_arn, "")
 
-  agent_run_inputs_read_policy_arn = data.terraform_remote_state.agent_run_inputs.outputs.read_policy_arn
+  agent_run_inputs_read_policy_arn = try(data.terraform_remote_state.agent_run_inputs[0].outputs.read_policy_arn, "")
 }
 
 output "security_group_id" {

--- a/infrastructure/environments/dev/broker/main.tf
+++ b/infrastructure/environments/dev/broker/main.tf
@@ -56,6 +56,15 @@ data "terraform_remote_state" "agent_experiment_metadata" {
   }
 }
 
+data "terraform_remote_state" "agent_run_inputs" {
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "agent-run-inputs/dev/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
 resource "aws_secretsmanager_secret" "service_tokens" {
   name        = "broker-service-tokens-dev"
   description = "Plaintext SERVICE_TOKEN used by the dispatch Lambda to call broker /internal/mint-run-token. Hash lives in broker-dev."
@@ -101,6 +110,8 @@ module "broker" {
   gp_api_sqs_queue_arn = data.aws_sqs_queue.results.arn
 
   sns_topic_arn = try(data.terraform_remote_state.fargate.outputs.sns_topic_arn, "")
+
+  agent_run_inputs_read_policy_arn = data.terraform_remote_state.agent_run_inputs.outputs.read_policy_arn
 }
 
 output "security_group_id" {

--- a/infrastructure/environments/dev/broker/main.tf
+++ b/infrastructure/environments/dev/broker/main.tf
@@ -21,15 +21,17 @@ provider "aws" {
   region = "us-west-2"
 }
 
-# Bootstrap toggle for the agent_run_inputs cross-stack lookup. Lets a fresh
-# dev environment plan/apply this stack before agent-run-inputs/dev exists,
-# matching the pattern qa and prod use. Other cross-stack lookups in this
-# file (fargate, control_plane, agent_experiment_metadata) predate this
-# variable; tightening them similarly is out of scope here.
-variable "bootstrap_agent_run_inputs" {
+# Bootstrap toggle, named to match qa/prod so operators use one procedure
+# (`-var bootstrap=true` on first apply, then false) across every environment.
+# On qa/prod `bootstrap` guards the whole stack because a fresh env has nothing
+# yet; on dev everything else already exists, so the only thing left to guard
+# is the agent_run_inputs cross-stack lookup. Same flag, same intent — it just
+# has less to guard here. Other dev lookups (fargate, control_plane,
+# agent_experiment_metadata) predate this and aren't bootstrap-gated.
+variable "bootstrap" {
   type        = bool
   default     = false
-  description = "Skip the agent_run_inputs remote_state lookup so plan succeeds before that stack exists. The broker module's count-guarded attachment leaves the IAM grant unset until the variable flips back to false on the second apply."
+  description = "Skip the agent_run_inputs remote_state lookup so plan succeeds before that stack exists. Mirrors the qa/prod bootstrap flag; on dev it gates only this lookup (the rest of the stack is already applied). The broker module's count-guarded attachment leaves the IAM grant unset until the variable flips back to false on the second apply."
 }
 
 data "terraform_remote_state" "fargate" {
@@ -68,7 +70,7 @@ data "terraform_remote_state" "agent_experiment_metadata" {
 }
 
 data "terraform_remote_state" "agent_run_inputs" {
-  count = var.bootstrap_agent_run_inputs ? 0 : 1
+  count = var.bootstrap ? 0 : 1
 
   backend = "s3"
   config = {

--- a/infrastructure/environments/prod/agent-run-inputs/.terraform.lock.hcl
+++ b/infrastructure/environments/prod/agent-run-inputs/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/environments/prod/agent-run-inputs/main.tf
+++ b/infrastructure/environments/prod/agent-run-inputs/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "agent-run-inputs/prod/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "agent_run_inputs" {
+  source = "../../../modules/agent-run-inputs"
+
+  environment = "prod"
+}
+
+output "bucket_name" {
+  value = module.agent_run_inputs.bucket_name
+}
+
+output "bucket_arn" {
+  value = module.agent_run_inputs.bucket_arn
+}
+
+output "read_policy_arn" {
+  value = module.agent_run_inputs.read_policy_arn
+}

--- a/infrastructure/environments/prod/broker/main.tf
+++ b/infrastructure/environments/prod/broker/main.tf
@@ -70,6 +70,17 @@ data "terraform_remote_state" "agent_experiment_metadata" {
   }
 }
 
+data "terraform_remote_state" "agent_run_inputs" {
+  count = var.bootstrap ? 0 : 1
+
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "agent-run-inputs/prod/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
 resource "aws_secretsmanager_secret" "service_tokens" {
   name        = "broker-service-tokens-prod"
   description = "Plaintext SERVICE_TOKEN used by the dispatch Lambda to call broker /internal/mint-run-token. Hash lives in broker-prod."
@@ -116,6 +127,8 @@ module "broker" {
   gp_api_sqs_queue_arn = data.aws_sqs_queue.results[0].arn
 
   sns_topic_arn = try(data.terraform_remote_state.fargate[0].outputs.sns_topic_arn, "")
+
+  agent_run_inputs_read_policy_arn = try(data.terraform_remote_state.agent_run_inputs[0].outputs.read_policy_arn, "")
 }
 
 output "security_group_id" {

--- a/infrastructure/environments/qa/agent-run-inputs/.terraform.lock.hcl
+++ b/infrastructure/environments/qa/agent-run-inputs/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/environments/qa/agent-run-inputs/main.tf
+++ b/infrastructure/environments/qa/agent-run-inputs/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "agent-run-inputs/qa/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "agent_run_inputs" {
+  source = "../../../modules/agent-run-inputs"
+
+  environment = "qa"
+}
+
+output "bucket_name" {
+  value = module.agent_run_inputs.bucket_name
+}
+
+output "bucket_arn" {
+  value = module.agent_run_inputs.bucket_arn
+}
+
+output "read_policy_arn" {
+  value = module.agent_run_inputs.read_policy_arn
+}

--- a/infrastructure/environments/qa/broker/main.tf
+++ b/infrastructure/environments/qa/broker/main.tf
@@ -70,6 +70,17 @@ data "terraform_remote_state" "agent_experiment_metadata" {
   }
 }
 
+data "terraform_remote_state" "agent_run_inputs" {
+  count = var.bootstrap ? 0 : 1
+
+  backend = "s3"
+  config = {
+    bucket = "goodparty-terraform-state-us-west-2"
+    key    = "agent-run-inputs/qa/terraform.tfstate"
+    region = "us-west-2"
+  }
+}
+
 resource "aws_secretsmanager_secret" "service_tokens" {
   name        = "broker-service-tokens-qa"
   description = "Plaintext SERVICE_TOKEN used by the dispatch Lambda to call broker /internal/mint-run-token. Hash lives in broker-qa."
@@ -113,6 +124,8 @@ module "broker" {
   gp_api_sqs_queue_arn = data.aws_sqs_queue.results[0].arn
 
   sns_topic_arn = try(data.terraform_remote_state.fargate[0].outputs.sns_topic_arn, "")
+
+  agent_run_inputs_read_policy_arn = try(data.terraform_remote_state.agent_run_inputs[0].outputs.read_policy_arn, "")
 }
 
 output "security_group_id" {

--- a/infrastructure/modules/agent-run-inputs/main.tf
+++ b/infrastructure/modules/agent-run-inputs/main.tf
@@ -1,0 +1,168 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+variable "environment" {
+  description = "Environment name (dev, qa, prod). Drives bucket name and CORS allowed-origin list."
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "qa", "prod"], var.environment)
+    error_message = "environment must be one of: dev, qa, prod"
+  }
+}
+
+locals {
+  bucket_name      = "gp-agent-run-inputs-${var.environment}"
+  read_policy_name = "AgentRunInputsRead-${var.environment}"
+
+  # Browser PUT origins per environment. Env-isolated by design — dev does NOT
+  # accept uploads from qa hostnames and vice versa. This diverges from the
+  # gp-api Pulumi browser-upload buckets (annotation-attachments, assets) which
+  # all share an older cross-env allowlist; align those separately if desired.
+  cors_allowed_origins = {
+    dev = [
+      "http://localhost:4000",
+      "https://dev.goodparty.org",
+    ]
+    qa = [
+      "http://localhost:4000",
+      "https://gp-ui-git-qa-good-party.vercel.app",
+      "https://qa.goodparty.org",
+    ]
+    prod = [
+      "https://goodparty.org",
+    ]
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Inputs bucket
+# Holds user-supplied files consumed by agent experiment runs (first use:
+# meeting-briefing agenda PDFs uploaded from /briefings). gp-api issues
+# presigned PUTs for browser uploads; the broker reads at runtime via
+# /inputs/read (auth gated by ScopeTicket.input_files allowlist).
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "inputs" {
+  bucket        = local.bucket_name
+  force_destroy = false
+
+  tags = {
+    Name        = local.bucket_name
+    Environment = var.environment
+    ManagedBy   = "terraform"
+    Purpose     = "User-uploaded files consumed by agent runs (e.g. meeting-briefing agenda PDFs)"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "inputs" {
+  bucket = aws_s3_bucket.inputs.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "inputs" {
+  bucket = aws_s3_bucket.inputs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "inputs" {
+  bucket = aws_s3_bucket.inputs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Current versions retained indefinitely (audit + re-run support); noncurrent
+# versions expire after 30 days to bound storage cost from re-uploads.
+resource "aws_s3_bucket_lifecycle_configuration" "inputs" {
+  bucket = aws_s3_bucket.inputs.id
+
+  rule {
+    id     = "expire-noncurrent-versions"
+    status = "Enabled"
+
+    filter {}
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
+# Browser PUTs directly to S3 via the presigned URL gp-api returns. Allowed
+# origins are scoped per environment to match the gp-webapp deployment.
+resource "aws_s3_bucket_cors_configuration" "inputs" {
+  bucket = aws_s3_bucket.inputs.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT"]
+    allowed_origins = local.cors_allowed_origins[var.environment]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3600
+  }
+}
+
+# ---------------------------------------------------------------------------
+# IAM: managed policy for read access. The broker module attaches this via
+# remote_state lookup of `read_policy_arn`. Mirrors the agent-experiment-
+# metadata pattern so future stacks that need to read this bucket attach the
+# same policy rather than each rebuilding it inline.
+#
+# GetObject only — explicit, no ListBucket. The /inputs/read endpoint always
+# fetches an exact key authorized by the ScopeTicket; nothing in the agent
+# flow ever enumerates the bucket.
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_policy" "inputs_read" {
+  name        = local.read_policy_name
+  description = "Read access to ${local.bucket_name} (user-uploaded files consumed by agent runs). Attach to runtime task roles that fetch via broker /inputs/read."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = ["${aws_s3_bucket.inputs.arn}/*"]
+      }
+    ]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+
+output "bucket_name" {
+  description = "Name of the inputs bucket (e.g. gp-agent-run-inputs-dev)."
+  value       = aws_s3_bucket.inputs.bucket
+}
+
+output "bucket_arn" {
+  description = "ARN of the inputs bucket."
+  value       = aws_s3_bucket.inputs.arn
+}
+
+output "read_policy_arn" {
+  description = "Managed IAM policy ARN granting GetObject on the inputs bucket. Attach to: broker task role (for /inputs/read). Add other consumers here as they appear."
+  value       = aws_iam_policy.inputs_read.arn
+}

--- a/infrastructure/modules/agent-run-inputs/main.tf
+++ b/infrastructure/modules/agent-run-inputs/main.tf
@@ -39,6 +39,7 @@ locals {
     ]
     prod = [
       "https://goodparty.org",
+      "https://www.goodparty.org",
     ]
   }
 }

--- a/infrastructure/modules/broker/main.tf
+++ b/infrastructure/modules/broker/main.tf
@@ -95,6 +95,12 @@ variable "hostname" {
   default     = ""
 }
 
+variable "agent_run_inputs_read_policy_arn" {
+  description = "ARN of the managed IAM policy granting GetObject on the agent-run-inputs bucket (sourced from the agent-run-inputs Terraform stack's read_policy_arn output). Attached to the broker task role so /inputs/read can fetch user-uploaded files on the runner's behalf. Empty string skips the attachment entirely (local-dev / pre-bucket bootstrap)."
+  type        = string
+  default     = ""
+}
+
 locals {
   broker_hostname = var.hostname != "" ? var.hostname : (
     var.environment == "prod" ? "broker.ai.goodparty.org" : "broker-${var.environment}.ai.goodparty.org"
@@ -271,6 +277,17 @@ resource "aws_iam_role_policy" "task_s3" {
       }
     ]
   })
+}
+
+# Read-only access to the agent-run-inputs bucket (one per environment). The
+# managed policy is owned by the agent-run-inputs Terraform stack; we attach
+# it here so the broker task role gains GetObject on the bucket. /inputs/read
+# enforces per-request authorization against the ScopeTicket's enumerated
+# input_files list — this attachment is just the underlying AWS grant.
+resource "aws_iam_role_policy_attachment" "task_agent_run_inputs_read" {
+  count      = var.agent_run_inputs_read_policy_arn != "" ? 1 : 0
+  role       = aws_iam_role.task_role.name
+  policy_arn = var.agent_run_inputs_read_policy_arn
 }
 
 resource "aws_iam_role_policy_attachment" "task_experiment_metadata_read" {

--- a/pmf_engine/control_plane/broker_client.py
+++ b/pmf_engine/control_plane/broker_client.py
@@ -26,6 +26,7 @@ class BrokerClient:
         clerk_user_id: str | None,
         exp_ttl_seconds: int = 3600,
         prior_artifact_versions: dict[str, str] | None = None,
+        input_files: list[dict] | None = None,
     ) -> dict:
         body = {
             "run_id": run_id,
@@ -36,6 +37,7 @@ class BrokerClient:
             "clerk_user_id": clerk_user_id,
             "exp_ttl_seconds": exp_ttl_seconds,
             "prior_artifact_versions": prior_artifact_versions,
+            "input_files": input_files,
         }
         response = httpx.post(
             f"{self.broker_url}/internal/mint-run-token",

--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -310,6 +310,13 @@ def _missing_critical_config() -> list[str]:
         missing.append("SERVICE_TOKEN")
     if not os.environ.get("EXPERIMENT_METADATA_BUCKET", "").strip():
         missing.append("EXPERIMENT_METADATA_BUCKET")
+    # ENVIRONMENT drives the expected `_input_files` bucket name. Without it,
+    # _validate_input_files raises ValueError on any dispatch carrying user
+    # uploads — surface the misconfig via the standard
+    # "dispatch-misconfig" error-callback path instead of letting the message
+    # dead-letter on an uncaught parse error.
+    if not os.environ.get("ENVIRONMENT", "").strip():
+        missing.append("ENVIRONMENT")
     return missing
 
 

--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -344,11 +344,20 @@ def _validate_prior_artifact_versions(versions) -> None:
 # `{0,254}` after the leading char bounds total length at 255 to match the
 # broker's Pydantic Field max_length.
 _INPUT_FILE_DEST_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9._-]{0,254}$")
-# Path-traversal guard, not S3 DNS validation — S3 enforces real bucket rules.
-_INPUT_FILE_BUCKET_RE = re.compile(r"^[A-Za-z0-9.\-_]{1,255}$")
 _INPUT_FILE_REQUIRED_KEYS = {"bucket", "key", "dest"}
 # Mirrors prior_artifact_versions cap.
 _MAX_INPUT_FILES = 10
+
+
+def _expected_inputs_bucket() -> str:
+    """The single bucket dispatch is allowed to authorize for /inputs/read in
+    this environment. Derived from the ENVIRONMENT env var (`dev`/`qa`/`prod`),
+    matching what gp-ai-projects Terraform creates and what the broker IAM
+    grants GetObject on. Any other bucket name in `_input_files[i].bucket` is
+    rejected — defense in depth atop the broker's ScopeTicket allowlist.
+    """
+    env = os.environ.get("ENVIRONMENT", "").strip().lower()
+    return f"gp-agent-run-inputs-{env}" if env else ""
 
 
 def _validate_input_files(value) -> None:
@@ -357,7 +366,9 @@ def _validate_input_files(value) -> None:
     Parallels `_validate_prior_artifact_versions`. Each entry must carry
     {bucket, key, dest} where `dest` is a safe basename (the runner writes
     `/workspace/input/<dest>`, so a slash or `..` here would escape the
-    workspace despite broker + runner re-checks).
+    workspace despite broker + runner re-checks). `bucket` must equal the
+    single expected inputs bucket for this environment — no caller is
+    legitimately authorized to reference any other bucket.
     """
     if value is None:
         return
@@ -365,6 +376,12 @@ def _validate_input_files(value) -> None:
         raise ValueError(f"_input_files must be an array, got {type(value).__name__}")
     if len(value) > _MAX_INPUT_FILES:
         raise ValueError(f"_input_files too large: {len(value)} entries (max {_MAX_INPUT_FILES})")
+    expected_bucket = _expected_inputs_bucket()
+    if not expected_bucket:
+        raise ValueError(
+            "_input_files cannot be validated: ENVIRONMENT env var missing on dispatch lambda; "
+            "set ENVIRONMENT to one of dev/qa/prod (see modules/pmf-engine-control-plane/main.tf)"
+        )
     for i, entry in enumerate(value):
         if not isinstance(entry, dict):
             raise ValueError(f"_input_files[{i}] must be an object, got {type(entry).__name__}")
@@ -372,9 +389,9 @@ def _validate_input_files(value) -> None:
         if missing:
             raise ValueError(f"_input_files[{i}] missing required keys: {sorted(missing)}")
         bucket, key, dest = entry["bucket"], entry["key"], entry["dest"]
-        if not isinstance(bucket, str) or not _INPUT_FILE_BUCKET_RE.fullmatch(bucket):
+        if not isinstance(bucket, str) or bucket != expected_bucket:
             raise ValueError(
-                f"_input_files[{i}].bucket must match [A-Za-z0-9.\\-_]{{1,255}}: got {bucket!r}"
+                f"_input_files[{i}].bucket must be {expected_bucket!r}: got {bucket!r}"
             )
         if not isinstance(key, str) or not (0 < len(key) <= 1024):
             raise ValueError(f"_input_files[{i}].key must be a 1-1024 char string: got {key!r}")

--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -322,6 +322,16 @@ def _missing_critical_config() -> list[str]:
 
 MAX_PARAMS_JSON_BYTES = 6000
 
+# Cap on the serialized INPUT_FILES_JSON env var the dispatch sets on the
+# Fargate task. AWS ECS RunTask limits the total `containerOverrides[]`
+# environment payload, and our other env vars (PARAMS_JSON, ANTHROPIC_BASE_URL,
+# etc.) already consume budget. With realistic agenda-upload entries
+# (~150–300 bytes each), 4000 bytes covers 10+ entries; with worst-case
+# max-length entries (~1.3 KB each) it covers ~3. Reject larger payloads at
+# dispatch with a clean error callback rather than letting RunTask fail
+# silently on oversize overrides.
+MAX_INPUT_FILES_JSON_BYTES = 4000
+
 _PRIOR_ARTIFACT_VALUE_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}/[A-Za-z0-9_-]{1,64}/artifact\.json$")
 
 
@@ -556,26 +566,41 @@ def handler(event: dict, context) -> dict:
         message_id = record.get("messageId", "unknown")
         body = record.get("body", "")
 
+        # When the Lambda is misconfigured (e.g. ENVIRONMENT unset), the strict
+        # parse below will raise on dispatches that exercise envelope validation
+        # — and that ValueError would otherwise be caught as InvalidDispatchPayload,
+        # masking the underlying misconfig. Check config FIRST and route through
+        # the dispatch-misconfig callback path. A minimal lenient parse extracts
+        # just enough message identity to make the callback useful; the strict
+        # parse below validates the envelope only after config is healthy.
+        if missing_config:
+            try:
+                partial = json.loads(body) if body else {}
+                shallow: dict = partial if isinstance(partial, dict) else {}
+            except (json.JSONDecodeError, TypeError):
+                shallow = {}
+            shallow.setdefault("run_id", "unknown")
+            shallow.setdefault("experiment_type", "_unknown")
+            shallow.setdefault("organization_slug", "unknown")
+            logger.error(
+                f"Dispatch Lambda misconfigured: missing required env vars "
+                f"{missing_config} (run: {shallow['run_id']}). "
+                f"Message will be retried via SQS until operator fixes config."
+            )
+            send_error_callback(
+                shallow,
+                f"Dispatch Lambda misconfigured: missing required env vars {missing_config}",
+                RESULTS_QUEUE_URL,
+                dedup_id=f"dispatch-misconfig-{shallow['run_id']}",
+            )
+            batch_item_failures.append({"itemIdentifier": message_id})
+            continue
+
         try:
             message = parse_dispatch_message(body)
         except ValueError as e:
             logger.error(f"Invalid message {message_id}: {e}")
             emit_dispatch_metric("InvalidDispatchPayload", "_unknown")
-            batch_item_failures.append({"itemIdentifier": message_id})
-            continue
-
-        if missing_config:
-            logger.error(
-                f"Dispatch Lambda misconfigured: missing required env vars "
-                f"{missing_config} (run: {message['run_id']}). "
-                f"Message will be retried via SQS until operator fixes config."
-            )
-            send_error_callback(
-                message,
-                f"Dispatch Lambda misconfigured: missing required env vars {missing_config}",
-                RESULTS_QUEUE_URL,
-                dedup_id=f"dispatch-misconfig-{message['run_id']}",
-            )
             batch_item_failures.append({"itemIdentifier": message_id})
             continue
 
@@ -653,6 +678,27 @@ def handler(event: dict, context) -> dict:
             if not sent:
                 batch_item_failures.append({"itemIdentifier": message_id})
             continue
+
+        if message.get("_input_files"):
+            input_files_json = json.dumps(message["_input_files"])
+            input_files_bytes = len(input_files_json.encode("utf-8"))
+            if input_files_bytes > MAX_INPUT_FILES_JSON_BYTES:
+                logger.error(
+                    f"_input_files too large for {experiment_id} "
+                    f"(run: {message['run_id']}, organization: {message['organization_slug']}): "
+                    f"{input_files_bytes} bytes > {MAX_INPUT_FILES_JSON_BYTES}"
+                )
+                emit_dispatch_metric("InputFilesJsonTooLarge", experiment_id)
+                sent = send_error_callback(
+                    message,
+                    f"_input_files serialized size exceeds limit "
+                    f"({input_files_bytes} > {MAX_INPUT_FILES_JSON_BYTES} bytes)",
+                    RESULTS_QUEUE_URL,
+                    dedup_id=f"input-files-too-large-{message['run_id']}",
+                )
+                if not sent:
+                    batch_item_failures.append({"itemIdentifier": message_id})
+                continue
 
         # Validate the dispatch message's params against the manifest's
         # input_schema (JSON Schema Draft-07). The meta-schema makes

--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -339,6 +339,60 @@ def _validate_prior_artifact_versions(versions) -> None:
             )
 
 
+# Mirrored in broker InputFileRef.dest and runner input_files._DEST_RE —
+# three-gate defense since `dest` becomes a basename under /workspace/input/.
+# `{0,254}` after the leading char bounds total length at 255 to match the
+# broker's Pydantic Field max_length.
+_INPUT_FILE_DEST_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9._-]{0,254}$")
+# Path-traversal guard, not S3 DNS validation — S3 enforces real bucket rules.
+_INPUT_FILE_BUCKET_RE = re.compile(r"^[A-Za-z0-9.\-_]{1,255}$")
+_INPUT_FILE_REQUIRED_KEYS = {"bucket", "key", "dest"}
+# Mirrors prior_artifact_versions cap.
+_MAX_INPUT_FILES = 10
+
+
+def _validate_input_files(value) -> None:
+    """Validate the shape of `_input_files` before it reaches mint / Fargate.
+
+    Parallels `_validate_prior_artifact_versions`. Each entry must carry
+    {bucket, key, dest} where `dest` is a safe basename (the runner writes
+    `/workspace/input/<dest>`, so a slash or `..` here would escape the
+    workspace despite broker + runner re-checks).
+    """
+    if value is None:
+        return
+    if not isinstance(value, list):
+        raise ValueError(f"_input_files must be an array, got {type(value).__name__}")
+    if len(value) > _MAX_INPUT_FILES:
+        raise ValueError(f"_input_files too large: {len(value)} entries (max {_MAX_INPUT_FILES})")
+    for i, entry in enumerate(value):
+        if not isinstance(entry, dict):
+            raise ValueError(f"_input_files[{i}] must be an object, got {type(entry).__name__}")
+        missing = _INPUT_FILE_REQUIRED_KEYS - set(entry.keys())
+        if missing:
+            raise ValueError(f"_input_files[{i}] missing required keys: {sorted(missing)}")
+        bucket, key, dest = entry["bucket"], entry["key"], entry["dest"]
+        if not isinstance(bucket, str) or not _INPUT_FILE_BUCKET_RE.fullmatch(bucket):
+            raise ValueError(
+                f"_input_files[{i}].bucket must match [A-Za-z0-9.\\-_]{{1,255}}: got {bucket!r}"
+            )
+        if not isinstance(key, str) or not (0 < len(key) <= 1024):
+            raise ValueError(f"_input_files[{i}].key must be a 1-1024 char string: got {key!r}")
+        if not isinstance(dest, str) or not _INPUT_FILE_DEST_RE.fullmatch(dest):
+            raise ValueError(
+                f"_input_files[{i}].dest must be a simple filename "
+                f"matching [A-Za-z0-9_][A-Za-z0-9._-]*: got {dest!r}"
+            )
+
+
+# Dispatch-envelope metadata that ships inside params. The `_` prefix marks
+# a key as runner-orchestration, not agent input: stripped from params before
+# input_schema validation and before PARAMS_JSON is built, then re-attached
+# to the top-level message for downstream code. Unknown `_`-prefixed keys
+# raise so typos don't silently vanish.
+_RESERVED_ENVELOPE_KEYS = {"_input_files"}
+
+
 def parse_dispatch_message(body: str) -> dict:
     try:
         data = json.loads(body)
@@ -363,6 +417,32 @@ def parse_dispatch_message(body: str) -> dict:
 
     if data.get("params") is None:
         data["params"] = {}
+
+    # Envelope-strip pass. Must happen BEFORE input_schema validation
+    # (otherwise the manifest would need to list `_input_files` in its
+    # schema) and BEFORE building PARAMS_JSON (otherwise the agent's env
+    # would carry runner-orchestration data). Non-dict params is handled
+    # later in the handler loop with an InvalidParamsType error callback,
+    # so we just skip stripping when params isn't a dict.
+    if isinstance(data["params"], dict):
+        unknown_envelope_keys = [
+            k for k in data["params"]
+            if isinstance(k, str)
+            and k.startswith("_")
+            and k not in _RESERVED_ENVELOPE_KEYS
+        ]
+        if unknown_envelope_keys:
+            raise ValueError(
+                f"params contains unknown _-prefixed key(s) "
+                f"{sorted(unknown_envelope_keys)}; reserved for dispatch envelope only"
+            )
+        input_files = data["params"].pop("_input_files", None)
+        if input_files is not None:
+            _validate_input_files(input_files)
+            # Re-attach on the top-level dispatch dict so downstream code
+            # (mint call, INPUT_FILES_JSON env builder) reads it like any
+            # other dispatch field — symmetric with prior_artifact_versions.
+            data["_input_files"] = input_files
 
     _validate_prior_artifact_versions(data.get("prior_artifact_versions"))
     return data
@@ -422,6 +502,17 @@ def build_container_overrides(
             {
                 "name": "ATTACHMENT_VERSION_IDS",
                 "value": json.dumps(experiment["attachment_version_ids"], sort_keys=True),
+            }
+        )
+    # When the dispatch carries enumerated input-file refs (e.g. user-uploaded
+    # agenda PDFs), the runner pre-fetches each via the broker's /inputs/read
+    # endpoint before invoking the agent. Refs travel as a JSON-encoded env var
+    # — refs are small (a few hundred bytes each, capped at 10 entries).
+    if message.get("_input_files"):
+        env.append(
+            {
+                "name": "INPUT_FILES_JSON",
+                "value": json.dumps(message["_input_files"]),
             }
         )
     # Write-action manifest fields (system_prompt, permission_mode,
@@ -627,6 +718,10 @@ def handler(event: dict, context) -> dict:
                 batch_item_failures.append({"itemIdentifier": message_id})
             continue
         prior_artifact_versions = message.get("prior_artifact_versions")
+        # Reads the envelope key parse_dispatch_message extracted out of
+        # params; renamed to `input_files` here to match the broker's
+        # MintRequest field name (no leading underscore at the API boundary).
+        input_files = message.get("_input_files")
         try:
             broker = get_broker_client()
             mint_result = broker.mint_run_token(
@@ -638,6 +733,7 @@ def handler(event: dict, context) -> dict:
                 clerk_user_id=message.get("clerk_user_id"),
                 exp_ttl_seconds=experiment.get("timeout_seconds", 3600) + 300,
                 prior_artifact_versions=prior_artifact_versions,
+                input_files=input_files,
             )
         except BrokerError as e:
             logger.warning(f"Broker rejected {experiment_id} (run={message['run_id']}): {e.status_code} {e.detail}")

--- a/pmf_engine/runner/input_files.py
+++ b/pmf_engine/runner/input_files.py
@@ -1,0 +1,100 @@
+"""Pre-fetch user-supplied input files into the workspace before the agent boots.
+
+The dispatch handler ships `INPUT_FILES_JSON` as an env var carrying enumerated
+S3 refs (`[{bucket, key, dest}, ...]`). The runner reads it here, fetches each
+ref via the broker's `/inputs/read` endpoint (which authorizes against the
+ScopeTicket's `input_files` allowlist), and writes the bytes to
+`/workspace/input/<dest>`. The agent then reads from disk via the canonical
+path documented in `instruction.md` — it never sees S3 refs or broker URLs.
+
+This indirection avoids the IAM-rotation failure mode that killed presigned-URL
+flows: the broker's long-lived ECS task role does the S3 read on every call,
+so a gp-api ECS roll mid-run doesn't invalidate anything.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# Mirrors the dest pattern enforced by dispatch_handler._INPUT_FILE_DEST_RE
+# and broker InputFileRef.dest — defense in depth. The runner is the final
+# line before bytes hit disk under /workspace/input/<dest>, so a leaked
+# unsafe basename here would escape the workspace despite upstream checks.
+# `{0,254}` after the leading char bounds total length at 255.
+_DEST_RE = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9._-]{0,254}$")
+
+
+def prefetch_input_files(
+    workspace_dir: str,
+    broker_url: str,
+    broker_token: str,
+    *,
+    client: httpx.Client | None = None,
+) -> None:
+    """Read INPUT_FILES_JSON, fetch each ref via broker, write to workspace/input/.
+
+    No-op when the env var is absent or empty — most dispatches don't carry
+    user-uploaded files. Failures bubble up: pre-fetch failure means the agent
+    cannot read its inputs, so the run is doomed; fail fast so main()'s outer
+    handler reports FAILED to gp-api cleanly rather than letting the agent hit
+    FileNotFoundError mid-stride.
+
+    A `client` arg is accepted for tests (httpx.MockTransport) — when omitted,
+    the helper owns the httpx.Client lifecycle.
+    """
+    raw = os.environ.get("INPUT_FILES_JSON", "").strip()
+    if not raw:
+        return
+
+    entries = json.loads(raw)
+    if not isinstance(entries, list) or not entries:
+        return
+
+    input_dir = Path(workspace_dir) / "input"
+    input_dir.mkdir(parents=True, exist_ok=True)
+
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(
+            base_url=broker_url,
+            headers={"X-Broker-Token": broker_token},
+            timeout=30.0,
+        )
+
+    try:
+        for entry in entries:
+            bucket = entry["bucket"]
+            key = entry["key"]
+            dest = entry["dest"]
+            if not _DEST_RE.fullmatch(dest):
+                raise ValueError(f"unsafe input_files dest: {dest!r}")
+
+            response = client.post(
+                "/inputs/read",
+                json={"bucket": bucket, "key": key},
+            )
+            response.raise_for_status()
+
+            target = input_dir / dest
+            # Exclusive-create: refuse to silently clobber a file that a prior
+            # iteration of this loop (or a future workspace-setup step) wrote.
+            # Duplicate `dest` across entries is a dispatch-side bug — surface
+            # it loudly here rather than racing on bytes.
+            with open(target, "xb") as f:
+                f.write(response.content)
+            logger.info(
+                "prefetched_input_file dest=%r bucket=%r key=%r bytes=%d",
+                dest, bucket, key, len(response.content),
+            )
+    finally:
+        if owns_client:
+            client.close()

--- a/pmf_engine/runner/input_files.py
+++ b/pmf_engine/runner/input_files.py
@@ -70,6 +70,12 @@ def prefetch_input_files(
             timeout=30.0,
         )
 
+    # Track files we've written so we can roll back on partial failure.
+    # If iteration N fails after iterations 1..N-1 succeeded, the already-
+    # written files would otherwise linger under /workspace/input/ — they're
+    # user-uploaded PDFs that may contain PII, and the agent would see a
+    # partial set of inputs which is worse than seeing none.
+    written: list[Path] = []
     try:
         for entry in entries:
             bucket = entry["bucket"]
@@ -91,10 +97,25 @@ def prefetch_input_files(
             # it loudly here rather than racing on bytes.
             with open(target, "xb") as f:
                 f.write(response.content)
+            written.append(target)
             logger.info(
                 "prefetched_input_file dest=%r bucket=%r key=%r bytes=%d",
                 dest, bucket, key, len(response.content),
             )
+    except BaseException:
+        # On ANY failure (broker error, unsafe dest, FileExistsError on
+        # duplicate dest, KeyError on malformed entry, KeyboardInterrupt),
+        # remove the files we already wrote so the agent never starts up
+        # against a partial input set. Use BaseException so SystemExit /
+        # KeyboardInterrupt also trigger cleanup. Unlink errors are
+        # swallowed — we're already on a failure path; raising here would
+        # mask the original exception.
+        for path in written:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+        raise
     finally:
         if owns_client:
             client.close()

--- a/pmf_engine/runner/main.py
+++ b/pmf_engine/runner/main.py
@@ -14,6 +14,7 @@ from shared.logger import get_logger
 from .config import RunnerConfig, BrokerUrlSchemeError, validate_broker_url_scheme
 from .contract import validate_artifact_contract, ContractViolation
 from .harness.base import AgentHarness
+from .input_files import prefetch_input_files
 from .pmf_runtime import publish
 from .pmf_runtime.config import init_config
 from .pmf_runtime.egress_guard import MESSAGE as EGRESS_MESSAGE
@@ -779,6 +780,8 @@ async def main():
 
         os.makedirs(workspace_dir, exist_ok=True)
         os.makedirs(os.path.join(workspace_dir, "output"), exist_ok=True)
+
+        prefetch_input_files(workspace_dir, config.broker_url, config.broker_token)
 
         instruction_path = os.path.join(workspace_dir, "instruction.md")
         with open(instruction_path, "w") as f:

--- a/pmf_engine/runner/main.py
+++ b/pmf_engine/runner/main.py
@@ -344,7 +344,14 @@ def _collect_workspace_files(
     total_size = 0
     if not os.path.isdir(root_dir):
         return collected
-    for dirpath, _dirnames, filenames in os.walk(root_dir):
+    for dirpath, dirnames, filenames in os.walk(root_dir):
+        # User-uploaded inputs (e.g. agenda PDFs pre-fetched by the runner
+        # into /workspace/input/) may contain PII. Don't bundle them into
+        # the log capture that ships to gp-api after a failure — the agent
+        # already has them as part of its run inputs; logs are for the
+        # agent's WORK product, not its input data.
+        if dirpath == root_dir and "input" in dirnames:
+            dirnames.remove("input")
         for filename in filenames:
             if _is_sensitive_file(filename):
                 continue

--- a/pmf_engine/tests/test_broker_client.py
+++ b/pmf_engine/tests/test_broker_client.py
@@ -186,3 +186,51 @@ class TestMintRunTokenPriorArtifactVersions:
 
         body = mock_post.call_args.kwargs["json"]
         assert body.get("prior_artifact_versions") is None
+
+
+class TestMintRunTokenInputFiles:
+    def test_mint_run_token_forwards_input_files(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"broker_token": "tok-xyz"}
+
+        refs = [
+            {
+                "bucket": "gp-agent-run-inputs-dev",
+                "key": "uploads/org-1/run-001/agenda.pdf",
+                "dest": "agenda.pdf",
+            }
+        ]
+        with patch("pmf_engine.control_plane.broker_client.httpx.post", return_value=mock_response) as mock_post:
+            client = BrokerClient("https://broker.example.com", "svc-token")
+            client.mint_run_token(
+                run_id="run-001",
+                organization_slug="org-1",
+                experiment_id="meeting_briefing",
+                scope={},
+                params={"state": "WI"},
+                clerk_user_id="user_test",
+                input_files=refs,
+            )
+
+        body = mock_post.call_args.kwargs["json"]
+        assert body["input_files"] == refs
+
+    def test_mint_run_token_omits_input_files_when_none(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"broker_token": "tok-xyz"}
+
+        with patch("pmf_engine.control_plane.broker_client.httpx.post", return_value=mock_response) as mock_post:
+            client = BrokerClient("https://broker.example.com", "svc-token")
+            client.mint_run_token(
+                run_id="run-001",
+                organization_slug="org-1",
+                experiment_id="smoke_test",
+                scope={"state": "NC"},
+                params={"city": "Hendersonville"},
+                clerk_user_id="user_test",
+            )
+
+        body = mock_post.call_args.kwargs["json"]
+        assert body.get("input_files") is None

--- a/pmf_engine/tests/test_dispatch_handler.py
+++ b/pmf_engine/tests/test_dispatch_handler.py
@@ -2126,3 +2126,323 @@ class TestWriteActionDispatchFlow:
         assert result["batchItemFailures"] == []
         mint_kwargs = mock_broker_cls.return_value.mint_run_token.call_args.kwargs
         assert mint_kwargs["scope"] == {}
+
+
+# --- _input_files dispatch envelope ----------------------------------------
+# Reserved `_`-prefixed params key carrying enumerated S3 refs the runner
+# pre-fetches via the broker. Stripped from params before input_schema
+# validation and PARAMS_JSON, re-attached to the dispatch dict as
+# `_input_files` so downstream code (mint, env-var) reads it.
+
+_VALID_INPUT_FILE = {
+    "bucket": "gp-agent-run-inputs-dev",
+    "key": "uploads/org-123/run-001/agenda.pdf",
+    "dest": "agenda.pdf",
+}
+
+
+class TestInputFilesEnvelopeStripping:
+    def test_strips_input_files_from_params_to_top_level(self):
+        body = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {"state": "WI", "_input_files": [_VALID_INPUT_FILE]},
+        }
+        result = parse_dispatch_message(json.dumps(body))
+        assert "_input_files" not in result["params"]
+        assert result["params"] == {"state": "WI"}
+        assert result["_input_files"] == [_VALID_INPUT_FILE]
+
+    def test_absent_input_files_leaves_dict_untouched(self):
+        body = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {"state": "WI"},
+        }
+        result = parse_dispatch_message(json.dumps(body))
+        assert "_input_files" not in result
+        assert result["params"] == {"state": "WI"}
+
+    def test_rejects_unknown_envelope_key(self):
+        body = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {"state": "WI", "_unknown_key": "value"},
+        }
+        with pytest.raises(ValueError, match="unknown _-prefixed key"):
+            parse_dispatch_message(json.dumps(body))
+
+    def test_rejects_path_traversal_in_dest(self):
+        body = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {
+                "state": "WI",
+                "_input_files": [
+                    {"bucket": "b", "key": "k", "dest": "../etc/passwd"}
+                ],
+            },
+        }
+        with pytest.raises(ValueError, match="dest"):
+            parse_dispatch_message(json.dumps(body))
+
+    def test_rejects_slash_in_dest(self):
+        body = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {
+                "state": "WI",
+                "_input_files": [
+                    {"bucket": "b", "key": "k", "dest": "sub/file.pdf"}
+                ],
+            },
+        }
+        with pytest.raises(ValueError, match="dest"):
+            parse_dispatch_message(json.dumps(body))
+
+    def test_rejects_path_traversal_in_bucket(self):
+        body = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {
+                "state": "WI",
+                "_input_files": [
+                    {"bucket": "bucket/with/slashes", "key": "k", "dest": "f.pdf"}
+                ],
+            },
+        }
+        with pytest.raises(ValueError, match="bucket"):
+            parse_dispatch_message(json.dumps(body))
+
+    def test_rejects_dest_over_255_chars(self):
+        body = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {
+                "state": "WI",
+                "_input_files": [
+                    {
+                        "bucket": "b",
+                        "key": "k",
+                        # 256 chars — one past the broker's Pydantic max_length=255
+                        "dest": "a" * 256,
+                    }
+                ],
+            },
+        }
+        with pytest.raises(ValueError, match="dest"):
+            parse_dispatch_message(json.dumps(body))
+
+    def test_accepts_dest_at_exactly_255_chars(self):
+        body = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {
+                "state": "WI",
+                "_input_files": [
+                    {"bucket": "b", "key": "k", "dest": "a" * 255},
+                ],
+            },
+        }
+        # Just shy of the boundary; should parse cleanly.
+        result = parse_dispatch_message(json.dumps(body))
+        assert result["_input_files"][0]["dest"] == "a" * 255
+
+    def test_rejects_too_many_input_files(self):
+        body = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {
+                "state": "WI",
+                "_input_files": [
+                    {"bucket": "b", "key": f"k{i}", "dest": f"f{i}.pdf"}
+                    for i in range(11)
+                ],
+            },
+        }
+        with pytest.raises(ValueError, match="too large"):
+            parse_dispatch_message(json.dumps(body))
+
+    def test_rejects_missing_required_keys(self):
+        body = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {
+                "state": "WI",
+                "_input_files": [{"bucket": "b", "key": "k"}],
+            },
+        }
+        with pytest.raises(ValueError, match="missing required keys"):
+            parse_dispatch_message(json.dumps(body))
+
+    def test_rejects_non_list_input_files(self):
+        body = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {
+                "state": "WI",
+                "_input_files": {"bucket": "b", "key": "k", "dest": "x.pdf"},
+            },
+        }
+        with pytest.raises(ValueError, match="array"):
+            parse_dispatch_message(json.dumps(body))
+
+
+class TestBuildContainerOverridesInputFiles:
+    def test_emits_input_files_json_when_present(self):
+        experiment = {
+            "model": "sonnet",
+            "timeout_seconds": 600,
+        }
+        message = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-abc",
+            "params": {},
+            "_input_files": [_VALID_INPUT_FILE],
+        }
+        overrides = build_container_overrides(
+            experiment=experiment,
+            message=message,
+            broker_token="tok",
+            broker_url="https://broker.example.com",
+            container_name="pmf-engine",
+        )
+        env_map = {e["name"]: e["value"] for e in overrides["containerOverrides"][0]["environment"]}
+        assert "INPUT_FILES_JSON" in env_map
+        assert json.loads(env_map["INPUT_FILES_JSON"]) == [_VALID_INPUT_FILE]
+
+    def test_omits_input_files_json_when_absent(self):
+        experiment = {
+            "model": "sonnet",
+            "timeout_seconds": 600,
+        }
+        message = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-abc",
+            "params": {},
+        }
+        overrides = build_container_overrides(
+            experiment=experiment,
+            message=message,
+            broker_token="tok",
+            broker_url="https://broker.example.com",
+            container_name="pmf-engine",
+        )
+        env_map = {e["name"]: e["value"] for e in overrides["containerOverrides"][0]["environment"]}
+        assert "INPUT_FILES_JSON" not in env_map
+
+    def test_omits_input_files_json_when_empty(self):
+        experiment = {
+            "model": "sonnet",
+            "timeout_seconds": 600,
+        }
+        message = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-abc",
+            "params": {},
+            "_input_files": [],
+        }
+        overrides = build_container_overrides(
+            experiment=experiment,
+            message=message,
+            broker_token="tok",
+            broker_url="https://broker.example.com",
+            container_name="pmf-engine",
+        )
+        env_map = {e["name"]: e["value"] for e in overrides["containerOverrides"][0]["environment"]}
+        assert "INPUT_FILES_JSON" not in env_map
+
+
+class TestInputFilesDispatchFlow:
+    """End-to-end: dispatch SQS message with `_input_files` in params reaches
+    mint as a top-level kwarg and ECS as an INPUT_FILES_JSON env var, and
+    the agent's PARAMS_JSON does NOT contain the envelope key.
+    """
+
+    @patch("pmf_engine.control_plane.dispatch_handler.BrokerClient")
+    @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
+    def test_input_files_flows_to_mint_and_ecs_env(self, mock_get_ecs, mock_broker_cls):
+        mock_broker_cls.return_value = _mock_broker_success("tok-prefetch")
+        mock_get_ecs.return_value.run_task.return_value = {
+            "tasks": [{"taskArn": "arn:aws:ecs:us-west-2:123:task/abc"}],
+            "failures": [],
+        }
+
+        event = _make_sqs_event(
+            {
+                "experiment_type": "smoke_test",
+                "organization_slug": "org-123",
+                "run_id": "run-pref-001",
+                "clerk_user_id": "user_test_dispatch",
+                "params": {**VALID_PARAMS, "_input_files": [_VALID_INPUT_FILE]},
+            }
+        )
+
+        result = handler(event, None)
+        assert result["batchItemFailures"] == []
+
+        mint_kwargs = mock_broker_cls.return_value.mint_run_token.call_args.kwargs
+        assert mint_kwargs["input_files"] == [_VALID_INPUT_FILE]
+        assert "_input_files" not in mint_kwargs["params"]
+
+        env_list = mock_get_ecs.return_value.run_task.call_args.kwargs["overrides"][
+            "containerOverrides"
+        ][0]["environment"]
+        env_map = {e["name"]: e["value"] for e in env_list}
+        assert "INPUT_FILES_JSON" in env_map
+        assert json.loads(env_map["INPUT_FILES_JSON"]) == [_VALID_INPUT_FILE]
+        assert "_input_files" not in json.loads(env_map["PARAMS_JSON"])
+
+    @patch("pmf_engine.control_plane.dispatch_handler.BrokerClient")
+    @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
+    def test_absent_input_files_passes_none_to_mint(self, mock_get_ecs, mock_broker_cls):
+        mock_broker_cls.return_value = _mock_broker_success("tok-no-prefetch")
+        mock_get_ecs.return_value.run_task.return_value = {
+            "tasks": [{"taskArn": "arn:aws:ecs:us-west-2:123:task/abc"}],
+            "failures": [],
+        }
+
+        event = _make_sqs_event(
+            {
+                "experiment_type": "smoke_test",
+                "organization_slug": "org-123",
+                "run_id": "run-none-001",
+                "clerk_user_id": "user_test_dispatch",
+                "params": dict(VALID_PARAMS),
+            }
+        )
+
+        handler(event, None)
+
+        mint_kwargs = mock_broker_cls.return_value.mint_run_token.call_args.kwargs
+        assert mint_kwargs["input_files"] is None
+        env_list = mock_get_ecs.return_value.run_task.call_args.kwargs["overrides"][
+            "containerOverrides"
+        ][0]["environment"]
+        env_map = {e["name"]: e["value"] for e in env_list}
+        assert "INPUT_FILES_JSON" not in env_map

--- a/pmf_engine/tests/test_dispatch_handler.py
+++ b/pmf_engine/tests/test_dispatch_handler.py
@@ -68,6 +68,10 @@ def _default_dispatch_env(monkeypatch):
     monkeypatch.setattr(dh, "BROKER_URL", "https://broker.example.com", raising=False)
     monkeypatch.setattr(dh, "SERVICE_TOKEN", "svc-token-xyz", raising=False)
     monkeypatch.setenv("EXPERIMENT_METADATA_BUCKET", "agent-experiment-metadata-test")
+    # Drives _input_files bucket validation in dispatch_handler (expected bucket
+    # is gp-agent-run-inputs-{ENVIRONMENT}). Test fixtures already use the
+    # `-dev` suffix in _VALID_INPUT_FILE, so we set ENVIRONMENT=dev.
+    monkeypatch.setenv("ENVIRONMENT", "dev")
     fake_loader = _build_synthetic_loader()
     monkeypatch.setattr(dh, "_manifest_loader", fake_loader, raising=False)
     monkeypatch.setattr(dh, "get_manifest_loader", lambda: fake_loader)
@@ -2187,7 +2191,7 @@ class TestInputFilesEnvelopeStripping:
             "params": {
                 "state": "WI",
                 "_input_files": [
-                    {"bucket": "b", "key": "k", "dest": "../etc/passwd"}
+                    {"bucket": "gp-agent-run-inputs-dev", "key": "k", "dest": "../etc/passwd"}
                 ],
             },
         }
@@ -2203,7 +2207,7 @@ class TestInputFilesEnvelopeStripping:
             "params": {
                 "state": "WI",
                 "_input_files": [
-                    {"bucket": "b", "key": "k", "dest": "sub/file.pdf"}
+                    {"bucket": "gp-agent-run-inputs-dev", "key": "k", "dest": "sub/file.pdf"}
                 ],
             },
         }
@@ -2226,6 +2230,45 @@ class TestInputFilesEnvelopeStripping:
         with pytest.raises(ValueError, match="bucket"):
             parse_dispatch_message(json.dumps(body))
 
+    def test_rejects_wrong_environment_bucket(self, monkeypatch):
+        # Closes the bot-flagged hole where any caller controlling the SQS
+        # message could craft a bucket name and rely solely on broker IAM for
+        # defense. Dev dispatch must NOT authorize reads from the prod bucket.
+        monkeypatch.setenv("ENVIRONMENT", "dev")
+        body = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {
+                "state": "WI",
+                "_input_files": [
+                    {
+                        "bucket": "gp-agent-run-inputs-prod",
+                        "key": "k",
+                        "dest": "f.pdf",
+                    }
+                ],
+            },
+        }
+        with pytest.raises(ValueError, match="gp-agent-run-inputs-dev"):
+            parse_dispatch_message(json.dumps(body))
+
+    def test_rejects_when_environment_env_var_missing(self, monkeypatch):
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        body = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-001",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {
+                "state": "WI",
+                "_input_files": [_VALID_INPUT_FILE],
+            },
+        }
+        with pytest.raises(ValueError, match="ENVIRONMENT"):
+            parse_dispatch_message(json.dumps(body))
+
     def test_rejects_dest_over_255_chars(self):
         body = {
             "experiment_type": "smoke_test",
@@ -2236,7 +2279,7 @@ class TestInputFilesEnvelopeStripping:
                 "state": "WI",
                 "_input_files": [
                     {
-                        "bucket": "b",
+                        "bucket": "gp-agent-run-inputs-dev",
                         "key": "k",
                         # 256 chars — one past the broker's Pydantic max_length=255
                         "dest": "a" * 256,
@@ -2256,7 +2299,7 @@ class TestInputFilesEnvelopeStripping:
             "params": {
                 "state": "WI",
                 "_input_files": [
-                    {"bucket": "b", "key": "k", "dest": "a" * 255},
+                    {"bucket": "gp-agent-run-inputs-dev", "key": "k", "dest": "a" * 255},
                 ],
             },
         }

--- a/pmf_engine/tests/test_dispatch_handler.py
+++ b/pmf_engine/tests/test_dispatch_handler.py
@@ -1013,6 +1013,44 @@ class TestMissingCriticalEnvVars:
         assert "EXPERIMENT_METADATA_BUCKET" in error_msg
         assert result["batchItemFailures"] == [{"itemIdentifier": "msg-001"}]
 
+    @patch("pmf_engine.control_plane.dispatch_handler.send_error_callback")
+    @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
+    def test_missing_environment_routes_to_misconfig_callback_not_invalid_payload(
+        self, mock_get_ecs, mock_send_error_callback, monkeypatch
+    ):
+        """Bot-flagged regression: when ENVIRONMENT is unset, a dispatch
+        carrying `_input_files` made _validate_input_files raise ValueError,
+        which the previous handler caught as InvalidDispatchPayload (retry-
+        forever-to-DLQ) instead of surfacing the dispatch-misconfig callback
+        the operator needs to see. Verify the misconfig path now fires
+        BEFORE parse, regardless of whether the dispatch carries envelope keys.
+        """
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+
+        event = _make_sqs_event(
+            {
+                "experiment_type": "meeting_briefing",
+                "organization_slug": "org-123",
+                "run_id": "run-env-missing",
+                "clerk_user_id": "user_test_dispatch",
+                "params": {
+                    "state": "WI",
+                    "_input_files": [_VALID_INPUT_FILE],
+                },
+            }
+        )
+
+        result = handler(event, None)
+        mock_get_ecs.return_value.run_task.assert_not_called()
+        mock_send_error_callback.assert_called_once()
+        error_msg = mock_send_error_callback.call_args[0][1]
+        assert "ENVIRONMENT" in error_msg
+        assert (
+            mock_send_error_callback.call_args.kwargs["dedup_id"]
+            == "dispatch-misconfig-run-env-missing"
+        )
+        assert result["batchItemFailures"] == [{"itemIdentifier": "msg-001"}]
+
 
 class TestParamsSizeLimit:
     @patch("pmf_engine.control_plane.dispatch_handler.send_error_callback")
@@ -1068,6 +1106,51 @@ class TestParamsSizeLimit:
         result = handler(event, None)
         assert result["batchItemFailures"] == []
         mock_ecs.run_task.assert_called_once()
+
+    @patch("pmf_engine.control_plane.dispatch_handler.send_error_callback")
+    @patch("pmf_engine.control_plane.dispatch_handler.emit_dispatch_metric")
+    @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
+    def test_oversized_input_files_rejected_before_ecs(
+        self, mock_get_ecs, mock_emit_metric, mock_send_error_callback
+    ):
+        # Worst-case-shaped entries: bucket-name max + key-max + dest-max
+        # serialize to ~1.3 KB each. 10 entries → ~13 KB, well past the
+        # ECS RunTask containerOverrides budget. Verify the cap fires before
+        # ECS is called and gets a clean dispatch-side error callback rather
+        # than RunTask silently truncating / failing.
+        bucket = "gp-agent-run-inputs-dev"
+        oversized_entries = [
+            {
+                "bucket": bucket,
+                "key": "k" * 1024,
+                "dest": "f" * 200 + str(i),
+            }
+            for i in range(10)
+        ]
+        event = _make_sqs_event(
+            {
+                "experiment_type": "smoke_test",
+                "organization_slug": "org-123",
+                "run_id": "run-big-inputs",
+                "clerk_user_id": "user_test_dispatch",
+                "params": {
+                    **VALID_PARAMS,
+                    "_input_files": oversized_entries,
+                },
+            }
+        )
+
+        result = handler(event, None)
+        mock_get_ecs.return_value.run_task.assert_not_called()
+        mock_send_error_callback.assert_called_once()
+        error_msg = mock_send_error_callback.call_args[0][1]
+        assert "_input_files" in error_msg
+        assert "exceeds limit" in error_msg
+        assert (
+            mock_send_error_callback.call_args.kwargs["dedup_id"]
+            == "input-files-too-large-run-big-inputs"
+        )
+        assert result["batchItemFailures"] == []
 
 
 class TestRequiredParamsValidation:

--- a/pmf_engine/tests/test_input_files.py
+++ b/pmf_engine/tests/test_input_files.py
@@ -266,3 +266,65 @@ class TestPrefetchDuplicateDestRejected:
                 BROKER_TOKEN,
                 client=_client_returning(handler),
             )
+
+
+class TestPrefetchCleansUpOnPartialFailure:
+    """User-uploaded PDFs may contain PII. If the second of N inputs fails to
+    fetch, the agent must NOT start up against a partial input set — both
+    because the first file would leak PII via log capture / error reports,
+    and because briefing against a partial input is incorrect.
+    """
+
+    def test_partial_fetch_failure_removes_already_written_files(
+        self, tmp_path, monkeypatch
+    ):
+        _set_input_files_env(
+            monkeypatch,
+            [
+                {"bucket": "b", "key": "k1", "dest": "agenda.pdf"},
+                {"bucket": "b", "key": "k2", "dest": "appendix.pdf"},
+            ],
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            if body["key"] == "k1":
+                return httpx.Response(200, content=b"agenda bytes")
+            # Second entry: broker 403 (e.g. ScopeTicket allowlist mismatch).
+            return httpx.Response(403, json={"detail": "not authorized"})
+
+        with pytest.raises(httpx.HTTPStatusError):
+            prefetch_input_files(
+                str(tmp_path),
+                BROKER_URL,
+                BROKER_TOKEN,
+                client=_client_returning(handler),
+            )
+
+        # Both files must be absent — the first one was rolled back.
+        assert not (tmp_path / "input" / "agenda.pdf").exists()
+        assert not (tmp_path / "input" / "appendix.pdf").exists()
+
+    def test_unsafe_dest_in_later_entry_rolls_back_earlier_writes(
+        self, tmp_path, monkeypatch
+    ):
+        _set_input_files_env(
+            monkeypatch,
+            [
+                {"bucket": "b", "key": "k1", "dest": "agenda.pdf"},
+                {"bucket": "b", "key": "k2", "dest": "../escape.pdf"},
+            ],
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b"first file content")
+
+        with pytest.raises(ValueError, match="unsafe input_files dest"):
+            prefetch_input_files(
+                str(tmp_path),
+                BROKER_URL,
+                BROKER_TOKEN,
+                client=_client_returning(handler),
+            )
+
+        assert not (tmp_path / "input" / "agenda.pdf").exists()

--- a/pmf_engine/tests/test_input_files.py
+++ b/pmf_engine/tests/test_input_files.py
@@ -1,0 +1,268 @@
+"""Behavioral tests for runner/input_files.py.
+
+Uses httpx.MockTransport to exercise the real client + response parsing path
+without hitting any network or boto3. Workspace I/O goes through tmp_path.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from pmf_engine.runner.input_files import prefetch_input_files
+
+BROKER_URL = "https://broker-dev.test"
+BROKER_TOKEN = "broker-token-test-123"
+
+
+def _client_returning(handler) -> httpx.Client:
+    return httpx.Client(
+        base_url=BROKER_URL,
+        headers={"X-Broker-Token": BROKER_TOKEN},
+        transport=httpx.MockTransport(handler),
+    )
+
+
+def _set_input_files_env(monkeypatch, entries):
+    monkeypatch.setenv("INPUT_FILES_JSON", json.dumps(entries))
+
+
+# ---------------------------------------------------------------------------
+# No-op cases
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchNoOp:
+    def test_absent_env_var_is_no_op(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("INPUT_FILES_JSON", raising=False)
+
+        prefetch_input_files(str(tmp_path), BROKER_URL, BROKER_TOKEN)
+
+        assert not (tmp_path / "input").exists()
+
+    def test_empty_env_var_is_no_op(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("INPUT_FILES_JSON", "")
+
+        prefetch_input_files(str(tmp_path), BROKER_URL, BROKER_TOKEN)
+
+        assert not (tmp_path / "input").exists()
+
+    def test_whitespace_env_var_is_no_op(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("INPUT_FILES_JSON", "   \n")
+
+        prefetch_input_files(str(tmp_path), BROKER_URL, BROKER_TOKEN)
+
+        assert not (tmp_path / "input").exists()
+
+    def test_empty_list_is_no_op(self, tmp_path, monkeypatch):
+        _set_input_files_env(monkeypatch, [])
+
+        prefetch_input_files(str(tmp_path), BROKER_URL, BROKER_TOKEN)
+
+        assert not (tmp_path / "input").exists()
+
+    def test_non_list_value_is_no_op(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("INPUT_FILES_JSON", json.dumps({"not": "a list"}))
+
+        prefetch_input_files(str(tmp_path), BROKER_URL, BROKER_TOKEN)
+
+        assert not (tmp_path / "input").exists()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchFetchesAndWrites:
+    def test_single_entry_writes_file_to_workspace(self, tmp_path, monkeypatch):
+        entry = {
+            "bucket": "gp-agent-run-inputs-dev",
+            "key": "uploads/org/run/agenda.pdf",
+            "dest": "agenda.pdf",
+        }
+        _set_input_files_env(monkeypatch, [entry])
+
+        pdf_bytes = b"%PDF-1.4 fake content"
+
+        captured: dict = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            captured["x-broker-token"] = request.headers["x-broker-token"]
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, content=pdf_bytes)
+
+        prefetch_input_files(
+            str(tmp_path),
+            BROKER_URL,
+            BROKER_TOKEN,
+            client=_client_returning(handler),
+        )
+
+        target = tmp_path / "input" / "agenda.pdf"
+        assert target.exists()
+        assert target.read_bytes() == pdf_bytes
+        assert captured["url"].endswith("/inputs/read")
+        assert captured["x-broker-token"] == BROKER_TOKEN
+        assert captured["body"] == {
+            "bucket": entry["bucket"],
+            "key": entry["key"],
+        }
+
+    def test_multiple_entries_each_written(self, tmp_path, monkeypatch):
+        entries = [
+            {"bucket": "b1", "key": "k1", "dest": "agenda.pdf"},
+            {"bucket": "b1", "key": "k2", "dest": "appendix.pdf"},
+            {"bucket": "b2", "key": "k3", "dest": "minutes.pdf"},
+        ]
+        _set_input_files_env(monkeypatch, entries)
+
+        bytes_by_key = {
+            "k1": b"agenda body",
+            "k2": b"appendix body",
+            "k3": b"minutes body",
+        }
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content)
+            return httpx.Response(200, content=bytes_by_key[body["key"]])
+
+        prefetch_input_files(
+            str(tmp_path),
+            BROKER_URL,
+            BROKER_TOKEN,
+            client=_client_returning(handler),
+        )
+
+        assert (tmp_path / "input" / "agenda.pdf").read_bytes() == b"agenda body"
+        assert (tmp_path / "input" / "appendix.pdf").read_bytes() == b"appendix body"
+        assert (tmp_path / "input" / "minutes.pdf").read_bytes() == b"minutes body"
+
+
+# ---------------------------------------------------------------------------
+# Broker errors propagate
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchBrokerErrors:
+    def test_broker_403_raises_http_status_error(self, tmp_path, monkeypatch):
+        _set_input_files_env(
+            monkeypatch,
+            [{"bucket": "b", "key": "k", "dest": "agenda.pdf"}],
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(403, json={"detail": "Input file not authorized"})
+
+        with pytest.raises(httpx.HTTPStatusError):
+            prefetch_input_files(
+                str(tmp_path),
+                BROKER_URL,
+                BROKER_TOKEN,
+                client=_client_returning(handler),
+            )
+
+        # Don't leave a partial file behind when fetch fails.
+        assert not (tmp_path / "input" / "agenda.pdf").exists()
+
+    def test_broker_500_raises_http_status_error(self, tmp_path, monkeypatch):
+        _set_input_files_env(
+            monkeypatch,
+            [{"bucket": "b", "key": "k", "dest": "agenda.pdf"}],
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, json={"detail": "S3 read error"})
+
+        with pytest.raises(httpx.HTTPStatusError):
+            prefetch_input_files(
+                str(tmp_path),
+                BROKER_URL,
+                BROKER_TOKEN,
+                client=_client_returning(handler),
+            )
+
+    def test_broker_404_raises(self, tmp_path, monkeypatch):
+        _set_input_files_env(
+            monkeypatch,
+            [{"bucket": "b", "key": "k", "dest": "agenda.pdf"}],
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"detail": "Input file not found"})
+
+        with pytest.raises(httpx.HTTPStatusError):
+            prefetch_input_files(
+                str(tmp_path),
+                BROKER_URL,
+                BROKER_TOKEN,
+                client=_client_returning(handler),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Local-defense path-traversal guard
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchUnsafeDestRejected:
+    """Even if dispatch_handler and broker checks were bypassed, the runner
+    must refuse to write a basename that would escape /workspace/input/."""
+
+    @pytest.mark.parametrize(
+        "unsafe_dest",
+        [
+            "../escape.pdf",
+            "sub/file.pdf",
+            ".hidden",
+            "..",
+            "",
+            "name with space",
+            "name\nwith\nnewline",
+            "a" * 256,  # one past the 255-char cap
+        ],
+    )
+    def test_rejects_unsafe_dest(self, tmp_path, monkeypatch, unsafe_dest):
+        _set_input_files_env(
+            monkeypatch,
+            [{"bucket": "b", "key": "k", "dest": unsafe_dest}],
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b"should not be written")
+
+        with pytest.raises(ValueError, match="unsafe input_files dest"):
+            prefetch_input_files(
+                str(tmp_path),
+                BROKER_URL,
+                BROKER_TOKEN,
+                client=_client_returning(handler),
+            )
+
+
+class TestPrefetchDuplicateDestRejected:
+    """Two entries with the same dest is a dispatch-side bug. Surface it
+    rather than silently overwriting bytes."""
+
+    def test_duplicate_dest_raises_on_second_write(self, tmp_path, monkeypatch):
+        _set_input_files_env(
+            monkeypatch,
+            [
+                {"bucket": "b", "key": "k1", "dest": "agenda.pdf"},
+                {"bucket": "b", "key": "k2", "dest": "agenda.pdf"},
+            ],
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, content=b"some content")
+
+        with pytest.raises(FileExistsError):
+            prefetch_input_files(
+                str(tmp_path),
+                BROKER_URL,
+                BROKER_TOKEN,
+                client=_client_returning(handler),
+            )

--- a/pmf_engine/tests/test_runner_main.py
+++ b/pmf_engine/tests/test_runner_main.py
@@ -1798,6 +1798,56 @@ class TestCollectWorkspaceFilesSensitiveWithAllowedExtensions:
         )
 
 
+class TestCollectWorkspaceFilesSkipsUserInputs:
+    """User-uploaded inputs (e.g. agenda PDFs pre-fetched to
+    /workspace/input/) may contain PII. They must never end up in the log
+    bundle that ships to gp-api on failure — the agent's WORK product is what
+    we log, not its input data.
+    """
+
+    def test_input_subdirectory_pruned_from_log_capture(self, tmp_path):
+        from pmf_engine.runner.main import _collect_workspace_files
+
+        (tmp_path / "output").mkdir()
+        (tmp_path / "output" / "result.json").write_text('{"ok": true}')
+        (tmp_path / "instruction.md").write_text("agent instructions")
+
+        # The user-input subdir the prefetch helper creates.
+        (tmp_path / "input").mkdir()
+        (tmp_path / "input" / "agenda.pdf").write_bytes(b"%PDF-1.4 user data")
+
+        collected = _collect_workspace_files(str(tmp_path))
+        keys = set(collected.keys())
+
+        assert "workspace/output/result.json" in keys, (
+            f"output/result.json should be collected, got keys: {keys}"
+        )
+        assert "workspace/instruction.md" in keys, (
+            f"instruction.md should be collected, got keys: {keys}"
+        )
+        assert "workspace/input/agenda.pdf" not in keys, (
+            f"input/agenda.pdf must NOT be collected (user-uploaded), got keys: {keys}"
+        )
+
+    def test_nested_input_directory_below_top_level_is_collected(self, tmp_path):
+        # The prune-on-walk targets only the TOP-LEVEL `input` next to the
+        # workspace root. A non-top-level `input` directory created by an
+        # agent's own work (e.g. `output/components/input/foo.md`) is NOT
+        # user-uploaded and should still be captured.
+        from pmf_engine.runner.main import _collect_workspace_files
+
+        nested = tmp_path / "output" / "subtree" / "input"
+        nested.mkdir(parents=True)
+        (nested / "agent-note.md").write_text("agent wrote this")
+
+        collected = _collect_workspace_files(str(tmp_path))
+        keys = set(collected.keys())
+
+        assert "workspace/output/subtree/input/agent-note.md" in keys, (
+            f"nested input/ files should still be collected, got keys: {keys}"
+        )
+
+
 class TestBrokerInitLastResortSqsFallback:
     """C2: When BOTH init_config AND the subsequent RunnerConfig.from_env
     broker fetch fail, the runner has no broker channel to send a failed


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches dispatch minting, broker authorization, S3 IAM, and user-uploaded content handling; mitigated by enumerated allowlists, env-scoped buckets, and dest validation, but rollout depends on correct Terraform apply order and ENVIRONMENT on dispatch.
> 
> **Overview**
> Adds an **authorized path for user-uploaded run inputs** (e.g. meeting agenda PDFs): dispatch carries `_input_files` in params, the broker mints an allowlisted `input_files` list on the scope ticket, and the runner pre-fetches bytes via **`POST /inputs/read`** into `/workspace/input/<dest>` before the agent starts.
> 
> **Broker & tickets:** New `InputFileRef` (`bucket`, `key`, `dest` with safe-basename rules) is stored on `ScopeTicket` and enforced at read time. Mint rejects refs outside the env bucket `gp-agent-run-inputs-{ENVIRONMENT}`. `/inputs/read` returns octet-stream bodies with a 75 MB cap and bounded reads.
> 
> **Dispatch & runner:** `parse_dispatch_message` strips `_input_files` from agent `params`, validates shape/bucket/dest/count, forwards refs to mint and sets `INPUT_FILES_JSON` on the Fargate task (with a serialized-size cap). `prefetch_input_files` uses the broker token; partial failures roll back written files. Failure log collection skips top-level `workspace/input/` to avoid shipping user PII.
> 
> **Infrastructure:** New Terraform `agent-run-inputs` stacks (dev/qa/prod) provision the inputs bucket (versioning, encryption, lifecycle, per-env CORS for browser PUTs) and a GetObject-only read policy attached to the broker task role; broker env wrappers gain remote-state lookup and a dev `bootstrap` toggle for first apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36938809e40b8ac97a1c8fd1cf6aaa88a0637586. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->