### PR TITLE
ENG-10299: Add experiment name to PMF task-failure Slack alerts

### DIFF
--- a/infrastructure/modules/pmf-engine-fargate/main.tf
+++ b/infrastructure/modules/pmf-engine-fargate/main.tf
@@ -355,6 +355,15 @@ resource "aws_cloudwatch_event_target" "send_to_sns" {
       exitCode      = "$.detail.containers[0].exitCode"
       clusterArn    = "$.detail.clusterArn"
       time          = "$.time"
+      # The ECS Task State Change event echoes the RunTask overrides. The
+      # experiment id is the FIRST entry of the container's environment array
+      # (control_plane/dispatch_handler.py:build_container_overrides emits
+      # EXPERIMENT_ID first and keeps the array byte-deterministic). We pull
+      # only this one value on purpose — the same array holds BROKER_TOKEN /
+      # ANTHROPIC_API_KEY / BRAINTRUST_API_KEY, which must not reach SNS or the
+      # notifier's CloudWatch logs. If that env ordering ever changes, this
+      # path must change with it.
+      experimentId = "$.detail.overrides.containerOverrides[0].environment[0].value"
     }
 
     input_template = <<EOF
@@ -363,6 +372,7 @@ resource "aws_cloudwatch_event_target" "send_to_sns" {
   "environment": "${var.environment}",
   "cluster": <clusterArn>,
   "taskArn": <taskArn>,
+  "experimentId": <experimentId>,
   "stoppedReason": <stoppedReason>,
   "exitCode": <exitCode>,
   "time": <time>,

--- a/infrastructure/modules/serve-analyze-fargate/slack-notifier/index.test.ts
+++ b/infrastructure/modules/serve-analyze-fargate/slack-notifier/index.test.ts
@@ -1,0 +1,118 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  formatSlackMessage,
+  extractTaskId,
+  getColorForExitCode,
+  type TaskFailureMessage,
+  type SlackMessage,
+} from './index';
+
+// A PMF Engine failure as the EventBridge input transformer emits it: the
+// experiment id is pulled from containerOverrides[0].environment[0].value.
+function pmfFailure(
+  overrides: Partial<TaskFailureMessage> = {}
+): TaskFailureMessage {
+  return {
+    alarm: 'PMF Engine Task Failed',
+    environment: 'dev',
+    cluster: 'arn:aws:ecs:us-west-2:333022194791:cluster/pmf-engine-dev',
+    taskArn:
+      'arn:aws:ecs:us-west-2:333022194791:task/pmf-engine-dev/dad53d5d1234567890abcdef',
+    experimentId: 'campaign-website-grader',
+    stoppedReason: 'Essential container in task exited',
+    exitCode: 1,
+    time: '2026-06-22T20:29:08Z',
+    logs: 'https://console.aws.amazon.com/cloudwatch/home',
+    ...overrides,
+  };
+}
+
+// Pull the flat {title: value} field map out of the Slack attachment so tests
+// can assert on content without depending on field ordering.
+function fieldMap(payload: SlackMessage): Record<string, string> {
+  const fields = payload.attachments[0].fields ?? [];
+  return Object.fromEntries(fields.map((f) => [f.title, f.value]));
+}
+
+test('surfaces the experiment id in the title and a field', () => {
+  const payload = formatSlackMessage(pmfFailure());
+
+  assert.equal(
+    payload.attachments[0].title,
+    ':x: PMF Engine Task Failed — campaign-website-grader'
+  );
+  assert.equal(fieldMap(payload).Experiment, 'campaign-website-grader');
+});
+
+test('keeps the existing fields alongside the new Experiment field', () => {
+  const fields = fieldMap(formatSlackMessage(pmfFailure()));
+
+  assert.equal(fields.Environment, 'dev');
+  assert.equal(fields['Task ID'], 'dad53d5d');
+  assert.equal(fields['Exit Code'], '1');
+  assert.equal(fields['Stopped Reason'], 'Essential container in task exited');
+});
+
+test('omits the Experiment field when no experiment id is present', () => {
+  // Other producers share this SNS topic and send no experimentId.
+  const payload = formatSlackMessage(pmfFailure({ experimentId: undefined }));
+
+  assert.equal(payload.attachments[0].title, ':x: PMF Engine Task Failed');
+  assert.equal('Experiment' in fieldMap(payload), false);
+});
+
+test('treats empty, whitespace, or the literal "null" as absent', () => {
+  // EventBridge substitutes a placeholder when the env path does not resolve:
+  // "" in the normal case, the literal string "null" for an unmatched path.
+  for (const experimentId of ['', '   ', 'null']) {
+    const payload = formatSlackMessage(pmfFailure({ experimentId }));
+    assert.equal(payload.attachments[0].title, ':x: PMF Engine Task Failed');
+    assert.equal('Experiment' in fieldMap(payload), false);
+  }
+});
+
+test('falls back to a generic title when alarm is missing', () => {
+  const payload = formatSlackMessage(
+    pmfFailure({ alarm: '', experimentId: undefined })
+  );
+  assert.equal(payload.attachments[0].title, ':x: ECS Task Failed');
+});
+
+test('combines the alarm fallback with an experiment suffix', () => {
+  const payload = formatSlackMessage(
+    pmfFailure({ alarm: '', experimentId: 'voter-turnout-model' })
+  );
+  assert.equal(
+    payload.attachments[0].title,
+    ':x: ECS Task Failed — voter-turnout-model'
+  );
+});
+
+test('color reflects the exit code', () => {
+  assert.equal(getColorForExitCode(1), '#FF0000');
+  assert.equal(getColorForExitCode(137), '#FF6600'); // SIGKILL / OOM
+  assert.equal(getColorForExitCode(143), '#FF9900'); // SIGTERM
+  assert.equal(getColorForExitCode(99), '#CC0000'); // fallback
+  assert.equal(
+    formatSlackMessage(pmfFailure({ exitCode: 137 })).attachments[0].color,
+    '#FF6600'
+  );
+});
+
+test('extractTaskId returns the first 8 chars of the task uuid', () => {
+  assert.equal(
+    extractTaskId(
+      'arn:aws:ecs:us-west-2:333022194791:task/pmf-engine-dev/dad53d5d1234567890abcdef'
+    ),
+    'dad53d5d'
+  );
+});
+
+test('extractTaskId returns a short id unchanged rather than padding', () => {
+  assert.equal(
+    extractTaskId('arn:aws:ecs:us-west-2:1:task/cluster/abc12'),
+    'abc12'
+  );
+});

