### PR TITLE
Release: qa → prod (2026-06-26)

### DIFF
--- a/infrastructure/environments/dev/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/environments/dev/ddhq-matcher-fargate/main.tf
@@ -9,11 +9,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "goodparty-terraform-state-us-west-2"
-    key            = "ddhq-matcher-fargate/dev/terraform.tfstate"
-    region         = "us-west-2"
-    dynamodb_table = "terraform-state-lock"
-    encrypt        = true
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "ddhq-matcher-fargate/dev/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
   }
 }
 

--- a/infrastructure/environments/prod/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/environments/prod/ddhq-matcher-fargate/main.tf
@@ -9,11 +9,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "goodparty-terraform-state-us-west-2"
-    key            = "ddhq-matcher-fargate/prod/terraform.tfstate"
-    region         = "us-west-2"
-    dynamodb_table = "terraform-state-lock"
-    encrypt        = true
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "ddhq-matcher-fargate/prod/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
   }
 }
 

--- a/infrastructure/environments/qa/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/environments/qa/ddhq-matcher-fargate/main.tf
@@ -9,11 +9,11 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "goodparty-terraform-state-us-west-2"
-    key            = "ddhq-matcher-fargate/qa/terraform.tfstate"
-    region         = "us-west-2"
-    dynamodb_table = "terraform-state-lock"
-    encrypt        = true
+    bucket       = "goodparty-terraform-state-us-west-2"
+    key          = "ddhq-matcher-fargate/qa/terraform.tfstate"
+    region       = "us-west-2"
+    use_lockfile = true
+    encrypt      = true
   }
 }
 

--- a/infrastructure/modules/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/modules/ddhq-matcher-fargate/main.tf
@@ -584,7 +584,7 @@ resource "aws_sns_topic_subscription" "shared_slack_notifier" {
 
 resource "aws_lambda_permission" "allow_sns_invoke_slack" {
   count         = var.shared_slack_notifier_lambda_arn != "" ? 1 : 0
-  statement_id  = "AllowSNSInvokeFromMatcherFailures"
+  statement_id  = "AllowSNSInvokeFromMatcherFailures-${var.environment}"
   action        = "lambda:InvokeFunction"
   function_name = var.shared_slack_notifier_lambda_arn
   principal     = "sns.amazonaws.com"


### PR DESCRIPTION
## Included PRs (qa → prod)

- dbe0c5e fix(ddhq-matcher): use S3-native state lock and per-env Slack-invoke statement id

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Terraform state is locked (DynamoDB → S3) and replaces Lambda permission resources with new statement IDs, which can affect apply behavior and briefly touch alerting wiring in prod.
> 
> **Overview**
> **ddhq-matcher-fargate** Terraform for **dev**, **qa**, and **prod** now uses **S3-native state locking** (`use_lockfile = true`) instead of the shared **DynamoDB** lock table, matching the pattern used elsewhere in this repo.
> 
> The module’s **`aws_lambda_permission`** for the shared Slack notifier gets a **per-environment `statement_id`** (`AllowSNSInvokeFromMatcherFailures-${var.environment}`) so dev/qa/prod can each grant SNS invoke on the same Lambda without conflicting statement IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d0b3a61a42ba5708c40d6598e05325a91df858c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->