### PR TITLE
fix(ddhq-matcher): repair state locking and per-env Slack-invoke permission

### DIFF
--- a/infrastructure/environments/dev/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/environments/dev/ddhq-matcher-fargate/main.tf
@@ -9,11 +9,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "goodparty-terraform-state-us-west-2"
-    key            = "ddhq-matcher-fargate/dev/terraform.tfstate"
-    region         = "us-west-2"
-    dynamodb_table = "terraform-state-lock"
-    encrypt        = true
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "ddhq-matcher-fargate/dev/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
   }
 }
 

--- a/infrastructure/environments/prod/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/environments/prod/ddhq-matcher-fargate/main.tf
@@ -9,11 +9,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "goodparty-terraform-state-us-west-2"
-    key            = "ddhq-matcher-fargate/prod/terraform.tfstate"
-    region         = "us-west-2"
-    dynamodb_table = "terraform-state-lock"
-    encrypt        = true
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "ddhq-matcher-fargate/prod/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
   }
 }
 

--- a/infrastructure/environments/qa/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/environments/qa/ddhq-matcher-fargate/main.tf
@@ -9,11 +9,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "goodparty-terraform-state-us-west-2"
-    key            = "ddhq-matcher-fargate/qa/terraform.tfstate"
-    region         = "us-west-2"
-    dynamodb_table = "terraform-state-lock"
-    encrypt        = true
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "ddhq-matcher-fargate/qa/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
   }
 }
 

--- a/infrastructure/modules/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/modules/ddhq-matcher-fargate/main.tf
@@ -584,7 +584,7 @@ resource "aws_sns_topic_subscription" "shared_slack_notifier" {
 
 resource "aws_lambda_permission" "allow_sns_invoke_slack" {
   count         = var.shared_slack_notifier_lambda_arn != "" ? 1 : 0
-  statement_id  = "AllowSNSInvokeFromMatcherFailures"
+  statement_id  = "AllowSNSInvokeFromMatcherFailures-${var.environment}"
   action        = "lambda:InvokeFunction"
   function_name = var.shared_slack_notifier_lambda_arn
   principal     = "sns.amazonaws.com"


### PR DESCRIPTION
While bringing the gp-ai-projects Terraform up to date across dev/qa/prod, two latent defects in the ddhq-matcher infra surfaced and blocked a clean apply. Both are fixed here.

**State lock backend points at a table that doesn't exist.** The ddhq-matcher env roots configured `dynamodb_table = "terraform-state-lock"`, but that table isn't present in the account, so any apply with locking enabled fails immediately with `ResourceNotFoundException`. Every sibling root already moved to S3-native locking (`use_lockfile = true`); this aligns ddhq-matcher with them so applies don't need `-lock=false` workarounds.

**Slack-invoke permission collides across environments.** The `allow_sns_invoke_slack` Lambda permission grants a per-env SNS failure topic the right to invoke the *shared* slack-notifier lambda, but the `statement_id` was hardcoded with no environment suffix. Because the target lambda is shared, only the first environment to apply can create the statement; the other two fail with a 409 `ResourceConflictException` and their matcher-failure topics silently never get Slack-notify permission. Namespacing the statement id per environment lets all three coexist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how state is locked (migration from missing DynamoDB to S3 lockfiles) and replaces Lambda permission resources with new statement IDs, which can affect apply order and whether existing permissions need import/replace.
> 
> **Overview**
> **Terraform state locking** for ddhq-matcher **dev**, **qa**, and **prod** no longer uses `dynamodb_table = "terraform-state-lock"` (which was failing because that table isn’t in the account). The S3 backend now uses **`use_lockfile = true`**, matching other infrastructure roots so applies can lock state without `-lock=false`.
> 
> **Slack failure notifications:** the shared slack-notifier Lambda’s SNS invoke permission **`statement_id`** is now **`AllowSNSInvokeFromMatcherFailures-${var.environment}`** instead of a single fixed id. That lets each environment’s matcher-failure SNS topic add its own permission on the same shared function without 409 conflicts, so qa/prod aren’t left without Slack invoke after the first env applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbe0c5e0307a27fc20d7850762868fe0c454f7c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->