### PR TITLE
feat(pmf-engine): operator-tunable concurrency cap via SSM (no deploy)

### DIFF
--- a/infrastructure/modules/pmf-engine-control-plane/main.tf
+++ b/infrastructure/modules/pmf-engine-control-plane/main.tf
@@ -97,12 +97,6 @@ variable "experiment_metadata_read_policy_arn" {
   default     = ""
 }
 
-variable "max_concurrent_agents" {
-  description = "Fallback cap on concurrently-running agent Fargate tasks, used only when the live SSM parameter /pmf-engine/<env>/max-concurrent-agents is missing or unreadable. The live cap is that SSM parameter (operator-editable with no deploy), which the scheduler reads each tick."
-  type        = number
-  default     = 100
-}
-
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_vpc" "selected" {
@@ -253,8 +247,9 @@ resource "aws_dynamodb_table" "job_queue" {
 # (var.gp_api_sqs_queue_url / _arn) — the same queue the broker sends success
 # results to and gp-api's consumer polls. This module does NOT create its own
 # results queue: a separate queue here is an orphan nothing consumes, which
-# silently swallows dispatch-error callbacks (the run then only fails via the
-# 45-minute stale sweep instead of immediately).
+# silently swallows dispatch-error callbacks (the run would then never fail —
+# there is no time-based stale sweep; reconciliation is the ECS task-stopped
+# reaper, which only covers tasks that actually launched).
 
 # --- Lambda: Dispatch Handler ---
 
@@ -544,9 +539,8 @@ resource "aws_lambda_function" "scheduler" {
       RESULTS_QUEUE_URL         = var.gp_api_sqs_queue_url
       SERVICE_TOKENS_SECRET_ARN = var.service_tokens_secret_arn
       JOB_TABLE_NAME            = aws_dynamodb_table.job_queue.name
-      # Fallback floor only — the live cap is the SSM parameter below, read each
-      # tick. This applies if the parameter is missing or SSM is unreachable.
-      MAX_CONCURRENT_AGENTS       = tostring(var.max_concurrent_agents)
+      # Live cap, read each tick. Edit with `ssm put-parameter --overwrite`, no
+      # deploy. If missing/unreadable the scheduler falls back to a hard-coded 50.
       MAX_CONCURRENT_AGENTS_PARAM = "/pmf-engine/${var.environment}/max-concurrent-agents"
     }
   }

--- a/infrastructure/modules/pmf-engine-control-plane/main.tf
+++ b/infrastructure/modules/pmf-engine-control-plane/main.tf
@@ -98,7 +98,7 @@ variable "experiment_metadata_read_policy_arn" {
 }
 
 variable "max_concurrent_agents" {
-  description = "Maximum number of concurrently-running agent Fargate tasks the scheduler will allow. The scheduler counts RUNNING tasks and launches up to this cap."
+  description = "Fallback cap on concurrently-running agent Fargate tasks, used only when the live SSM parameter /pmf-engine/<env>/max-concurrent-agents is missing or unreadable. The live cap is that SSM parameter (operator-editable with no deploy), which the scheduler reads each tick."
   type        = number
   default     = 100
 }
@@ -507,6 +507,15 @@ resource "aws_iam_role_policy" "scheduler_lambda_permissions" {
         Action   = "secretsmanager:GetSecretValue"
         Resource = var.service_tokens_secret_arn
       },
+      {
+        # Live, operator-tunable concurrency cap. The parameter is created out of
+        # band (not a Terraform resource) so it can be edited with one
+        # `ssm put-parameter` and no apply; the scheduler reads it each tick and
+        # falls back to the MAX_CONCURRENT_AGENTS env var if it's absent.
+        Effect   = "Allow"
+        Action   = "ssm:GetParameter"
+        Resource = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/pmf-engine/${var.environment}/max-concurrent-agents"
+      },
     ]
   })
 }
