### PR TITLE
Tag AWS resources with Project for cost allocation

### DIFF
--- a/clickup_bot/lambda/handler.py
+++ b/clickup_bot/lambda/handler.py
@@ -242,6 +242,7 @@ def trigger_fargate_task(task_id: str, instruction: str, label: str, model: str 
             cluster=cluster_arn,
             taskDefinition=task_definition,
             launchType="FARGATE",
+            tags=[{"key": "Project", "value": "clickup-bot"}],
             networkConfiguration={
                 "awsvpcConfiguration": {
                     "subnets": subnet_ids,

--- a/infrastructure/environments/dev/agent-experiment-metadata/main.tf
+++ b/infrastructure/environments/dev/agent-experiment-metadata/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "pmf-engine"
+    }
+  }
 }
 
 module "agent_experiment_metadata" {

--- a/infrastructure/environments/dev/agent-run-inputs/main.tf
+++ b/infrastructure/environments/dev/agent-run-inputs/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "pmf-engine"
+    }
+  }
 }
 
 module "agent_run_inputs" {

--- a/infrastructure/environments/dev/broker/main.tf
+++ b/infrastructure/environments/dev/broker/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "broker"
+    }
+  }
 }
 
 # Bootstrap toggle, named to match qa/prod so operators use one procedure

--- a/infrastructure/environments/dev/campaign-plan-lambda/main.tf
+++ b/infrastructure/environments/dev/campaign-plan-lambda/main.tf
@@ -20,6 +20,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "campaign-plan"
+    }
+  }
 }
 
 data "terraform_remote_state" "shared_slack_notifier" {

--- a/infrastructure/environments/dev/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/environments/dev/ddhq-matcher-fargate/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "ddhq-matcher"
+    }
+  }
 }
 
 variable "vpc_id" {

--- a/infrastructure/environments/dev/engineer-agent-fargate/main.tf
+++ b/infrastructure/environments/dev/engineer-agent-fargate/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "engineer-agent"
+    }
+  }
 }
 
 variable "vpc_id" {

--- a/infrastructure/environments/dev/pmf-engine-control-plane/main.tf
+++ b/infrastructure/environments/dev/pmf-engine-control-plane/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "pmf-engine"
+    }
+  }
 }
 
 # gp-api's results queue — the same queue the broker sends success results to

