### PR TITLE
broker: remove unused Tavily scaffolding

### DIFF
--- a/broker/ARCHITECTURE.md
+++ b/broker/ARCHITECTURE.md
@@ -191,7 +191,7 @@ Full spec: see `broker/endpoints/*.py`.
 | Scope-aware SQL rewriter (broker) | Runner's Databricks queries auto-scoped to its own candidate's state/city; cross-scope access denied |
 | Contract validation (broker) | Malformed artifact rejected; never lands in S3 or results queue |
 | Broker task IAM (limited) | Broker can write only to the specific S3 prefix + SQS queue; cannot invoke Lambdas or read other secrets |
-| TLS (broker → upstream APIs) | In transit to Anthropic / Databricks / Tavily (via NAT) |
+| TLS (broker → upstream APIs) | In transit to Anthropic / Databricks (via NAT) |
 
 Note: runner → broker traffic inside the VPC is HTTP (no TLS). Not a leak — `awsvpc` network mode gives each task its own ENI, no shared wire with other tenants, and no traffic mirroring enabled in the VPC.
 

--- a/broker/RUNBOOK.md
+++ b/broker/RUNBOOK.md
@@ -72,7 +72,7 @@ New agent tasks automatically pull the latest image with the same tag. No ECS se
 
 After Terraform creates `broker-{env}` and `broker-service-tokens-{env}` they are empty (both use `ignore_changes = [secret_string]`). Populate them before the broker can do work.
 
-Prerequisites: `AI_SECRETS_{ENV_UPPER}` already holds `PMF_ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `TAVILY_API_KEY`, `BRAINTRUST_API_KEY`, `DATABRICKS_SERVER_HOSTNAME`, `DATABRICKS_HTTP_PATH`, `DATABRICKS_API_KEY`.
+Prerequisites: `AI_SECRETS_{ENV_UPPER}` already holds `PMF_ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `BRAINTRUST_API_KEY`, `DATABRICKS_SERVER_HOSTNAME`, `DATABRICKS_HTTP_PATH`, `DATABRICKS_API_KEY`.
 
 > **WARNING:** `BRAINTRUST_API_KEY` MUST be present in the `broker-{env}` secret BEFORE running `terraform apply` on the broker module. The ECS task definition injects it via a Secrets Manager `valueFrom` entry, and ECS fails the entire task at launch with `ResourceInitializationError` if the JSON key is absent — the broker will not start in any env whose secret lacks the key. Dev was already backfilled; qa and prod MUST be backfilled before promoting.
 
@@ -94,13 +94,12 @@ aws secretsmanager put-secret-value \
   --secret-string "$(jq -n \
     --arg a "$(jq -r .PMF_ANTHROPIC_API_KEY   <<<"$AI")" \
     --arg g "$(jq -r .GEMINI_API_KEY          <<<"$AI")" \
-    --arg t "$(jq -r .TAVILY_API_KEY          <<<"$AI")" \
     --arg bt "$(jq -r .BRAINTRUST_API_KEY     <<<"$AI")" \
     --arg h "$(jq -r .DATABRICKS_SERVER_HOSTNAME <<<"$AI")" \
     --arg p "$(jq -r .DATABRICKS_HTTP_PATH    <<<"$AI")" \
     --arg k "$(jq -r .DATABRICKS_API_KEY      <<<"$AI")" \
     --arg s "$HASH" \
-    '{ANTHROPIC_API_KEY:$a, GEMINI_API_KEY:$g, TAVILY_API_KEY:$t, BRAINTRUST_API_KEY:$bt, DATABRICKS_SERVER_HOSTNAME:$h, DATABRICKS_HTTP_PATH:$p, DATABRICKS_API_KEY:$k, SERVICE_TOKEN_HASH:$s}')"
+    '{ANTHROPIC_API_KEY:$a, GEMINI_API_KEY:$g, BRAINTRUST_API_KEY:$bt, DATABRICKS_SERVER_HOSTNAME:$h, DATABRICKS_HTTP_PATH:$p, DATABRICKS_API_KEY:$k, SERVICE_TOKEN_HASH:$s}')"
 
 # 2. Force-redeploy broker so it reads the new hash. Wait stable.
 aws ecs update-service \
@@ -137,7 +136,7 @@ Notes:
 
 ## 3. Rotating Secrets
 
