### PR TITLE
Release prep: develop → qa (2026-06-26)

### DIFF
--- a/infrastructure/environments/dev/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/environments/dev/ddhq-matcher-fargate/main.tf
@@ -9,11 +9,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "goodparty-terraform-state-us-west-2"
-    key            = "ddhq-matcher-fargate/dev/terraform.tfstate"
-    region         = "us-west-2"
-    dynamodb_table = "terraform-state-lock"
-    encrypt        = true
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "ddhq-matcher-fargate/dev/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
   }
 }
 

--- a/infrastructure/environments/prod/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/environments/prod/ddhq-matcher-fargate/main.tf
@@ -9,11 +9,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "goodparty-terraform-state-us-west-2"
-    key            = "ddhq-matcher-fargate/prod/terraform.tfstate"
-    region         = "us-west-2"
-    dynamodb_table = "terraform-state-lock"
-    encrypt        = true
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "ddhq-matcher-fargate/prod/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
   }
 }
 

--- a/infrastructure/environments/qa/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/environments/qa/ddhq-matcher-fargate/main.tf
@@ -9,11 +9,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "goodparty-terraform-state-us-west-2"
-    key            = "ddhq-matcher-fargate/qa/terraform.tfstate"
-    region         = "us-west-2"
-    dynamodb_table = "terraform-state-lock"
-    encrypt        = true
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "ddhq-matcher-fargate/qa/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
   }
 }
 

--- a/infrastructure/modules/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/modules/ddhq-matcher-fargate/main.tf
@@ -584,7 +584,7 @@ resource "aws_sns_topic_subscription" "shared_slack_notifier" {
 
 resource "aws_lambda_permission" "allow_sns_invoke_slack" {
   count         = var.shared_slack_notifier_lambda_arn != "" ? 1 : 0
-  statement_id  = "AllowSNSInvokeFromMatcherFailures"
+  statement_id  = "AllowSNSInvokeFromMatcherFailures-${var.environment}"
   action        = "lambda:InvokeFunction"
   function_name = var.shared_slack_notifier_lambda_arn
   principal     = "sns.amazonaws.com"


### PR DESCRIPTION
## Included PRs

- dbe0c5e fix(ddhq-matcher): use S3-native state lock and per-env Slack-invoke statement id

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Backend lock mechanism changes can affect concurrent applies; the Lambda permission change may replace an existing permission resource per environment on apply.
> 
> **Overview**
> **ddhq-matcher-fargate** Terraform for **dev**, **qa**, and **prod** no longer uses the shared DynamoDB table for state locking. Each stack’s S3 backend now enables **`use_lockfile`** (S3-native locking), matching other infrastructure in the repo.
> 
> In **`ddhq-matcher-fargate`**, the SNS→shared Slack notifier **`aws_lambda_permission`** **`statement_id`** is suffixed with **`-${var.environment}`** so dev/qa/prod can each grant invoke on the same Lambda without colliding on a single global statement id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d994823a8bc4f745db4f30f6f5211d3d0f0eb085. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->