### PR TITLE
fix(infra): remove parens from agent-run-inputs bucket Purpose tag

### DIFF
--- a/infrastructure/modules/agent-run-inputs/main.tf
+++ b/infrastructure/modules/agent-run-inputs/main.tf
@@ -60,7 +60,7 @@ resource "aws_s3_bucket" "inputs" {
     Name        = local.bucket_name
     Environment = var.environment
     ManagedBy   = "terraform"
-    Purpose     = "User-uploaded files consumed by agent runs (e.g. meeting-briefing agenda PDFs)"
+    Purpose     = "User-uploaded files consumed by agent runs such as meeting-briefing agenda PDFs"
   }
 }
 


### PR DESCRIPTION
S3 bucket tag values only allow letters, numbers, spaces, and _ . : / = + - @. The Purpose tag's '(e.g. ...)' parentheses made terraform apply fail with InvalidTag on bucket creation (not caught pre-merge since terraform isn't run in CI). Reword to drop the parentheses. Affects dev/qa/prod equally — they share this module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single tag string change with no IAM, bucket policy, or runtime behavior impact.
> 
> **Overview**
> Updates the **`Purpose`** tag on the `aws_s3_bucket.inputs` resource in the shared **`agent-run-inputs`** Terraform module so the value no longer uses parentheses (e.g. around “e.g. …”), which AWS rejects with **InvalidTag** during apply.
> 
> The wording is unchanged in meaning—still describes user-uploaded files for agent runs like meeting-briefing agenda PDFs—so **dev, qa, and prod** stacks that use this module can create or update the bucket without tag validation failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef7f85c8773c48895231418febcc1df7c74c9871. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->