### PR TITLE
fix(broker): page.content() fallback when response.body() is evicted (Ballotpedia 500)

### DIFF
--- a/broker/browser_fetcher.py
+++ b/broker/browser_fetcher.py
@@ -425,7 +425,45 @@ class PlaywrightBrowserFetcher:
                         body_path=body_path,
                     )
 
-            body = await response.body()
+            try:
+                body = await response.body()
+            except PlaywrightError as e:
+                # After the networkidle settle above, Chromium frequently evicts
+                # the main document's network resource, so response.body() raises
+                # "No resource with given identifier found". For HTML, the
+                # rendered DOM is an equivalent-or-better source for scraping and
+                # is reliably available; for anything else there's no fallback.
+                if content_type.startswith("text/html"):
+                    logger.warning(
+                        "response.body() unavailable, falling back to page.content() url=%s error=%s",
+                        url,
+                        e,
+                    )
+                    try:
+                        body = (await page.content()).encode("utf-8")
+                    except PlaywrightError as page_err:
+                        # The same eviction class can tear down the page/context
+                        # itself under Fargate memory pressure; no fallback left.
+                        logger.warning(
+                            "page.content() also unavailable url=%s error=%s",
+                            url,
+                            page_err,
+                        )
+                        raise HTTPException(
+                            status_code=502,
+                            detail="upstream response body unavailable",
+                        ) from page_err
+                else:
+                    logger.warning(
+                        "response.body() unavailable for non-HTML content-type=%s url=%s error=%s",
+                        content_type,
+                        url,
+                        e,
+                    )
+                    raise HTTPException(
+                        status_code=502,
+                        detail="upstream response body unavailable",
+                    ) from e
             _raise_if_violation()
             if len(body) > PAGE_RESPONSE_MAX_BYTES:
                 raise HTTPException(

--- a/broker/tests/test_browser_fetcher.py
+++ b/broker/tests/test_browser_fetcher.py
@@ -608,6 +608,134 @@ class TestPageResponsePath:
         assert exc.value.status_code == 413
 
 
+class TestResponseBodyUnavailableFallback:
+    """After the post-nav networkidle settle, Chromium often evicts the main
+    document's network resource, so response.body() raises 'No resource with
+    given identifier found'. For HTML we must fall back to the rendered DOM via
+    page.content() (200 OK); for non-HTML there's no equivalent fallback so we
+    return a clean 502 instead of letting the Playwright error bubble to a 500.
+    Reproduces the Ballotpedia /http/fetch 500 (ClickUp 86aj864zq)."""
+
+    @pytest.mark.asyncio
+    async def test_html_body_failure_falls_back_to_page_content(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_playwright_async_api(monkeypatch)
+        _patch_playwright_types(monkeypatch)
+
+        from playwright.async_api import Error as PlaywrightError
+
+        rendered = "<html><body>rendered ballotpedia DOM</body></html>"
+
+        page = _FakePage(
+            response=_FakeResponse(
+                url="https://ballotpedia.org/Some_Race",
+                status=200,
+                headers={"content-type": "text/html; charset=utf-8"},
+                body=b"raw network body that will be evicted",
+            ),
+            url="https://ballotpedia.org/Some_Race",
+        )
+
+        async def body_evicted() -> bytes:
+            raise PlaywrightError(
+                "Response.body: Protocol error (Network.getResponseBody): No resource with given identifier found"
+            )
+
+        page._response.body = body_evicted  # type: ignore[method-assign]
+
+        async def content() -> str:
+            return rendered
+
+        page.content = content  # type: ignore[method-assign,attr-defined]
+
+        fetcher = PlaywrightBrowserFetcher()
+        fetcher._browser = _FakeBrowser(lambda: page)  # type: ignore[assignment]
+        monkeypatch.setattr("broker.browser_fetcher.validate_url", _allow_all)
+
+        result = await fetcher.fetch("https://ballotpedia.org/Some_Race")
+
+        assert result.status == 200
+        assert result.content_type == "text/html"
+        assert result.body == rendered.encode("utf-8")
+        assert result.body_path is None
+        assert result.byte_size == len(rendered.encode("utf-8"))
+        assert result.final_url == "https://ballotpedia.org/Some_Race"
+
+    @pytest.mark.asyncio
+    async def test_non_html_body_failure_raises_502(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_playwright_async_api(monkeypatch)
+        _patch_playwright_types(monkeypatch)
+
+        from playwright.async_api import Error as PlaywrightError
+
+        page = _FakePage(
+            response=_FakeResponse(
+                url="https://example.com/data.json",
+                status=200,
+                headers={"content-type": "application/json"},
+                body=b'{"ok":true}',
+            ),
+            url="https://example.com/data.json",
+        )
+
+        async def body_evicted() -> bytes:
+            raise PlaywrightError(
+                "Response.body: Protocol error (Network.getResponseBody): No resource with given identifier found"
+            )
+
+        page._response.body = body_evicted  # type: ignore[method-assign]
+
+        fetcher = PlaywrightBrowserFetcher()
+        fetcher._browser = _FakeBrowser(lambda: page)  # type: ignore[assignment]
+        monkeypatch.setattr("broker.browser_fetcher.validate_url", _allow_all)
+
+        with pytest.raises(HTTPException) as exc:
+            await fetcher.fetch("https://example.com/data.json")
+        assert exc.value.status_code == 502
+        assert exc.value.detail == "upstream response body unavailable"
+
+    @pytest.mark.asyncio
+    async def test_html_double_failure_raises_502(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """For text/html, if BOTH response.body() and the page.content()
+        fallback raise PlaywrightError (page/context torn down under memory
+        pressure), the fetcher must return a clean 502 — not let the second
+        Playwright error escape to an unhandled 500."""
+        _patch_playwright_async_api(monkeypatch)
+        _patch_playwright_types(monkeypatch)
+
+        from playwright.async_api import Error as PlaywrightError
+
+        page = _FakePage(
+            response=_FakeResponse(
+                url="https://ballotpedia.org/Some_Race",
+                status=200,
+                headers={"content-type": "text/html; charset=utf-8"},
+                body=b"raw network body that will be evicted",
+            ),
+            url="https://ballotpedia.org/Some_Race",
+        )
+
+        async def body_evicted() -> bytes:
+            raise PlaywrightError(
+                "Response.body: Protocol error (Network.getResponseBody): No resource with given identifier found"
+            )
+
+        page._response.body = body_evicted  # type: ignore[method-assign]
+
+        async def content_torn_down() -> str:
+            raise PlaywrightError("Page.content: Target page, context or browser has been closed")
+
+        page.content = content_torn_down  # type: ignore[method-assign,attr-defined]
+
+        fetcher = PlaywrightBrowserFetcher()
+        fetcher._browser = _FakeBrowser(lambda: page)  # type: ignore[assignment]
+        monkeypatch.setattr("broker.browser_fetcher.validate_url", _allow_all)
+
+        with pytest.raises(HTTPException) as exc:
+            await fetcher.fetch("https://ballotpedia.org/Some_Race")
+        assert exc.value.status_code == 502
+        assert exc.value.detail == "upstream response body unavailable"
+
+
 class TestNavigationFailure:
     @pytest.mark.asyncio
     async def test_nav_error_with_no_download_raises_generic_502(


### PR DESCRIPTION
## Problem
Broker `/http/fetch` returns 500 on Ballotpedia. In `browser_fetcher.py` `_fetch_impl`, `text/html` responses wait for `networkidle` before `await response.body()`; after the settle Chromium has often evicted the main document's network resource, so `response.body()` raises `PlaywrightError: Network.getResponseBody: No resource with given identifier found` → unhandled 500.

## Fix
Wrap `response.body()`: on `PlaywrightError`, fall back to the rendered DOM `page.content()` for `text/html` (as good or better for scraping); return a clean 502 for non-HTML body failures. Size cap / `validate_url` / violation checks still apply to the fallback content.

## Tests
`broker/tests/test_browser_fetcher.py` (+2, 38 pass): mocked `response.body()` raising the real protocol error → HTML falls back to `page.content()` (200); non-HTML → 502 (not 500).

## Impact
Unblocks Know Your Opponent — Phase 0 (ENG-10525) Ballotpedia collection. Found via the Phase-0 dev smoke-test (run e01e3820). Needs a broker rebuild + rollover to dev to take effect.

ClickUp: 86aj864zq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error-handling change on the browser fetch path; HTML fallback may differ slightly from raw wire bytes but is intended for scraping; existing caps and SSRF checks still apply.
> 
> **Overview**
> Fixes broker `/http/fetch` **500s** on sites like Ballotpedia where Chromium drops the main document’s network buffer after the post-nav **`networkidle`** settle, so `response.body()` raises a Playwright protocol error.
> 
> **`PlaywrightBrowserFetcher`** now catches that error: for **`text/html`**, it logs and returns the **rendered DOM** via `page.content()` (still subject to size cap, SSRF checks, and `final_url` validation); for other content types it returns a **502** with `upstream response body unavailable` instead of an unhandled 500.
> 
> Tests add **`TestResponseBodyUnavailableFallback`** with mocked evicted `response.body()` for HTML (200 + DOM bytes) and JSON (502).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08dd05243b62c173e7d1d9bdeb5865e27f629a70. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->