-### API Keys (Anthropic, Gemini, Tavily, Databricks)
+### API Keys (Anthropic, Gemini, Databricks)
 
 ```bash
 export ENV=dev
@@ -152,7 +151,6 @@ aws secretsmanager put-secret-value \
   --secret-string "$(jq -n \
     --arg anthropic "NEW_KEY" \
     --arg gemini "NEW_KEY" \
-    --arg tavily "NEW_KEY" \
     --arg braintrust "NEW_KEY" \
     --arg db_host "HOSTNAME" \
     --arg db_path "HTTP_PATH" \
@@ -161,7 +159,6 @@ aws secretsmanager put-secret-value \
     '{
       ANTHROPIC_API_KEY: $anthropic,
       GEMINI_API_KEY: $gemini,
-      TAVILY_API_KEY: $tavily,
       BRAINTRUST_API_KEY: $braintrust,
       DATABRICKS_SERVER_HOSTNAME: $db_host,
       DATABRICKS_HTTP_PATH: $db_path,

--- a/broker/secrets.py
+++ b/broker/secrets.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 
 import boto3
 
-
 _REQUIRED_FIELDS = {
     "ANTHROPIC_API_KEY": "anthropic_api_key",
     "SERVICE_TOKEN_HASH": "service_token_hash",
@@ -16,7 +15,6 @@ _REQUIRED_FIELDS = {
 }
 
 _OPTIONAL_FIELDS = {
-    "TAVILY_API_KEY": "tavily_api_key",
     "DATABRICKS_SERVER_HOSTNAME": "databricks_server_hostname",
     "DATABRICKS_HTTP_PATH": "databricks_http_path",
     "DATABRICKS_API_KEY": "databricks_api_key",
@@ -36,7 +34,6 @@ class BrokerSecrets:
     gp_api_base_url: str
     agent_fleet_clerk_id: str
     agent_mcp_token_secret: str
-    tavily_api_key: str = ""
     databricks_server_hostname: str = ""
     databricks_http_path: str = ""
     databricks_api_key: str = ""

--- a/broker/tests/conftest.py
+++ b/broker/tests/conftest.py
@@ -14,7 +14,7 @@ def fake_scope_ticket() -> ScopeTicket:
         run_id="run-20260415-001",
         organization_slug="org-42",
         experiment_id="voter_targeting",
-        scope={"databricks": ["SELECT"], "tavily": True, "s3": ["PutObject"]},
+        scope={"databricks": ["SELECT"], "s3": ["PutObject"]},
         params={"state": "CA", "district": "SD-15", "election_type": "general"},
         exp=now + 3600,
         issued_at=now,
@@ -26,7 +26,6 @@ def fake_scope_ticket() -> ScopeTicket:
 def fake_secrets() -> BrokerSecrets:
     return BrokerSecrets(
         anthropic_api_key="sk-ant-fake-key-for-testing",
-        tavily_api_key="tvly-fake-key-for-testing",
         databricks_server_hostname="test-workspace.cloud.databricks.com",
         databricks_http_path="/sql/1.0/warehouses/test123",
         databricks_api_key="dapi-fake-key-for-testing",

--- a/broker/tests/test_dynamodb_client.py
+++ b/broker/tests/test_dynamodb_client.py
@@ -37,7 +37,7 @@ def _make_ticket(
         "run_id": "run-001",
         "organization_slug": "org-42",
         "experiment_id": "voter_targeting",
-        "scope": {"databricks": ["SELECT"], "tavily": True},
+        "scope": {"databricks": ["SELECT"]},
         "params": {"state": "CA", "district": "SD-15"},
         "exp": now + exp_offset,
         "issued_at": now,

--- a/broker/tests/test_main.py
+++ b/broker/tests/test_main.py
@@ -21,7 +21,6 @@ class _NoopFetcher:
 def _fake_secrets() -> BrokerSecrets:
     return BrokerSecrets(
         anthropic_api_key="sk-ant-fake",
-        tavily_api_key="tvly-fake",
         databricks_server_hostname="test.databricks.com",
         databricks_http_path="/sql/test",
         databricks_api_key="dapi-fake",

--- a/broker/tests/test_mint_run_token.py
+++ b/broker/tests/test_mint_run_token.py
@@ -44,7 +44,7 @@ def _mint_payload(**overrides) -> dict:
         "run_id": "run-20260415-001",
         "organization_slug": "org-42",
         "experiment_id": "voter_targeting",
-        "scope": {"databricks": ["SELECT"], "tavily": True},
+        "scope": {"databricks": ["SELECT"]},
         "params": {"state": "CA", "district": "SD-15"},
         "clerk_user_id": DEFAULT_CLERK_USER_ID,
     }
@@ -550,9 +550,9 @@ class TestFailureLogging:
             headers={"Authorization": "Bearer wrong-token"},
         )
         assert resp.status_code == 401
-        assert any("invalid_service_token" in r.message for r in caplog.records if r.name == self.LOGGER_NAME), (
-            f"missing invalid_service_token warning; got: {[r.message for r in caplog.records]}"
-        )
+        assert any(
+            "invalid_service_token" in r.message for r in caplog.records if r.name == self.LOGGER_NAME
+        ), f"missing invalid_service_token warning; got: {[r.message for r in caplog.records]}"
 
     def test_logs_warning_on_ttl_above_cap(self, caplog):
         caplog.set_level(logging.WARNING, logger=self.LOGGER_NAME)

--- a/broker/tests/test_secrets.py
+++ b/broker/tests/test_secrets.py
@@ -5,10 +5,8 @@ import pytest
 
 from broker.secrets import BrokerSecrets, load_secrets, load_secrets_from_env
 
-
 FULL_SECRET = {
     "ANTHROPIC_API_KEY": "sk-ant-test",
-    "TAVILY_API_KEY": "tavily-test",
     "DATABRICKS_SERVER_HOSTNAME": "db-host.cloud.databricks.com",
     "DATABRICKS_HTTP_PATH": "/sql/1.0/warehouses/abc",
     "DATABRICKS_API_KEY": "dapi-test",
@@ -37,7 +35,6 @@ class TestLoadSecrets:
         mock_client.get_secret_value.assert_called_once_with(SecretId="AI_SECRETS_DEV")
         assert isinstance(result, BrokerSecrets)
         assert result.anthropic_api_key == "sk-ant-test"
-        assert result.tavily_api_key == "tavily-test"
         assert result.databricks_server_hostname == "db-host.cloud.databricks.com"
         assert result.databricks_http_path == "/sql/1.0/warehouses/abc"
         assert result.databricks_api_key == "dapi-test"

--- a/infrastructure/modules/broker/main.tf
+++ b/infrastructure/modules/broker/main.tf
@@ -124,7 +124,7 @@ resource "aws_cloudwatch_log_group" "broker" {
 
 resource "aws_secretsmanager_secret" "broker" {
   name        = "broker-${var.environment}"
-  description = "Secrets for PMF broker service. Operator populates: ANTHROPIC_API_KEY, GEMINI_API_KEY, TAVILY_API_KEY, DATABRICKS_SERVER_HOSTNAME, DATABRICKS_HTTP_PATH, DATABRICKS_API_KEY, SERVICE_TOKEN_HASH, CLERK_SECRET_KEY, CLERK_FRONTEND_API_BASE, GP_API_BASE_URL, AGENT_FLEET_CLERK_ID, AGENT_MCP_TOKEN_SECRET, BRAINTRUST_API_KEY"
+  description = "Secrets for PMF broker service. Operator populates: ANTHROPIC_API_KEY, GEMINI_API_KEY, DATABRICKS_SERVER_HOSTNAME, DATABRICKS_HTTP_PATH, DATABRICKS_API_KEY, SERVICE_TOKEN_HASH, CLERK_SECRET_KEY, CLERK_FRONTEND_API_BASE, GP_API_BASE_URL, AGENT_FLEET_CLERK_ID, AGENT_MCP_TOKEN_SECRET, BRAINTRUST_API_KEY"
 
   tags = {
     Environment = var.environment
@@ -424,7 +424,7 @@ resource "aws_security_group_rule" "broker_egress_https" {
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  description       = "HTTPS for Anthropic, Databricks, Tavily, Gemini APIs via NAT"
+  description       = "HTTPS for Anthropic, Databricks, Gemini APIs via NAT"
   security_group_id = aws_security_group.broker.id
   cidr_blocks       = ["0.0.0.0/0"]
 }
@@ -670,10 +670,6 @@ resource "aws_ecs_task_definition" "broker" {
           valueFrom = "${aws_secretsmanager_secret.broker.arn}:GEMINI_API_KEY::"
         },
         {
-          name      = "TAVILY_API_KEY"
-          valueFrom = "${aws_secretsmanager_secret.broker.arn}:TAVILY_API_KEY::"
-        },
-        {
           name      = "DATABRICKS_SERVER_HOSTNAME"
           valueFrom = "${aws_secretsmanager_secret.broker.arn}:DATABRICKS_SERVER_HOSTNAME::"
         },
@@ -898,7 +894,6 @@ resource "aws_route53_resolver_firewall_domain_list" "broker_allow" {
   domains = [
     "api.anthropic.com.",
     "*.databricks.com.",
-    "api.tavily.com.",
     "generativelanguage.googleapis.com.",
     "s3.us-west-2.amazonaws.com.",
     "sqs.us-west-2.amazonaws.com.",


### PR DESCRIPTION
## What

Removes the broker's **unused Tavily plumbing**. The broker never read `TAVILY_API_KEY` or the `scope.tavily` flag — web search runs server-side at Anthropic via the `/anthropic` proxy, and no broker endpoint consumes Tavily. This was provisioned-but-unwired scaffolding (secret field, ECS env injection, DNS-firewall allowlist entry, a `scope.tavily` fixture convention, docs) for a search route that was never built.

## Changes
- `broker/secrets.py` — drop the `TAVILY_API_KEY` mapping + `BrokerSecrets.tavily_api_key`
- `infrastructure/modules/broker/main.tf` — drop the `TAVILY_API_KEY` ECS secret injection, the `api.tavily.com` DNS-firewall allowlist entry, and Tavily from the secret + egress-SG descriptions
- `broker/RUNBOOK.md` / `broker/ARCHITECTURE.md` — drop Tavily from secret population, key rotation, and the TLS-upstream table
- tests — drop tavily fixtures/assertions and the `scope.tavily` flag

## Scope (important)
Tavily remains a **live integration** in `ai_generated_campaign_plan` (`shared/tavily_client.py`, used for campaign-plan web search) and the `tavily-python` workspace dep. Those are a separate module and are **untouched** — this PR only removes the broker's unused copy.

## Deploy safety
Removing the ECS `valueFrom` is safe: ECS simply stops injecting the env var (no `ResourceInitializationError` ordering hazard — that only applies to *adding* a `valueFrom` for an absent key). The orphan `TAVILY_API_KEY` key still in the `broker-{env}` secret is harmless; `_parse_secrets` ignores unknown keys.

## Verification
- Full project test suite: **1899 passed**, 1 skipped, 3 network-deselected. (2 unrelated failures are local `.env` contamination in non-hermetic tests — both pass on a clean `develop` checkout / CI.)
- `ruff` + `ruff-format` clean; `terraform fmt -check` clean; `terraform validate` valid.
- **Deployed to dev from local** (built/pushed `broker-dev`, rolled the service) — broker boots and parses the dev secret cleanly; live `/health`, `/internal/mint-run-token`, `/experiment/manifest` all 200.
- **Smoke run** `smoke-collin-e8844ee1aa8b` (`top_community_issues`, replaying yesterday's successful WY Cheyenne Ward 3 run) completed and published a valid 42KB artifact — exercising mint-token, manifest, `/anthropic`, `/databricks/query`, `/agent/mcp`, web search, and `/artifact/publish` end-to-end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code and infra/doc cleanup only; no broker runtime behavior change and ECS task startup is safer when removing optional secret injection.
> 
> **Overview**
> Removes **unused Tavily plumbing** from the PMF broker. The broker never consumed `TAVILY_API_KEY` or `scope.tavily`; web search goes through the Anthropic proxy, and no broker route called Tavily.
> 
> **`broker/secrets.py`** drops the optional `TAVILY_API_KEY` mapping and `BrokerSecrets.tavily_api_key`. **Terraform** (`infrastructure/modules/broker/main.tf`) removes ECS secret injection for `TAVILY_API_KEY`, `api.tavily.com` from the broker DNS firewall allowlist, and Tavily mentions in secret/SG descriptions. **Docs** (`RUNBOOK.md`, `ARCHITECTURE.md`) no longer list Tavily in prerequisites, secret population, rotation, or upstream TLS. **Tests** drop Tavily fixtures and the `scope.tavily` convention from mint/scope ticket payloads.
> 
> Deploy note: removing a `valueFrom` entry does not require the secret key to be deleted first; leftover `TAVILY_API_KEY` in `broker-{env}` is ignored. Tavily in `ai_generated_campaign_plan` / `shared/tavily_client.py` is **out of scope**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f5548723116bb902fd66b9e347f7f185ea93288. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->