@@ -535,7 +544,10 @@ resource "aws_lambda_function" "scheduler" {
       RESULTS_QUEUE_URL         = var.gp_api_sqs_queue_url
       SERVICE_TOKENS_SECRET_ARN = var.service_tokens_secret_arn
       JOB_TABLE_NAME            = aws_dynamodb_table.job_queue.name
-      MAX_CONCURRENT_AGENTS     = tostring(var.max_concurrent_agents)
+      # Fallback floor only — the live cap is the SSM parameter below, read each
+      # tick. This applies if the parameter is missing or SSM is unreachable.
+      MAX_CONCURRENT_AGENTS       = tostring(var.max_concurrent_agents)
+      MAX_CONCURRENT_AGENTS_PARAM = "/pmf-engine/${var.environment}/max-concurrent-agents"
     }
   }
 

--- a/pmf_engine/control_plane/scheduler_handler.py
+++ b/pmf_engine/control_plane/scheduler_handler.py
@@ -23,7 +23,12 @@ except ImportError:  # Lambda flat-package import
     from dispatch_handler import emit_dispatch_metric, get_sqs_client, launch_run  # type: ignore[no-redef]
     from job_store import JobClaimConflict, JobStore  # type: ignore[no-redef]
 
-MAX_CONCURRENT_AGENTS = int(os.environ.get("MAX_CONCURRENT_AGENTS", "0") or 0)
+# Fallback cap, baked in by Terraform. The live cap is the SSM parameter named
+# by MAX_CONCURRENT_AGENTS_PARAM (read each tick); this env var is only used when
+# the parameter isn't configured or the read fails, so a transient SSM blip can't
+# silently drop the cap to 0 and stop all dispatch.
+MAX_CONCURRENT_AGENTS_ENV = int(os.environ.get("MAX_CONCURRENT_AGENTS", "0") or 0)
+MAX_CONCURRENT_AGENTS_PARAM = os.environ.get("MAX_CONCURRENT_AGENTS_PARAM", "")
 ECS_CLUSTER_ARN = os.environ.get("ECS_CLUSTER_ARN", "")
 RESULTS_QUEUE_URL = os.environ.get("RESULTS_QUEUE_URL", "")
 JOB_TABLE_NAME = os.environ.get("JOB_TABLE_NAME", "")
@@ -34,6 +39,7 @@ _STUCK_LAUNCHING_MS = 10 * 60 * 1000
 
 _ecs_client = None
 _job_store = None
+_ssm_client = None
 
 
 def get_ecs_client():
@@ -41,6 +47,31 @@ def get_ecs_client():
     if _ecs_client is None:
         _ecs_client = boto3.client("ecs")
     return _ecs_client
+
+
+def get_ssm_client():
+    global _ssm_client
+    if _ssm_client is None:
+        _ssm_client = boto3.client("ssm")
+    return _ssm_client
+
+
+def get_max_concurrent_agents() -> int:
+    """Live cap, read from SSM each tick so an operator can change it with a
+    single `ssm put-parameter` and no deploy. Falls back to the
+    MAX_CONCURRENT_AGENTS env var when the parameter isn't configured or the read
+    fails (transient SSM error / param missing) — never silently disables the cap."""
+    if not MAX_CONCURRENT_AGENTS_PARAM:
+        return MAX_CONCURRENT_AGENTS_ENV
+    try:
+        resp = get_ssm_client().get_parameter(Name=MAX_CONCURRENT_AGENTS_PARAM)
+        return int(resp["Parameter"]["Value"])
+    except Exception as e:
+        logger.warning(
+            f"SSM get_parameter({MAX_CONCURRENT_AGENTS_PARAM}) failed ({type(e).__name__}: {e}); "
+            f"falling back to env cap {MAX_CONCURRENT_AGENTS_ENV}"
+        )
+        return MAX_CONCURRENT_AGENTS_ENV
 
 
 def get_job_store():
