### PR TITLE
feat(pmf-engine): enforce max concurrent agents in the dispatch Lambda

### DIFF
--- a/infrastructure/modules/pmf-engine-control-plane/main.tf
+++ b/infrastructure/modules/pmf-engine-control-plane/main.tf
@@ -97,6 +97,12 @@ variable "experiment_metadata_read_policy_arn" {
   default     = ""
 }
 
+variable "max_concurrent_agents" {
+  description = "Maximum number of concurrently RUNNING agent Fargate tasks. The dispatch Lambda defers at-cap messages back to the queue with an extended visibility timeout. 0 disables the cap."
+  type        = number
+  default     = 100
+}
+
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_vpc" "selected" {
@@ -192,9 +198,13 @@ resource "aws_sqs_queue" "dispatch" {
   deduplication_scope         = "messageGroup"
   fifo_throughput_limit       = "perMessageGroupId"
 
+  # 30 receives (not 3): cap-deferred messages consume one receive per retry
+  # (10-minute visibility per deferral) — this tolerates ~5 hours of cap
+  # saturation before a healthy message dead-letters. Tradeoff: genuinely
+  # poison messages retry ~60 minutes before reaching the DLQ instead of ~6.
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.dispatch_dlq.arn
-    maxReceiveCount     = 3
+    maxReceiveCount     = 30
   })
 
   tags = {
@@ -329,9 +339,20 @@ resource "aws_iam_role_policy" "dispatch_lambda_permissions" {
         Action = [
           "sqs:ReceiveMessage",
           "sqs:DeleteMessage",
-          "sqs:GetQueueAttributes"
+          "sqs:GetQueueAttributes",
+          "sqs:ChangeMessageVisibility"
         ]
         Resource = aws_sqs_queue.dispatch.arn
+      },
+      {
+        Effect   = "Allow"
+        Action   = "ecs:ListTasks"
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
       },
       {
         Effect   = "Allow"
@@ -390,18 +411,19 @@ resource "aws_lambda_function" "dispatch" {
 
   environment {
     variables = {
-      ENVIRONMENT           = var.environment
-      ECS_CLUSTER_ARN       = var.ecs_cluster_arn
-      ECS_TASK_DEFINITION   = var.ecs_task_definition_family
-      ECS_SUBNET_IDS        = join(",", var.ecs_subnet_ids)
-      ECS_SECURITY_GROUP_ID = var.ecs_security_group_id
-      ARTIFACT_BUCKET       = aws_s3_bucket.artifacts.id
-      CONTAINER_NAME        = "pmf-engine"
+      ENVIRONMENT                = var.environment
+      ECS_CLUSTER_ARN            = var.ecs_cluster_arn
+      ECS_TASK_DEFINITION        = var.ecs_task_definition_family
+      ECS_SUBNET_IDS             = join(",", var.ecs_subnet_ids)
+      ECS_SECURITY_GROUP_ID      = var.ecs_security_group_id
+      ARTIFACT_BUCKET            = aws_s3_bucket.artifacts.id
+      CONTAINER_NAME             = "pmf-engine"
       AI_SECRETS_NAME            = "AI_SECRETS_${upper(var.environment)}"
       BROKER_URL                 = var.broker_url
       RESULTS_QUEUE_URL          = aws_sqs_queue.results.url
       SERVICE_TOKEN              = try(jsondecode(data.aws_secretsmanager_secret_version.service_tokens.secret_string)["SERVICE_TOKEN"], "")
       EXPERIMENT_METADATA_BUCKET = var.experiment_metadata_bucket_name
+      MAX_CONCURRENT_AGENTS      = tostring(var.max_concurrent_agents)
     }
   }
 
@@ -422,6 +444,14 @@ resource "aws_lambda_event_source_mapping" "dispatch_sqs" {
   enabled          = true
 
   function_response_types = ["ReportBatchItemFailures"]
+
+  # FIFO scales Lambda concurrency to the number of active message groups
+  # (one per org), so a bulk dispatch could run hundreds of cap checks
+  # simultaneously and race straight past MAX_CONCURRENT_AGENTS. Capping at
+  # 2 bounds the check-then-launch race to 1 task of overshoot.
+  scaling_config {
+    maximum_concurrency = 2
+  }
 }
 
 # --- CloudWatch Alarms ---

--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -23,24 +23,24 @@ except (ImportError, OSError):
 
 try:
     from .broker_client import BrokerClient, BrokerError
-    from .scope_derivation import derive_scope
     from .jsonschema_errors import format_validation_errors
     from .manifest_loader import (
-        ManifestRoutingLoader,
         ManifestLoaderError,
         ManifestLoaderMalformedError,
         ManifestLoaderTransientError,
+        ManifestRoutingLoader,
     )
+    from .scope_derivation import derive_scope
 except ImportError:
     from broker_client import BrokerClient, BrokerError
-    from scope_derivation import derive_scope  # type: ignore[no-redef]
     from jsonschema_errors import format_validation_errors  # type: ignore[no-redef]
     from manifest_loader import (  # type: ignore[no-redef]
-        ManifestRoutingLoader,
         ManifestLoaderError,
         ManifestLoaderMalformedError,
         ManifestLoaderTransientError,
+        ManifestRoutingLoader,
     )
+    from scope_derivation import derive_scope  # type: ignore[no-redef]
 
 _ecs_client = None
 _sqs_client = None
@@ -282,6 +282,13 @@ def send_error_callback(
         return False
 
 
+# Maximum number of concurrently RUNNING agent Fargate tasks. 0 (or unset)
+# disables the cap. At-cap messages are deferred — returned to the queue with
+# an extended visibility timeout so each SQS receive buys a long wait instead
+# of burning maxReceiveCount every 120s.
+MAX_CONCURRENT_AGENTS = int(os.environ.get("MAX_CONCURRENT_AGENTS", "0") or 0)
+CAP_DEFERRAL_VISIBILITY_SECONDS = 600
+
 ECS_CLUSTER_ARN = os.environ.get("ECS_CLUSTER_ARN", "")
 ECS_TASK_DEFINITION = os.environ.get("ECS_TASK_DEFINITION", "")
 ECS_SUBNET_IDS = [s for s in os.environ.get("ECS_SUBNET_IDS", "").split(",") if s]
@@ -343,7 +350,7 @@ def parse_dispatch_message(body: str) -> dict:
     try:
         data = json.loads(body)
     except (json.JSONDecodeError, TypeError) as e:
-        raise ValueError(f"Invalid message body: {e}")
+        raise ValueError(f"Invalid message body: {e}") from e
 
     for field in ("experiment_type", "organization_slug", "run_id"):
         if not data.get(field):
@@ -425,6 +432,54 @@ def build_container_overrides(
     return {"containerOverrides": [{"name": container_name, "environment": env}]}
 
 
+def _count_active_agent_tasks() -> int:
+    """Live RUNNING task count on the agent cluster — the source of truth for
+    "concurrent active agents". desiredStatus=RUNNING includes tasks still
+    PROVISIONING/PENDING, so just-launched tasks count immediately.
+    list_tasks returns at most 100 ARNs per page; paginate or caps >= 100
+    silently never bind.
+    """
+    paginator = get_ecs_client().get_paginator("list_tasks")
+    count = 0
+    for page in paginator.paginate(cluster=ECS_CLUSTER_ARN, desiredStatus="RUNNING"):
+        count += len(page.get("taskArns", []))
+    return count
+
+
+def _queue_url_from_arn(queue_arn: str) -> str:
+    _, _, _, region, account, name = queue_arn.split(":")
+    return f"https://sqs.{region}.amazonaws.com/{account}/{name}"
+
+
+def _defer_for_concurrency_cap(record: dict, message: dict, active: int) -> None:
+    """Return an at-cap message to the queue for a later retry.
+
+    Extends the message's visibility timeout so the retry comes in
+    CAP_DEFERRAL_VISIBILITY_SECONDS instead of the queue's 120s default —
+    each receive consumes one of maxReceiveCount, so longer waits mean a
+    cap-blocked message survives longer saturation before dead-lettering.
+    No error callback: deferral is not a failure; gp-api's run row stays
+    RUNNING until the agent actually executes.
+    """
+    logger.info(
+        f"Concurrency cap reached ({active}/{MAX_CONCURRENT_AGENTS}); deferring run {message['run_id']} "
+        f"(experiment={message['experiment_type']}, organization={message['organization_slug']})"
+    )
+    emit_dispatch_metric("ConcurrencyCapDeferred", message["experiment_type"])
+    try:
+        get_sqs_client().change_message_visibility(
+            QueueUrl=_queue_url_from_arn(record["eventSourceARN"]),
+            ReceiptHandle=record["receiptHandle"],
+            VisibilityTimeout=CAP_DEFERRAL_VISIBILITY_SECONDS,
+        )
+    except Exception:
+        logger.warning(
+            f"change_message_visibility failed for deferred run {message['run_id']}; "
+            f"message will retry after the queue's default visibility timeout",
+            exc_info=True,
+        )
+
+
 def handler(event: dict, context) -> dict:
     batch_item_failures = []
     missing_config = _missing_critical_config()
@@ -455,6 +510,23 @@ def handler(event: dict, context) -> dict:
             )
             batch_item_failures.append({"itemIdentifier": message_id})
             continue
+
+        # Concurrency cap gate — before routing/mint so a deferred message
+        # does no work and leaks no broker token. Fail open on count errors:
+        # an ECS API hiccup or IAM regression must not wedge all dispatch.
+        if MAX_CONCURRENT_AGENTS > 0:
+            try:
+                active = _count_active_agent_tasks()
+            except Exception as e:
+                logger.warning(
+                    f"Concurrency cap check failed ({type(e).__name__}: {e}); "
+                    f"dispatching run {message['run_id']} without cap enforcement"
+                )
+                active = -1
+            if active >= MAX_CONCURRENT_AGENTS:
+                _defer_for_concurrency_cap(record, message, active)
+                batch_item_failures.append({"itemIdentifier": message_id})
+                continue
 
         experiment_id = message["experiment_type"]
         try:

--- a/pmf_engine/tests/test_dispatch_handler.py
+++ b/pmf_engine/tests/test_dispatch_handler.py
@@ -7,11 +7,10 @@ import httpx
 import pytest
 
 from pmf_engine.control_plane.dispatch_handler import (
+    build_container_overrides,
     handler,
     parse_dispatch_message,
-    build_container_overrides,
 )
-
 
 SYNTHETIC_MANIFEST_VERSION_ID = "test-manifest-v-abc123"
 SYNTHETIC_INSTRUCTION_VERSION_ID = "test-instruction-v-def456"
@@ -223,7 +222,7 @@ class TestParseDispatchMessage:
             "organization_slug": "org-123",
             "run_id": "run-001",
             "clerk_user_id": "user_test_dispatch",
-            "prior_artifact_versions": {f"k{i}": f"e/r/artifact.json" for i in range(11)},
+            "prior_artifact_versions": {f"k{i}": "e/r/artifact.json" for i in range(11)},
         }
         with pytest.raises(ValueError, match="too large"):
             parse_dispatch_message(json.dumps(body))
@@ -323,9 +322,7 @@ class TestBuildContainerOverrides:
         # sort_keys=True: env-var bytes must be deterministic across dispatches
         # so idempotency checks / cache keys downstream don't churn on dict
         # iteration order.
-        assert env_map["ATTACHMENT_VERSION_IDS"] == json.dumps(
-            {"lookup.csv": "Vlk", "notes.md": "Vnt"}, sort_keys=True
-        )
+        assert env_map["ATTACHMENT_VERSION_IDS"] == json.dumps({"lookup.csv": "Vlk", "notes.md": "Vnt"}, sort_keys=True)
 
     def test_attachment_version_ids_omitted_when_empty(self):
         """Empty attachment_version_ids dict must NOT produce an env var
@@ -435,7 +432,7 @@ class TestHandler:
             }
         )
 
-        result = handler(event, None)
+        handler(event, None)
         mock_ecs.run_task.assert_not_called()
         mock_send_error_callback.assert_called_once()
         call_args = mock_send_error_callback.call_args
@@ -499,13 +496,13 @@ class TestHandler:
         )
 
         warning_records = [r for r in records if r.levelno == logging.WARNING and "nonexistent" in r.getMessage()]
-        assert warning_records == [], (
-            f"Expected no WARNING-level log for unknown experiment, got: {[r.getMessage() for r in warning_records]}"
-        )
+        assert (
+            warning_records == []
+        ), f"Expected no WARNING-level log for unknown experiment, got: {[r.getMessage() for r in warning_records]}"
 
-        assert any("smoke_test" in r.getMessage() for r in error_records), (
-            "Expected error log to include known experiment IDs for operator triage"
-        )
+        assert any(
+            "smoke_test" in r.getMessage() for r in error_records
+        ), "Expected error log to include known experiment IDs for operator triage"
 
     @patch("pmf_engine.control_plane.dispatch_handler.BrokerClient")
     @patch("pmf_engine.control_plane.dispatch_handler.send_error_callback")
@@ -813,7 +810,7 @@ class TestNonDictParamsGuard:
             }
         )
 
-        result = handler(event, None)
+        handler(event, None)
 
         mock_get_ecs.return_value.run_task.assert_not_called()
         mock_send_error_callback.assert_called_once()
@@ -975,7 +972,7 @@ class TestMissingCriticalEnvVars:
             }
         )
 
-        result = handler(event, None)
+        handler(event, None)
         mock_get_ecs.return_value.run_task.assert_not_called()
         mock_send_error_callback.assert_called_once()
         error_msg = mock_send_error_callback.call_args[0][1]
@@ -1027,7 +1024,7 @@ class TestParamsSizeLimit:
             }
         )
 
-        result = handler(event, None)
+        handler(event, None)
 
         mock_get_ecs.return_value.run_task.assert_not_called()
         mock_send_error_callback.assert_called_once()
@@ -1491,9 +1488,9 @@ class TestEcsErrorCallbackDoesNotLeakRawDetail:
         mock_send_error_callback.assert_called_once()
         error_str = mock_send_error_callback.call_args[0][1]
         assert "arn:aws:iam" not in error_str, f"Expected sanitized error, got ARN-leaking message: {error_str!r}"
-        assert "333022194791" not in error_str, (
-            f"Expected sanitized error, got account-id-leaking message: {error_str!r}"
-        )
+        assert (
+            "333022194791" not in error_str
+        ), f"Expected sanitized error, got account-id-leaking message: {error_str!r}"
         assert "ECS RunTask failed" in error_str
 
     @patch("pmf_engine.control_plane.dispatch_handler.send_error_callback")
@@ -1533,9 +1530,9 @@ class TestEcsErrorCallbackDoesNotLeakRawDetail:
         mock_send_error_callback.assert_called_once()
         error_str = mock_send_error_callback.call_args[0][1]
         assert "arn:aws:iam" not in error_str, f"Expected sanitized error, got ARN-leaking message: {error_str!r}"
-        assert "333022194791" not in error_str, (
-            f"Expected sanitized error, got account-id-leaking message: {error_str!r}"
-        )
+        assert (
+            "333022194791" not in error_str
+        ), f"Expected sanitized error, got account-id-leaking message: {error_str!r}"
         assert "ClientError" in error_str, f"Expected exception type name in sanitized message, got: {error_str!r}"
 
     @patch("pmf_engine.control_plane.dispatch_handler.send_error_callback")
@@ -1579,9 +1576,9 @@ class TestEcsErrorCallbackDoesNotLeakRawDetail:
             dh.logger.setLevel(original_level)
 
         combined = " ".join(r.getMessage() for r in records if r.levelno >= logging.ERROR)
-        assert "arn:aws:iam::333022194791" in combined, (
-            f"Operator diagnostic log must retain full ARN detail; got: {combined!r}"
-        )
+        assert (
+            "arn:aws:iam::333022194791" in combined
+        ), f"Operator diagnostic log must retain full ARN detail; got: {combined!r}"
 
 
 class TestRunTaskFailureCleansUpMintedTicket:
@@ -1769,7 +1766,7 @@ class TestInputSchemaSortKeyMixedTypes:
         )
 
         # If the sort key blows up, this raises TypeError uncaught.
-        result = handler(event, None)
+        handler(event, None)
 
         # Validation should have caught the issues and emitted a callback,
         # NOT crashed.
@@ -1871,9 +1868,9 @@ class TestResolveRoutingFailures:
         assert routing["model"] == "sonnet"
         # known is only populated on the unknown-experiment branch (routing is None).
         assert known == []
-        assert not any(call.args[0] == "manifest_loader_fallback" for call in mock_metric.call_args_list), (
-            "happy path must not emit fallback metric"
-        )
+        assert not any(
+            call.args[0] == "manifest_loader_fallback" for call in mock_metric.call_args_list
+        ), "happy path must not emit fallback metric"
 
     def test_loader_transient_error_raises_and_emits_metric(self, monkeypatch):
         """S3 outage / IAM throttle → re-raise ManifestLoaderTransientError so
@@ -2126,3 +2123,126 @@ class TestWriteActionDispatchFlow:
         assert result["batchItemFailures"] == []
         mint_kwargs = mock_broker_cls.return_value.mint_run_token.call_args.kwargs
         assert mint_kwargs["scope"] == {}
+
+
+class TestConcurrencyCap:
+    DISPATCH_QUEUE_ARN = "arn:aws:sqs:us-west-2:123:agent-dispatch-test.fifo"
+
+    def _make_event(self) -> dict:
+        event = _make_sqs_event(
+            {
+                "experiment_type": "smoke_test",
+                "organization_slug": "org-123",
+                "run_id": "run-cap-001",
+                "clerk_user_id": "user_test_dispatch",
+                "params": dict(VALID_PARAMS),
+            }
+        )
+        event["Records"][0]["eventSourceARN"] = self.DISPATCH_QUEUE_ARN
+        event["Records"][0]["receiptHandle"] = "rh-001"
+        return event
+
+    def _set_cap(self, monkeypatch, cap: int):
+        import pmf_engine.control_plane.dispatch_handler as dh
+
+        monkeypatch.setattr(dh, "MAX_CONCURRENT_AGENTS", cap, raising=False)
+
+    def _mock_running_tasks(self, mock_get_ecs, pages: list[int]):
+        paginator = mock_get_ecs.return_value.get_paginator.return_value
+        paginator.paginate.return_value = [
+            {"taskArns": [f"task-{p}-{i}" for i in range(n)]} for p, n in enumerate(pages)
+        ]
+
+    @patch("pmf_engine.control_plane.dispatch_handler.get_sqs_client")
+    @patch("pmf_engine.control_plane.dispatch_handler.BrokerClient")
+    @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
+    def test_defers_message_when_at_cap(self, mock_get_ecs, mock_broker_cls, mock_get_sqs, monkeypatch):
+        self._set_cap(monkeypatch, 2)
+        self._mock_running_tasks(mock_get_ecs, [2])
+
+        result = handler(self._make_event(), None)
+
+        assert result["batchItemFailures"] == [{"itemIdentifier": "msg-001"}]
+        mock_get_ecs.return_value.run_task.assert_not_called()
+        mock_broker_cls.return_value.mint_run_token.assert_not_called()
+        visibility_kwargs = mock_get_sqs.return_value.change_message_visibility.call_args.kwargs
+        assert visibility_kwargs["QueueUrl"] == "https://sqs.us-west-2.amazonaws.com/123/agent-dispatch-test.fifo"
+        assert visibility_kwargs["ReceiptHandle"] == "rh-001"
+        assert visibility_kwargs["VisibilityTimeout"] == 600
+
+    @patch("pmf_engine.control_plane.dispatch_handler.get_sqs_client")
+    @patch("pmf_engine.control_plane.dispatch_handler.BrokerClient")
+    @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
+    def test_dispatches_when_below_cap(self, mock_get_ecs, mock_broker_cls, mock_get_sqs, monkeypatch):
+        self._set_cap(monkeypatch, 2)
+        self._mock_running_tasks(mock_get_ecs, [1])
+        mock_broker_cls.return_value = _mock_broker_success()
+        mock_get_ecs.return_value.run_task.return_value = {
+            "tasks": [{"taskArn": "arn:aws:ecs:us-west-2:123:task/abc"}],
+            "failures": [],
+        }
+
+        result = handler(self._make_event(), None)
+
+        assert result["batchItemFailures"] == []
+        mock_get_ecs.return_value.run_task.assert_called_once()
+        mock_get_sqs.return_value.change_message_visibility.assert_not_called()
+
+    @patch("pmf_engine.control_plane.dispatch_handler.BrokerClient")
+    @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
+    def test_cap_of_zero_disables_enforcement(self, mock_get_ecs, mock_broker_cls, monkeypatch):
+        self._set_cap(monkeypatch, 0)
+        mock_broker_cls.return_value = _mock_broker_success()
+        mock_get_ecs.return_value.run_task.return_value = {
+            "tasks": [{"taskArn": "arn:aws:ecs:us-west-2:123:task/abc"}],
+            "failures": [],
+        }
+
+        result = handler(self._make_event(), None)
+
+        assert result["batchItemFailures"] == []
+        mock_get_ecs.return_value.get_paginator.assert_not_called()
+        mock_get_ecs.return_value.run_task.assert_called_once()
+
+    @patch("pmf_engine.control_plane.dispatch_handler.get_sqs_client")
+    @patch("pmf_engine.control_plane.dispatch_handler.BrokerClient")
+    @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
+    def test_counts_tasks_across_pages(self, mock_get_ecs, mock_broker_cls, mock_get_sqs, monkeypatch):
+        self._set_cap(monkeypatch, 100)
+        self._mock_running_tasks(mock_get_ecs, [100, 5])
+
+        result = handler(self._make_event(), None)
+
+        assert result["batchItemFailures"] == [{"itemIdentifier": "msg-001"}]
+        mock_get_ecs.return_value.run_task.assert_not_called()
+        paginate_kwargs = mock_get_ecs.return_value.get_paginator.return_value.paginate.call_args.kwargs
+        assert paginate_kwargs["desiredStatus"] == "RUNNING"
+
+    @patch("pmf_engine.control_plane.dispatch_handler.BrokerClient")
+    @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
+    def test_fails_open_when_count_errors(self, mock_get_ecs, mock_broker_cls, monkeypatch):
+        self._set_cap(monkeypatch, 2)
+        mock_get_ecs.return_value.get_paginator.return_value.paginate.side_effect = RuntimeError("ecs down")
+        mock_broker_cls.return_value = _mock_broker_success()
+        mock_get_ecs.return_value.run_task.return_value = {
+            "tasks": [{"taskArn": "arn:aws:ecs:us-west-2:123:task/abc"}],
+            "failures": [],
+        }
+
+        result = handler(self._make_event(), None)
+
+        assert result["batchItemFailures"] == []
+        mock_get_ecs.return_value.run_task.assert_called_once()
+
+    @patch("pmf_engine.control_plane.dispatch_handler.get_sqs_client")
+    @patch("pmf_engine.control_plane.dispatch_handler.BrokerClient")
+    @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
+    def test_defers_even_when_visibility_change_fails(self, mock_get_ecs, mock_broker_cls, mock_get_sqs, monkeypatch):
+        self._set_cap(monkeypatch, 1)
+        self._mock_running_tasks(mock_get_ecs, [1])
+        mock_get_sqs.return_value.change_message_visibility.side_effect = RuntimeError("sqs denied")
+
+        result = handler(self._make_event(), None)
+
+        assert result["batchItemFailures"] == [{"itemIdentifier": "msg-001"}]
+        mock_get_ecs.return_value.run_task.assert_not_called()


### PR DESCRIPTION
## Why

The agent infrastructure has no concurrency limit. The dispatch Lambda launches one Fargate task per SQS message, and the only ceiling is the AWS account's Fargate vCPU quota. The fleet cap that exists today lives client-side in gp-api's bulk dispatch script — nothing in the infrastructure backs it up, so any caller (or a resume sweep) can launch an unbounded number of agents.

This makes the cap automatic and server-side: the dispatch Lambda counts RUNNING tasks on the agent cluster before `run_task` and defers at-cap messages back to the queue.

## Design choices

- **Cap = live ECS task count.** No new state store; the cluster is the source of truth for "active agents". `AWAITING_RESUME` runs aren't counted — they consume no compute, and resumes re-enter through this same queue, so they're capped on re-dispatch.
- **Deferral, not failure.** At-cap messages go back via `batchItemFailures` with visibility extended to 10 minutes, so each SQS receive buys a long wait instead of burning `maxReceiveCount` every 120s. No error callback — gp-api's run row stays RUNNING. FIFO means a deferred message only blocks its own org's message group.
- **Deferral happens before token mint**, so no broker token leaks for a run that doesn't launch.
- **Fail open on count errors.** An ECS API hiccup or IAM regression must not wedge all dispatch.
- **`maximum_concurrency = 2` on the event source mapping.** FIFO scales Lambda to one invocation per active message group (one per org), so a bulk dispatch across hundreds of orgs would otherwise run the check-then-launch race hundreds wide and blow straight past the cap. At 2, overshoot is bounded at 1 task.
- **`maxReceiveCount` 3 → 30** so cap-blocked messages survive ~5 hours of saturation before dead-lettering. Tradeoff: genuinely poison messages take ~60 minutes to reach the DLQ instead of ~6. Their per-attempt error callbacks are idempotent on the gp-api side (consumer guards on `status === RUNNING`).

## Known interaction

gp-api's stale sweep flips RUNNING `ExperimentRun` rows older than 45 minutes to FAILED, so a run that waits at-cap longer than that gets swept before it executes and its eventual result is ignored. Acceptable for a backstop cap — the bulk script's own throttle keeps queue wait near zero in practice — but worth knowing if the cap is ever lowered aggressively.

## Config

`max_concurrent_agents` module variable (default 100, `0` disables) → `MAX_CONCURRENT_AGENTS` env var on the Lambda. Per-env overrides go in `infrastructure/environments/{env}/pmf-engine-control-plane`.

Note: `pmf_engine/tests/test_runner_main.py` (22) and `test_config.py` (2) failures are pre-existing on develop; `test_dispatch_handler.py` is 94/94 green including 6 new cap tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core dispatch behavior (when Fargate launches) and SQS redrive timing; misconfiguration or ECS list failures could allow brief overshoot or longer DLQ delay for poison messages, though cap-check errors fail open by design.
> 
> **Overview**
> Adds a **server-side cap** on concurrent agent Fargate tasks in the PMF dispatch path, replacing reliance on client-only throttling in gp-api.
> 
> The dispatch Lambda reads **`MAX_CONCURRENT_AGENTS`** (Terraform `max_concurrent_agents`, default 100; `0` disables). Before manifest routing or broker mint, it **paginates ECS `list_tasks`** for `RUNNING` tasks on the agent cluster; at cap it **defers** the SQS message via `batchItemFailures`, extends visibility to **10 minutes**, emits **`ConcurrencyCapDeferred`**, and skips mint/`run_task`. ECS count failures **fail open** so dispatch is not wedged.
> 
> Terraform wires **`ecs:ListTasks`**, **`sqs:ChangeMessageVisibility`**, the env var, dispatch queue **`maxReceiveCount` 3→30** (longer cap waits), and SQS trigger **`maximum_concurrency = 2`** to limit check-then-launch races. Tests add **`TestConcurrencyCap`** (six cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23dd8ec8c4c7868166e951e8f41d494bb712dbfa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->