--- a/infrastructure/environments/dev/pmf-engine-fargate/main.tf
+++ b/infrastructure/environments/dev/pmf-engine-fargate/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "pmf-engine"
+    }
+  }
 }
 
 data "terraform_remote_state" "broker" {

--- a/infrastructure/environments/dev/pmf-vpc-endpoints/main.tf
+++ b/infrastructure/environments/dev/pmf-vpc-endpoints/main.tf
@@ -26,6 +26,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "pmf-engine"
+    }
+  }
 }
 
 locals {

--- a/infrastructure/environments/dev/serve-analyze-fargate/main.tf
+++ b/infrastructure/environments/dev/serve-analyze-fargate/main.tf
@@ -20,6 +20,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "serve-analyze"
+    }
+  }
 }
 
 variable "vpc_id" {

--- a/infrastructure/environments/dev/shared-infra/main.tf
+++ b/infrastructure/environments/dev/shared-infra/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project = "ai-projects"
+    }
+  }
 }
 
 data "aws_secretsmanager_secret_version" "ai_secrets" {

--- a/infrastructure/environments/prod/agent-experiment-metadata/main.tf
+++ b/infrastructure/environments/prod/agent-experiment-metadata/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "pmf-engine"
+    }
+  }
 }
 
 module "agent_experiment_metadata" {

--- a/infrastructure/environments/prod/agent-run-inputs/main.tf
+++ b/infrastructure/environments/prod/agent-run-inputs/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "pmf-engine"
+    }
+  }
 }
 
 module "agent_run_inputs" {

--- a/infrastructure/environments/prod/broker/main.tf
+++ b/infrastructure/environments/prod/broker/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "broker"
+    }
+  }
 }
 
 variable "bootstrap" {

--- a/infrastructure/environments/prod/campaign-plan-lambda/main.tf
+++ b/infrastructure/environments/prod/campaign-plan-lambda/main.tf
@@ -20,6 +20,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "campaign-plan"
+    }
+  }
 }
 
 data "terraform_remote_state" "shared_slack_notifier" {

--- a/infrastructure/environments/prod/clickup-bot/main.tf
+++ b/infrastructure/environments/prod/clickup-bot/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "clickup-bot"
+    }
+  }
 }
 
 variable "enable_fargate_trigger" {

--- a/infrastructure/environments/prod/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/environments/prod/ddhq-matcher-fargate/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "ddhq-matcher"
+    }
+  }
 }
 
 variable "vpc_id" {

--- a/infrastructure/environments/prod/engineer-agent-fargate/main.tf
+++ b/infrastructure/environments/prod/engineer-agent-fargate/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "engineer-agent"
+    }
+  }
 }
 
 variable "vpc_id" {

--- a/infrastructure/environments/prod/pmf-engine-control-plane/main.tf
+++ b/infrastructure/environments/prod/pmf-engine-control-plane/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "pmf-engine"
+    }
+  }
 }
 
 variable "bootstrap" {

--- a/infrastructure/environments/prod/pmf-engine-fargate/main.tf
+++ b/infrastructure/environments/prod/pmf-engine-fargate/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "pmf-engine"
+    }
+  }
 }
 
 variable "bootstrap" {

--- a/infrastructure/environments/prod/serve-analyze-fargate/main.tf
+++ b/infrastructure/environments/prod/serve-analyze-fargate/main.tf
@@ -20,6 +20,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "serve-analyze"
+    }
+  }
 }
 
 variable "vpc_id" {

--- a/infrastructure/environments/prod/shared-infra/main.tf
+++ b/infrastructure/environments/prod/shared-infra/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project = "ai-projects"
+    }
+  }
 }
 
 data "aws_secretsmanager_secret_version" "ai_secrets" {

--- a/infrastructure/environments/qa/agent-experiment-metadata/main.tf
+++ b/infrastructure/environments/qa/agent-experiment-metadata/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "pmf-engine"
+    }
+  }
 }
 
 module "agent_experiment_metadata" {

--- a/infrastructure/environments/qa/agent-run-inputs/main.tf
+++ b/infrastructure/environments/qa/agent-run-inputs/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "pmf-engine"
+    }
+  }
 }
 
 module "agent_run_inputs" {

--- a/infrastructure/environments/qa/broker/main.tf
+++ b/infrastructure/environments/qa/broker/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "broker"
+    }
+  }
 }
 
 variable "bootstrap" {

--- a/infrastructure/environments/qa/campaign-plan-lambda/main.tf
+++ b/infrastructure/environments/qa/campaign-plan-lambda/main.tf
@@ -20,6 +20,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "campaign-plan"
+    }
+  }
 }
 
 data "terraform_remote_state" "shared_slack_notifier" {

--- a/infrastructure/environments/qa/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/environments/qa/ddhq-matcher-fargate/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "ddhq-matcher"
+    }
+  }
 }
 
 variable "vpc_id" {

--- a/infrastructure/environments/qa/engineer-agent-fargate/main.tf
+++ b/infrastructure/environments/qa/engineer-agent-fargate/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "engineer-agent"
+    }
+  }
 }
 
 variable "vpc_id" {

--- a/infrastructure/environments/qa/pmf-engine-control-plane/main.tf
+++ b/infrastructure/environments/qa/pmf-engine-control-plane/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "pmf-engine"
+    }
+  }
 }
 
 variable "bootstrap" {

--- a/infrastructure/environments/qa/pmf-engine-fargate/main.tf
+++ b/infrastructure/environments/qa/pmf-engine-fargate/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "pmf-engine"
+    }
+  }
 }
 
 variable "bootstrap" {

--- a/infrastructure/environments/qa/serve-analyze-fargate/main.tf
+++ b/infrastructure/environments/qa/serve-analyze-fargate/main.tf
@@ -20,6 +20,12 @@ terraform {
 
 provider "aws" {
   region = "us-west-2"
+
+  default_tags {
+    tags = {
+      Project = "serve-analyze"
+    }
+  }
 }
 
 variable "vpc_id" {

--- a/infrastructure/environments/qa/shared-infra/main.tf
+++ b/infrastructure/environments/qa/shared-infra/main.tf
@@ -19,6 +19,12 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project = "ai-projects"
+    }
+  }
 }
 
 data "aws_secretsmanager_secret_version" "ai_secrets" {

--- a/infrastructure/modules/clickup-bot/main.tf
+++ b/infrastructure/modules/clickup-bot/main.tf
@@ -134,6 +134,15 @@ resource "aws_iam_role_policy" "clickup_bot_ecs" {
       {
         Effect = "Allow"
         Action = [
+          "ecs:TagResource"
+        ]
+        Resource = [
+          "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:task/${element(split("/", var.ecs_cluster_arn), 1)}/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
           "iam:PassRole"
         ]
         Resource = [

--- a/infrastructure/modules/ddhq-matcher-fargate/lambda-trigger/lambda_handler.py
+++ b/infrastructure/modules/ddhq-matcher-fargate/lambda-trigger/lambda_handler.py
@@ -38,6 +38,7 @@ def handler(event, context):
             cluster=os.environ['ECS_CLUSTER_NAME'],
             taskDefinition=os.environ['TASK_DEFINITION_ARN'],
             launchType='FARGATE',
+            tags=[{'key': 'Project', 'value': 'ddhq-matcher'}],
             networkConfiguration={
                 'awsvpcConfiguration': {
                     'subnets': os.environ['SUBNET_IDS'].split(','),

--- a/infrastructure/modules/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/modules/ddhq-matcher-fargate/main.tf
@@ -403,6 +403,15 @@ resource "aws_iam_role_policy" "lambda_ecs_run_task" {
       {
         Effect = "Allow"
         Action = [
+          "ecs:TagResource"
+        ]
+        Resource = [
+          "${replace(aws_ecs_cluster.matcher.arn, ":cluster/", ":task/")}/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
           "iam:PassRole"
         ]
         Resource = [

--- a/infrastructure/modules/pmf-engine-control-plane/main.tf
+++ b/infrastructure/modules/pmf-engine-control-plane/main.tf
@@ -483,6 +483,11 @@ resource "aws_iam_role_policy" "scheduler_lambda_permissions" {
       },
       {
         Effect   = "Allow"
+        Action   = "ecs:TagResource"
+        Resource = "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:task/${element(split("/", var.ecs_cluster_arn), 1)}/*"
+      },
+      {
+        Effect   = "Allow"
         Action   = "iam:PassRole"
         Resource = [var.ecs_task_execution_role_arn, var.ecs_task_role_arn]
       },

--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -674,6 +674,7 @@ def launch_run(
             cluster=ECS_CLUSTER_ARN,
             taskDefinition=ECS_TASK_DEFINITION,
             launchType="FARGATE",
+            tags=[{"key": "Project", "value": "pmf-engine"}],
             # Tag the task with the run_id (uuid7, 36 chars — within the 36-char
             # startedBy limit) so the stuck-LAUNCHING sweep can tell whether a
             # LAUNCHING job has a live task before it fails the row.


### PR DESCRIPTION
## Why

A Cost Explorer review of the last 90 days surfaced ~\$21k of AWS spend in the gp-admin account with no `Project` tag. The untagged spend wasn't random — it was whole services that were stood up without a `Project` tag, almost all of them owned by this repo's Terraform: pmf-engine, engineer-agent, serve-analyze, ddhq-matcher, broker, clickup-bot, the campaign-plan lambda, and the AI ALBs. (omni's Pulumi stacks already set `Project`, so they were correctly attributed.)

Without these tags we can't see what each agent/data service actually costs, which is exactly the granularity we need now that the agent fleet is the largest line item.

## What makes this two parts

For Fargate, cost is attributed to the tags on the **running task**, not the task definition. So provider `default_tags` alone tags the scaffolding (cluster, task-def, ALB, lambda, S3, DynamoDB, SQS) but leaves the ephemeral task runtime — the bulk of the ~\$10k ECS spend — untagged.

1. `default_tags { Project = "<service>" }` on the `aws` provider in every `environments/<env>/<service>` root.
2. An explicit `Project` tag on each `run_task` call (pmf-engine dispatch, clickup-bot, ddhq-matcher), plus the matching `ecs:TagResource` grant on the caller's role (serve-analyze already had this pattern).

`Project` is an active cost-allocation tag, so attribution flows automatically once these apply. Tags apply prospectively — they fix going-forward spend, not the historical 90 days.

`terraform validate` passes on the edited roots; the pmf-engine dispatch test suite (118 tests) is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tagging and narrow IAM grants only; no runtime logic or data-path changes beyond ECS launch permissions needed for task tags.
> 
> **Overview**
> Adds **`Project`** cost-allocation tagging across Terraform-managed AWS resources and ephemeral Fargate task runtime.
> 
> Every affected **`environments/<env>/<service>`** root now sets **`default_tags { Project = "<service>" }`** on the AWS provider (e.g. `pmf-engine`, `broker`, `clickup-bot`, `serve-analyze`, `ai-projects` for shared ALB stacks). That tags durable infra on the next apply; it does not attribute Fargate spend, which follows **running task** tags.
> 
> **`ecs.run_task`** callers now pass **`tags=[{"key": "Project", "value": "..."}]`** for **clickup-bot**, **ddhq-matcher**, and **pmf-engine** (`launch_run` in `dispatch_handler.py`, used by the scheduler). Matching **`ecs:TagResource`** grants were added on the **clickup-bot** Lambda role, **ddhq-matcher** trigger Lambda, and **pmf-engine scheduler** role so tagging cannot fail at launch.
> 
> Tags apply prospectively after deploy; existing resources pick up provider default tags on update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79021ac302d3348d3f2bcf7a822faebd79c86f1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->