### PR TITLE
fix(agent-run-inputs): allow https://app.goodparty.org in prod bucket CORS

### DIFF
--- a/infrastructure/modules/agent-run-inputs/main.tf
+++ b/infrastructure/modules/agent-run-inputs/main.tf
@@ -40,6 +40,7 @@ locals {
     prod = [
       "https://goodparty.org",
       "https://www.goodparty.org",
+      "https://app.goodparty.org",
     ]
   }
 }


### PR DESCRIPTION
## Why

Agenda uploads on the prod briefings page were failing with a CORS error. The browser PUTs the PDF directly to `gp-agent-run-inputs-prod` via a presigned URL, but that bucket's CORS allowlist only had `https://goodparty.org` and `https://www.goodparty.org`. The prod app actually serves from `https://app.goodparty.org/dashboard/briefings`, so every direct upload was cross-origin-denied.

## What

Adds `https://app.goodparty.org` to the prod entry of `cors_allowed_origins` in the `agent-run-inputs` module. Dev/qa are unchanged.

## Already applied live

To unblock the user immediately, this origin was added to the live bucket CORS via `aws s3api put-bucket-cors`. This PR codifies that so the next `terraform apply` doesn't revert it. `terraform plan` against the prod env reports **"No changes"** (the code now matches the live state) and `terraform fmt` is clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-origin addition to prod S3 CORS configuration; no auth, IAM, or application logic changes.
> 
> **Overview**
> **Prod briefings agenda uploads** were blocked because browser PUTs to `gp-agent-run-inputs-prod` use presigned URLs and CORS only allowed `goodparty.org` / `www.goodparty.org`, while the live app runs on **`https://app.goodparty.org`**.
> 
> This PR adds **`https://app.goodparty.org`** to the prod `cors_allowed_origins` list in the `agent-run-inputs` Terraform module so S3 CORS matches the gp-webapp deployment. Dev and qa origin lists are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c295a18e426dcdcc513d74f62c6c0d1221e65d66. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->