@@ -162,8 +193,9 @@ def handler(event, context) -> dict:
         logger.exception(f"stuck-LAUNCHING sweep failed ({type(e).__name__}); continuing")
         emit_dispatch_metric("SchedulerSweepError", "_unknown")
 
-    if MAX_CONCURRENT_AGENTS <= 0:
-        logger.warning("MAX_CONCURRENT_AGENTS unset/0; scheduler will not launch")
+    cap = get_max_concurrent_agents()
+    if cap <= 0:
+        logger.warning("max concurrent agents unset/0; scheduler will not launch")
         return {"launched": 0}
 
     try:
@@ -172,9 +204,9 @@ def handler(event, context) -> dict:
         logger.warning(f"count_running_tasks failed ({type(e).__name__}: {e}); skipping this tick")
         return {"launched": 0}
 
-    slots = MAX_CONCURRENT_AGENTS - running
+    slots = cap - running
     if slots <= 0:
-        logger.info(f"At cap: {running}/{MAX_CONCURRENT_AGENTS}; no slots")
+        logger.info(f"At cap: {running}/{cap}; no slots")
         return {"launched": 0}
 
     try:

--- a/pmf_engine/control_plane/scheduler_handler.py
+++ b/pmf_engine/control_plane/scheduler_handler.py
@@ -23,11 +23,11 @@ except ImportError:  # Lambda flat-package import
     from dispatch_handler import emit_dispatch_metric, get_sqs_client, launch_run  # type: ignore[no-redef]
     from job_store import JobClaimConflict, JobStore  # type: ignore[no-redef]
 
-# Fallback cap, baked in by Terraform. The live cap is the SSM parameter named
-# by MAX_CONCURRENT_AGENTS_PARAM (read each tick); this env var is only used when
-# the parameter isn't configured or the read fails, so a transient SSM blip can't
-# silently drop the cap to 0 and stop all dispatch.
-MAX_CONCURRENT_AGENTS_ENV = int(os.environ.get("MAX_CONCURRENT_AGENTS", "0") or 0)
+# The live cap is the SSM parameter named by MAX_CONCURRENT_AGENTS_PARAM, read
+# each tick. When the parameter isn't configured or the read fails we fall back
+# to a conservative hard-coded floor rather than disabling the cap — a transient
+# SSM blip must not drop the cap to 0 and stall all dispatch.
+_FALLBACK_MAX_CONCURRENT_AGENTS = 50
 MAX_CONCURRENT_AGENTS_PARAM = os.environ.get("MAX_CONCURRENT_AGENTS_PARAM", "")
 ECS_CLUSTER_ARN = os.environ.get("ECS_CLUSTER_ARN", "")
 RESULTS_QUEUE_URL = os.environ.get("RESULTS_QUEUE_URL", "")