--- a/infrastructure/modules/serve-analyze-fargate/slack-notifier/index.ts
+++ b/infrastructure/modules/serve-analyze-fargate/slack-notifier/index.ts
@@ -12,15 +12,45 @@ interface SNSEvent {
   }>;
 }
 
-interface TaskFailureMessage {
+export interface TaskFailureMessage {
   alarm: string;
   environment: string;
   cluster: string;
   taskArn: string;
+  // Present for PMF Engine task failures (the experiment that was running).
+  // Absent for other producers on this shared topic, so treat as optional.
+  experimentId?: string;
   stoppedReason: string;
   exitCode: number;
   time: string;
   logs: string;
+}
+
+interface SlackField {
+  title: string;
+  value: string;
+  short: boolean;
+}
+
+export interface SlackMessage {
+  username: string;
+  icon_emoji: string;
+  attachments: Array<{
+    color: string;
+    title: string;
+    title_link?: string;
+    text?: string;
+    fields?: SlackField[];
+    footer: string;
+    footer_icon?: string;
+    ts: number;
+    actions?: Array<{
+      type: string;
+      text: string;
+      url: string;
+      style: string;
+    }>;
+  }>;
 }
 
 interface AISecrets {
@@ -66,21 +96,71 @@ async function getSlackWebhookUrl(): Promise<string> {
   }
 }
 
-function extractTaskId(taskArn: string): string {
+export function extractTaskId(taskArn: string): string {
   const parts = taskArn.split('/');
   return parts[parts.length - 1].substring(0, 8);
 }
 
-function getColorForExitCode(exitCode: number): string {
+export function getColorForExitCode(exitCode: number): string {
   if (exitCode === 1) return '#FF0000';
   if (exitCode === 137) return '#FF6600';
   if (exitCode === 143) return '#FF9900';
   return '#CC0000';
 }
 
-function formatSlackMessage(message: TaskFailureMessage): any {
+export function formatSlackMessage(message: TaskFailureMessage): SlackMessage {
   const taskId = extractTaskId(message.taskArn);
   const color = getColorForExitCode(message.exitCode);
+  // When the experimentId path doesn't resolve (a non-PMF producer on this
+  // shared topic, or a task with no container overrides), EventBridge
+  // substitutes a placeholder into the template — empty string in the normal
+  // case, but the literal string "null" for an unmatched input path. Treat all
+  // of those as "no experiment" so they never render as a field or title.
+  const raw = message.experimentId?.trim();
+  const experimentId = raw && raw !== 'null' ? raw : undefined;
+
+  // Lead with the experiment so PMF experiment owners can triage at a glance.
+  const base = `:x: ${message.alarm || 'ECS Task Failed'}`;
+  const title = experimentId ? `${base} — ${experimentId}` : base;
+
+  const fields: SlackField[] = [
+    {
+      title: 'Environment',
+      value: message.environment,
+      short: true,
+    },
+  ];
+
+  if (experimentId) {
+    fields.push({
+      title: 'Experiment',
+      value: experimentId,
+      short: true,
+    });
+  }
+
+  fields.push(
+    {
+      title: 'Task ID',
+      value: taskId,
+      short: true,
+    },
+    {
+      title: 'Exit Code',
+      value: String(message.exitCode),
+      short: true,
+    },
+    {
+      title: 'Time',
+      value: new Date(message.time).toLocaleString(),
+      short: true,
+    },
+    {
+      title: 'Stopped Reason',
+      value: message.stoppedReason,
+      short: false,
+    }
+  );
 
   return {
     username: 'ECS Pipeline Monitor',
@@ -88,35 +168,9 @@ function formatSlackMessage(message: TaskFailureMessage): any {
     attachments: [
       {
         color: color,
-        title: ':x: ECS Task Failed',
+        title: title,
         title_link: message.logs,
-        fields: [
-          {
-            title: 'Environment',
-            value: message.environment,
-            short: true,
-          },
-          {
-            title: 'Task ID',
-            value: taskId,
-            short: true,
-          },
-          {
-            title: 'Exit Code',
-            value: String(message.exitCode),
-            short: true,
-          },
-          {
-            title: 'Time',
-            value: new Date(message.time).toLocaleString(),
-            short: true,
-          },
-          {
-            title: 'Stopped Reason',
-            value: message.stoppedReason,
-            short: false,
-          },
-        ],
+        fields: fields,
         footer: 'ECS Task Failure Monitor',
         footer_icon: 'https://a0.awsstatic.com/libra-css/images/logos/aws_logo_smile_1200x630.png',
         ts: Math.floor(new Date(message.time).getTime() / 1000),

--- a/infrastructure/modules/serve-analyze-fargate/slack-notifier/package.json
+++ b/infrastructure/modules/serve-analyze-fargate/slack-notifier/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "package": "npm run build && cd dist && zip -r ../slack-notifier.zip .",
-    "clean": "rm -rf dist slack-notifier.zip"
+    "clean": "rm -rf dist slack-notifier.zip",
+    "test": "node --import tsx --test \"*.test.ts\""
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.0.0"
@@ -14,6 +15,7 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.145",
     "@types/node": "^22.0.0",
+    "tsx": "^4.19.2",
     "typescript": "^5.5.4"
   }
 }

--- a/infrastructure/modules/serve-analyze-fargate/slack-notifier/tsconfig.json
+++ b/infrastructure/modules/serve-analyze-fargate/slack-notifier/tsconfig.json
@@ -13,5 +13,5 @@
     "resolveJsonModule": true
   },
   "include": ["*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "*.test.ts"]
 }

--- a/pmf_engine/tests/test_dispatch_handler.py
+++ b/pmf_engine/tests/test_dispatch_handler.py
@@ -334,6 +334,40 @@ class TestBuildContainerOverrides:
         assert json.loads(env_map["PARAMS_JSON"]) == {"district": "CA-12"}
         assert env_map["TIMEOUT_SECONDS"] == "600"
 
+    def test_experiment_id_is_first_env_var(self):
+        # CONTRACT: EXPERIMENT_ID MUST be the first entry of the container
+        # environment array. The pmf-engine-fargate EventBridge rule extracts
+        # the experiment id for failure Slack alerts via the positional path
+        # `$.detail.overrides.containerOverrides[0].environment[0].value`
+        # (EventBridge input transformers cannot filter an array by key name).
+        # Reordering this array would silently surface the WRONG value in the
+        # alert — and because BROKER_TOKEN / ANTHROPIC_API_KEY / BRAINTRUST_API_KEY
+        # live later in the same array, a reorder that pushed a secret to index 0
+        # would leak it into SNS and the notifier's CloudWatch logs. This test
+        # pins the ordering so any such regression breaks CI loudly instead.
+        experiment = {
+            "harness": "claude_sdk",
+            "model": "sonnet",
+            "contract": {"type": "json", "s3_key_template": "t"},
+        }
+        message = {
+            "experiment_type": "smoke_test",
+            "organization_slug": "org-123",
+            "run_id": "run-abc",
+            "clerk_user_id": "user_test_dispatch",
+            "params": {},
+        }
+        overrides = build_container_overrides(
+            experiment=experiment,
+            message=message,
+            broker_token="tok",
+            broker_url="https://broker.example.com",
+            container_name="pmf-engine",
+        )
+        env = overrides["containerOverrides"][0]["environment"]
+        assert env[0]["name"] == "EXPERIMENT_ID"
+        assert env[0]["value"] == "smoke_test"
+
     def test_no_artifact_bucket_or_callback_queue_in_overrides(self):
         experiment = {
             "harness": "claude_sdk",
@@ -740,13 +774,13 @@ class TestHandler:
         )
 
         warning_records = [r for r in records if r.levelno == logging.WARNING and "nonexistent" in r.getMessage()]
-        assert (
-            warning_records == []
-        ), f"Expected no WARNING-level log for unknown experiment, got: {[r.getMessage() for r in warning_records]}"
+        assert warning_records == [], (
+            f"Expected no WARNING-level log for unknown experiment, got: {[r.getMessage() for r in warning_records]}"
+        )
 
-        assert any(
-            "smoke_test" in r.getMessage() for r in error_records
-        ), "Expected error log to include known experiment IDs for operator triage"
+        assert any("smoke_test" in r.getMessage() for r in error_records), (
+            "Expected error log to include known experiment IDs for operator triage"
+        )
 
     @patch("pmf_engine.control_plane.dispatch_handler.BrokerClient")
     @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
@@ -1799,9 +1833,9 @@ class TestEcsErrorCallbackDoesNotLeakRawDetail:
         assert result["status"] == "failed"
         error_str = result["error"]
         assert "arn:aws:iam" not in error_str, f"Expected sanitized error, got ARN-leaking message: {error_str!r}"
-        assert (
-            "333022194791" not in error_str
-        ), f"Expected sanitized error, got account-id-leaking message: {error_str!r}"
+        assert "333022194791" not in error_str, (
+            f"Expected sanitized error, got account-id-leaking message: {error_str!r}"
+        )
         assert "ECS RunTask failed" in error_str
 
     @patch("pmf_engine.control_plane.dispatch_handler.BrokerClient")
@@ -1875,9 +1909,9 @@ class TestEcsErrorCallbackDoesNotLeakRawDetail:
             dh.logger.setLevel(original_level)
 
         combined = " ".join(r.getMessage() for r in records if r.levelno >= logging.ERROR)
-        assert (
-            "arn:aws:iam::333022194791" in combined
-        ), f"Operator diagnostic log must retain full ARN detail; got: {combined!r}"
+        assert "arn:aws:iam::333022194791" in combined, (
+            f"Operator diagnostic log must retain full ARN detail; got: {combined!r}"
+        )
 
 
 class TestRunTaskFailureCleansUpMintedTicket:
@@ -2149,9 +2183,9 @@ class TestResolveRoutingFailures:
         assert routing["model"] == "sonnet"
         # known is only populated on the unknown-experiment branch (routing is None).
         assert known == []
-        assert not any(
-            call.args[0] == "manifest_loader_fallback" for call in mock_metric.call_args_list
-        ), "happy path must not emit fallback metric"
+        assert not any(call.args[0] == "manifest_loader_fallback" for call in mock_metric.call_args_list), (
+            "happy path must not emit fallback metric"
+        )
 
     def test_loader_transient_error_raises_and_emits_metric(self, monkeypatch):
         """S3 outage / IAM throttle → re-raise ManifestLoaderTransientError so


### PR DESCRIPTION
## Problem

PMF Engine runs many experiments — effectively separate products with different owners. But the `PMF Engine Task Failed` alerts in **#ai-service-failures** never said *which* experiment failed:

> PMF Engine Task Failed · Environment dev · Task ID dad53d5d · Exit Code 1 · Time … · Stopped Reason Essential container in task exited

So owners couldn't tell at a glance whether an alert was theirs.

## Change

The experiment id rides in the task's `containerOverrides` environment as `EXPERIMENT_ID` (`build_container_overrides` emits it first). The ECS Task State Change event echoes those overrides, so:

- **`pmf-engine-fargate` EventBridge rule** now extracts `$.detail.overrides.containerOverrides[0].environment[0].value` into the SNS payload as `experimentId`.
- **`shared-slack-notifier`** surfaces it in the alert title (`:x: PMF Engine Task Failed — <experiment>`) and as an `Experiment` field. The title now derives from `message.alarm`, matching what deployed alerts already show.

## Safety

Only that single value is forwarded — the same env array also holds `BROKER_TOKEN` / `ANTHROPIC_API_KEY` / `BRAINTRUST_API_KEY`, which must not reach SNS or CloudWatch logs. Forwarding the whole array would leak them into the notifier's `console.log`.

Because EventBridge input transformers can't filter an array by key name, the extraction is positional (`environment[0]`). To keep that safe, a new `pmf_engine` test pins `EXPERIMENT_ID` at index 0 — a reorder now breaks CI loudly instead of silently leaking a secret or surfacing the wrong value.

The notifier treats empty / whitespace / the literal `"null"` as "no experiment" (EventBridge substitutes a placeholder for non-PMF producers that share the topic).

## Tests

- New `pmf_engine` test pinning the `EXPERIMENT_ID` env-ordering invariant (124 dispatch tests pass).
- First TS tests in infra — `node:test` via `tsx` — covering the notifier formatting (title, experiment field, absent/null guards, color, task-id extraction). Test files are excluded from the Lambda build zip.

## Reviewed by ai-rules critics

ran ts-engineer, test-engineer, bugs, security, breaking-changes, and code-duplication critics; their should-fix items (typed return, dedup, null guard, env-ordering pin, added test cases) are folded in.

## Deploy notes

- Two parts: `terraform apply` for the EventBridge change, and a rebuild+redeploy of `shared-slack-notifier`. Note the shared Lambda loads its zip from `infrastructure/shared/slack-notifier/slack-notifier.zip` — confirm how that zip is built before shipping.
- **Worth verifying in dev first:** that the real ECS Task State Change event actually echoes `overrides.containerOverrides[].environment`. The design assumes it does; if AWS omits the env array for a given event version, `experimentId` won't resolve (the notifier degrades gracefully to the old format).
- Scope is PMF only — `engineer-agent-fargate` and `ddhq-matcher-fargate` share the same pattern if we want the same treatment later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alerting and EventBridge payload shape change with positional env extraction tied to dispatch ordering; misconfiguration or env reorder could omit the experiment id or leak secrets, though tests and single-value forwarding mitigate that.
> 
> **Overview**
> PMF Engine task-failure Slack alerts now identify **which experiment** failed, so owners can triage without digging through generic ECS metadata.
> 
> The **pmf-engine-fargate** EventBridge input transformer adds `experimentId` to the SNS payload by reading the first container override env value (`containerOverrides[0].environment[0]`), matching how dispatch emits `EXPERIMENT_ID` first. Only that single field is forwarded so broker/API secrets in the same env list never reach SNS or the notifier logs.
> 
> The **shared slack-notifier** accepts optional `experimentId`, appends it to the attachment title (`— <experiment>`), and adds an **Experiment** field when present; empty, whitespace, and EventBridge’s literal `"null"` are treated as absent so other SNS producers on the topic keep the old format. Formatting helpers are exported and covered by new **node:test** cases; test files are excluded from the Lambda build.
> 
> A new **pmf_engine** test asserts `EXPERIMENT_ID` stays at env index 0 so a reorder would break CI instead of leaking the wrong value or a secret into alerts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 441fb132ae137fadb46a8f9110cd01217853eace. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->