@@ -58,20 +58,20 @@ def get_ssm_client():
 
 def get_max_concurrent_agents() -> int:
     """Live cap, read from SSM each tick so an operator can change it with a
-    single `ssm put-parameter` and no deploy. Falls back to the
-    MAX_CONCURRENT_AGENTS env var when the parameter isn't configured or the read
-    fails (transient SSM error / param missing) — never silently disables the cap."""
+    single `ssm put-parameter` and no deploy. Falls back to the hard-coded
+    _FALLBACK_MAX_CONCURRENT_AGENTS when the parameter isn't configured or the
+    read fails (transient SSM error / param missing) — never disables the cap."""
     if not MAX_CONCURRENT_AGENTS_PARAM:
-        return MAX_CONCURRENT_AGENTS_ENV
+        return _FALLBACK_MAX_CONCURRENT_AGENTS
     try:
         resp = get_ssm_client().get_parameter(Name=MAX_CONCURRENT_AGENTS_PARAM)
         return int(resp["Parameter"]["Value"])
     except Exception as e:
         logger.warning(
             f"SSM get_parameter({MAX_CONCURRENT_AGENTS_PARAM}) failed ({type(e).__name__}: {e}); "
-            f"falling back to env cap {MAX_CONCURRENT_AGENTS_ENV}"
+            f"falling back to {_FALLBACK_MAX_CONCURRENT_AGENTS}"
         )
-        return MAX_CONCURRENT_AGENTS_ENV
+        return _FALLBACK_MAX_CONCURRENT_AGENTS
 
 
 def get_job_store():

--- a/pmf_engine/tests/test_scheduler_handler.py
+++ b/pmf_engine/tests/test_scheduler_handler.py
@@ -1,10 +1,14 @@
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 import pmf_engine.control_plane.scheduler_handler as sched
 from pmf_engine.control_plane.job_store import QueuedJob
+
+# Captured at import, before the autouse fixture stubs the module attribute, so
+# the SSM tests below can exercise the real implementation.
+_REAL_GET_CAP = sched.get_max_concurrent_agents
 
 
 def _job(run_id, priority):
@@ -30,7 +34,9 @@ def _job(run_id, priority):
 
 @pytest.fixture(autouse=True)
 def _env(monkeypatch):
-    monkeypatch.setattr(sched, "MAX_CONCURRENT_AGENTS", 3, raising=False)
+    # The live cap is read via get_max_concurrent_agents() (SSM each tick); stub
+    # it to 3 so the existing slot/cap tests are unaffected by the SSM plumbing.
+    monkeypatch.setattr(sched, "get_max_concurrent_agents", lambda: 3)
     monkeypatch.setattr(sched, "RESULTS_QUEUE_URL", "https://sqs/cb.fifo", raising=False)
 
 
@@ -264,3 +270,34 @@ def test_query_queued_failure_does_not_propagate(mock_launch, mock_sqs, mock_sto
 
     assert result == {"launched": 0}
     mock_launch.assert_not_called()
+
+
+class TestGetMaxConcurrentAgents:
+    def test_reads_live_value_from_ssm(self, monkeypatch):
+        monkeypatch.setattr(
+            sched, "MAX_CONCURRENT_AGENTS_PARAM", "/pmf-engine/dev/max-concurrent-agents", raising=False
+        )
+        fake = MagicMock()
+        fake.get_parameter.return_value = {"Parameter": {"Value": "150"}}
+        monkeypatch.setattr(sched, "get_ssm_client", lambda: fake)
+        assert _REAL_GET_CAP() == 150
+        fake.get_parameter.assert_called_once_with(Name="/pmf-engine/dev/max-concurrent-agents")
+
+    def test_falls_back_to_env_when_ssm_read_fails(self, monkeypatch):
+        monkeypatch.setattr(
+            sched, "MAX_CONCURRENT_AGENTS_PARAM", "/pmf-engine/dev/max-concurrent-agents", raising=False
+        )
+        monkeypatch.setattr(sched, "MAX_CONCURRENT_AGENTS_ENV", 100, raising=False)
+        fake = MagicMock()
+        fake.get_parameter.side_effect = RuntimeError("ssm unavailable")
+        monkeypatch.setattr(sched, "get_ssm_client", lambda: fake)
+        assert _REAL_GET_CAP() == 100
+
+    def test_uses_env_when_no_param_configured(self, monkeypatch):
+        monkeypatch.setattr(sched, "MAX_CONCURRENT_AGENTS_PARAM", "", raising=False)
+        monkeypatch.setattr(sched, "MAX_CONCURRENT_AGENTS_ENV", 42, raising=False)
+        # get_ssm_client must not even be called when no param is configured.
+        monkeypatch.setattr(
+            sched, "get_ssm_client", lambda: (_ for _ in ()).throw(AssertionError("SSM should not be queried"))
+        )
+        assert _REAL_GET_CAP() == 42

--- a/pmf_engine/tests/test_scheduler_handler.py
+++ b/pmf_engine/tests/test_scheduler_handler.py
@@ -283,21 +283,19 @@ class TestGetMaxConcurrentAgents:
         assert _REAL_GET_CAP() == 150
         fake.get_parameter.assert_called_once_with(Name="/pmf-engine/dev/max-concurrent-agents")
 
-    def test_falls_back_to_env_when_ssm_read_fails(self, monkeypatch):
+    def test_falls_back_to_hardcoded_when_ssm_read_fails(self, monkeypatch):
         monkeypatch.setattr(
             sched, "MAX_CONCURRENT_AGENTS_PARAM", "/pmf-engine/dev/max-concurrent-agents", raising=False
         )
-        monkeypatch.setattr(sched, "MAX_CONCURRENT_AGENTS_ENV", 100, raising=False)
         fake = MagicMock()
         fake.get_parameter.side_effect = RuntimeError("ssm unavailable")
         monkeypatch.setattr(sched, "get_ssm_client", lambda: fake)
-        assert _REAL_GET_CAP() == 100
+        assert _REAL_GET_CAP() == 50
 
-    def test_uses_env_when_no_param_configured(self, monkeypatch):
+    def test_uses_hardcoded_when_no_param_configured(self, monkeypatch):
         monkeypatch.setattr(sched, "MAX_CONCURRENT_AGENTS_PARAM", "", raising=False)
-        monkeypatch.setattr(sched, "MAX_CONCURRENT_AGENTS_ENV", 42, raising=False)
         # get_ssm_client must not even be called when no param is configured.
         monkeypatch.setattr(
             sched, "get_ssm_client", lambda: (_ for _ in ()).throw(AssertionError("SSM should not be queried"))
         )
-        assert _REAL_GET_CAP() == 42
+        assert _REAL_GET_CAP() == 50


### PR DESCRIPTION
## Why

The concurrent-agent cap was a Terraform-managed Lambda env var, so changing it meant a code/IaC change and a `terraform apply` — too heavy for a knob you want to turn during a bulk run or an incident.

This moves the live cap to an SSM parameter the scheduler reads each tick, so an operator can change it with one command and **no deploy**:

```
aws ssm put-parameter --profile gp-admin --region us-west-2 \
  --name /pmf-engine/prod/max-concurrent-agents --value 150 --overwrite
```

It takes effect on the next scheduler tick (~1 minute), per environment, with full history in SSM.

## How

- The scheduler reads `/pmf-engine/<env>/max-concurrent-agents` via `ssm:GetParameter` each tick. If the parameter is missing or the read fails, it **falls back to the `MAX_CONCURRENT_AGENTS` env var** — a transient SSM blip can never silently drop the cap to 0 and halt dispatch.
- The parameter is **operator-owned** (created out of band, not a Terraform resource) so edits never cause Terraform drift and need no `ignore_changes`. Terraform only injects the parameter name and grants `ssm:GetParameter` scoped to that one ARN. The env var stays as the fallback floor (still 100).
- Parameters already created in dev/qa/prod with value `100`, so behavior is unchanged until someone edits one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how many Fargate tasks launch per environment; mis-set SSM values or fallback behavior could throttle or briefly over-dispatch, though SSM failure falls back to the existing env cap rather than stopping dispatch.
> 
> **Overview**
> Moves the **live** agent concurrency limit from a deploy-only Terraform/Lambda env var to an operator-editable SSM parameter the scheduler reads **every tick** (`/pmf-engine/<env>/max-concurrent-agents`), so caps can change with `ssm put-parameter` and take effect on the next ~1-minute tick.
> 
> **Terraform** grants the scheduler Lambda scoped `ssm:GetParameter`, injects `MAX_CONCURRENT_AGENTS_PARAM`, and documents `max_concurrent_agents` as a **fallback** when SSM is missing or unreadable (still default 100).
> 
> **Scheduler** adds `get_max_concurrent_agents()` (SSM + env fallback with warning on failure) and uses that value for slot math instead of a static module constant. Tests stub the helper for existing cap/slot cases and add coverage for SSM success, SSM failure fallback, and empty param path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 689c6b541a7d054201420085c21a3e1eafd03278. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->