### PR TITLE
Release: qa → prod (2026-06-29)

### DIFF
--- a/.claude/skills/terraform-deploy.md
+++ b/.claude/skills/terraform-deploy.md
@@ -1,0 +1,72 @@
+---
+name: terraform-deploy
+description: Use when deploying a gp-ai-projects code or infra change to an environment (dev/qa/prod) via Terraform — especially control-plane Lambda changes (dispatch_handler.py, scheduler_handler.py, task_reaper.py) that a branch merge does NOT auto-deploy. Covers the build_lambda_package + AWS-credential bridge + init/plan/apply procedure and what deploys automatically vs. manually.
+---
+
+You are deploying a change in `gp-ai-projects`. Read this before assuming a merge deployed your code — for some components it did, for others it did not.
+
+## What deploys automatically vs. needs Terraform
+
+A push/merge to a deployment branch (`develop`→dev, `qa`→qa, `prod`→prod) triggers `build-*.yml` workflows that build+push images. That is the WHOLE deploy for some components and only HALF for others:
+
+| Component | How its code goes live | Action on a code change |
+| --- | --- | --- |
+| **Broker** (`broker/**`) | `build-broker.yml` builds the image and runs `aws ecs update-service --force-new-deployment` | **Automatic** on branch push. None. |
+| **Runner** (`pmf_engine/runner/**`) | `build-pmf-engine.yml` pushes the `:pmf-engine-<env>` image; the Fargate task def points at that moving tag, so the next `RunTask` pulls it | **Automatic** (next run). None. |
+| **Control-plane Lambdas** — dispatch, scheduler, task_reaper (`pmf_engine/control_plane/**`) | **Zip-packaged by Terraform** (`data.archive_file` over `pmf_engine/.lambda_build`). The image build does NOT touch them. | **Manual `terraform apply`.** A merge alone never updates them. |
+| **Any `*.tf` change** (IAM, SG, task def cpu/mem/env, new resources) | Terraform state | **Manual `terraform apply`** for that module. |
+
+**The trap:** you change `dispatch_handler.py` or `scheduler_handler.py`, merge to `develop`, see the green CI builds, and assume dev is deployed. It is not — those run in the zip Lambdas, which only update via `terraform apply`. (Runner-side files like `config.py`/`params.py` DO ride the image, so a change spanning both needs the image build AND the apply.)
+
+## Deploy procedure (control-plane Lambdas / any terraform module)
+
+Run from a checkout of the **target branch** — `archive_file` zips your local source, so a stale checkout ships stale Lambda code. Branch→env: `develop`→`dev`, `qa`→`qa`, `prod`→`prod`.
+
+```bash
+# 1. Be on the deployed branch's code
+git fetch origin && git reset --hard origin/<branch>   # develop | qa | prod
+
+# 2. Build the Lambda package (only needed for control-plane Lambda changes).
+#    Re-zips dispatch_handler/scheduler_handler/task_reaper + vendored deps into
+#    pmf_engine/.lambda_build, which the terraform archive_file points at.
+bash pmf_engine/scripts/build_lambda_package.sh
+
+# 3. Bridge AWS creds into Terraform (see "Credentials" below), then apply.
+cd infrastructure/environments/<env>/<module>   # e.g. dev/pmf-engine-control-plane
+eval "$(aws configure export-credentials --format env)"
+terraform init -input=false
+terraform plan -input=false -out=tfplan          # REVIEW before applying
+terraform apply -input=false tfplan
+```
+
+**Always review the plan.** A clean control-plane code deploy is exactly
+`0 to add, 3 to change, 0 to destroy` — the dispatch/scheduler/task_reaper
+Lambdas with only `source_code_hash` (and `last_modified`) changing. If the plan
+shows IAM/SG/S3/networking changes you did not intend, STOP — your checkout has
+drift or other unapplied changes; surface it before applying.
+
+Each environment is independent state (S3 backend key `<module>/<env>/terraform.tfstate`). Applying dev does not touch qa/prod. Promote through `develop`→`qa`→`prod`, applying each env from its own branch.
+
+## Credentials
+
+The README says `AWS_PROFILE=work`, but a typical local setup authenticates the
+**`default`** profile via a login helper (`~/.aws/login/`). The `aws` CLI resolves
+those creds, but Terraform's AWS provider does **not** read them and fails with
+`No valid credential sources found` (then tries EC2 IMDS and times out).
+
+Fix: bridge the CLI's live creds into the provider's env, in the **same shell** as
+the terraform command (each invocation is a fresh shell):
+
+```bash
+eval "$(aws configure export-credentials --format env)"
+```
+
+No persistent env var is needed — do not hardcode keys in `.env`. Confirm the
+target account first: `aws sts get-caller-identity` should show account `333022194791`.
+
+## Quick reference
+
+- Build script: `pmf_engine/scripts/build_lambda_package.sh` (writes `pmf_engine/.lambda_build`).
+- Module dirs: `infrastructure/environments/<env>/<module>/`; modules in `infrastructure/modules/`.
+- Verify image builds landed: `gh run list --workflow build-broker.yml --branch <branch>` (and `build-pmf-engine.yml`).
+- Provider is region-only (no hardcoded `profile`), so default creds via the bridge above work.

--- a/broker/ARCHITECTURE.md
+++ b/broker/ARCHITECTURE.md
@@ -160,9 +160,14 @@ Full spec: see `broker/endpoints/*.py`.
          BROKER_TOKEN=<uuid>
          ANTHROPIC_API_KEY=<uuid>  (same token; SDK uses it as auth header)
          RUN_ID, EXPERIMENT_ID, ORGANIZATION_SLUG, PARAMS_JSON, ...
+       (small params ride PARAMS_JSON inline; params over the inline budget are
+        sent as PARAMS_VIA_BROKER=1 instead and the runner fetches them from
+        GET /params/read, served from the ticket — keeps the overrides under the
+        ECS RunTask size limit)
 
   3. Runner Fargate task:
      - Pulls image via ECR endpoints + S3 prefix list
+     - If PARAMS_VIA_BROKER is set: GET /params/read (token auth) → ticket params
      - Starts Claude Agent SDK (passes ANTHROPIC_BASE_URL + ANTHROPIC_API_KEY as env)
      - Every API call: Claude SDK → broker /anthropic/v1/messages (token auth)
      - Every DB query: pmf_runtime.databricks → broker /databricks/query

--- a/broker/endpoints/params_read.py
+++ b/broker/endpoints/params_read.py
@@ -1,0 +1,30 @@
+import logging
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+from broker.dynamodb_client import ScopeTicket
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/params", tags=["params"])
+
+
+def get_scope_ticket() -> ScopeTicket:  # pragma: no cover
+    raise NotImplementedError("Must be overridden via dependency_overrides")
+
+
+@router.get("/read")
+def params_read(ticket: ScopeTicket = Depends(get_scope_ticket)):
+    """Return this run's params from its scope ticket.
+
+    Params are minted into the ticket at dispatch (mint-run-token) and held in
+    DynamoDB, TTL'd and keyed by this run's broker token. The runner calls this
+    only when the dispatch routed params off the ECS env var (it sets
+    PARAMS_VIA_BROKER when the serialized params exceed the containerOverrides
+    budget); small params still ride PARAMS_JSON inline and never hit this path.
+    Authorization is the broker token itself, resolved into `ticket` by the app
+    dependency, so a run can only ever read its own params.
+    """
+    logger.info("params_read ok run_id=%s keys=%d", ticket.run_id, len(ticket.params))
+    return JSONResponse(content=ticket.params)

--- a/broker/main.py
+++ b/broker/main.py
@@ -46,6 +46,10 @@ from broker.endpoints.artifact_read import (
     get_scope_ticket as read_get_scope_ticket,
     router as read_router,
 )
+from broker.endpoints.params_read import (
+    get_scope_ticket as params_get_scope_ticket,
+    router as params_router,
+)
 from broker.endpoints.inputs_read import (
     get_s3_client as inputs_get_s3_client,
     get_scope_ticket as inputs_get_scope_ticket,
@@ -198,6 +202,7 @@ async def lifespan(app: FastAPI):
 
     app.dependency_overrides[inputs_get_scope_ticket] = _resolve_ticket_from_request
     app.dependency_overrides[inputs_get_s3_client] = lambda: s3_client
+    app.dependency_overrides[params_get_scope_ticket] = _resolve_ticket_from_request
 
     app.dependency_overrides[status_get_scope_ticket] = _resolve_ticket_from_request
     app.dependency_overrides[status_get_s3_client] = lambda: s3_client
@@ -267,6 +272,7 @@ app.include_router(braintrust_router)
 app.include_router(publish_router)
 app.include_router(read_router)
 app.include_router(inputs_router)
+app.include_router(params_router)
 app.include_router(status_router)
 app.include_router(databricks_router)
 app.include_router(upload_router)

--- a/broker/tests/test_params_read.py
+++ b/broker/tests/test_params_read.py
@@ -1,0 +1,65 @@
+import time
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from broker.dynamodb_client import ScopeTicket
+from broker.endpoints.params_read import get_scope_ticket, router
+
+BROKER_TOKEN = "broker-token-test-abc123"
+
+
+def _make_ticket(params: dict) -> ScopeTicket:
+    now = int(time.time())
+    return ScopeTicket(
+        pk=BROKER_TOKEN,
+        run_id="run-001",
+        organization_slug="org-42",
+        experiment_id="opponent_research",
+        scope={},
+        params=params,
+        exp=now + 3600,
+        issued_at=now,
+        issued_by="dispatch-lambda-dev",
+    )
+
+
+def _create_app(ticket: ScopeTicket) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_scope_ticket] = lambda: ticket
+    return app
+
+
+class TestParamsRead:
+    def test_returns_the_ticket_params(self):
+        params = {
+            "opponent": {"full_name": "Jane Doe"},
+            "candidate_platform": {"issues": "roads, schools, taxes"},
+        }
+        client = TestClient(_create_app(_make_ticket(params)))
+
+        resp = client.get("/params/read", headers={"X-Broker-Token": BROKER_TOKEN})
+
+        assert resp.status_code == 200
+        assert resp.json() == params
+
+    def test_returns_large_params_intact(self):
+        # The whole point: params that would blow the ECS env-var budget round
+        # trip exactly through the broker ticket.
+        params = {"candidate_platform": {"issues": "x" * 18000}}
+        client = TestClient(_create_app(_make_ticket(params)))
+
+        resp = client.get("/params/read", headers={"X-Broker-Token": BROKER_TOKEN})
+
+        assert resp.status_code == 200
+        assert resp.json() == params
+        assert len(resp.json()["candidate_platform"]["issues"]) == 18000
+
+    def test_returns_empty_object_when_params_empty(self):
+        client = TestClient(_create_app(_make_ticket({})))
+
+        resp = client.get("/params/read", headers={"X-Broker-Token": BROKER_TOKEN})
+
+        assert resp.status_code == 200
+        assert resp.json() == {}

--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -370,14 +370,16 @@ def _missing_critical_config() -> list[str]:
     return missing
 
 
-# Hard upper bound on a dispatch's serialized params. Params no longer have to
-# fit the ECS RunTask containerOverrides budget: anything over
-# INLINE_PARAMS_BUDGET is routed off the env var and the runner pulls it from
-# the broker (which already holds it in the run's scope ticket). This cap is now
-# a product/cost sanity bound on agent input, well under the broker ticket's
-# DynamoDB item ceiling (400 KB). Oversize dispatches still get a clean
-# dispatch-time error rather than failing deep in the run.
-MAX_PARAMS_JSON_BYTES = 20000
+# Hard upper bound on a dispatch's serialized params. Params no longer ride the
+# ECS RunTask containerOverrides budget (anything over INLINE_PARAMS_BUDGET is
+# pulled from the broker ticket instead), so the binding limit is now the SQS
+# message that carries the dispatch gp-api -> this Lambda: SQS caps a message at
+# 262144 bytes (params + the small run_id/slugs/type envelope). This cap is
+# measured on Python's spaced json.dumps, which is always >= gp-api's compact
+# JSON.stringify, so a payload that passes here is guaranteed to fit the compact
+# SQS body (+ ~300-byte envelope) under 262144. 260000 leaves that headroom;
+# going higher needs an SQS extended client / S3 offload on the gp-api side.
+MAX_PARAMS_JSON_BYTES = 260000
 
 # At or under this serialized size, params ride the PARAMS_JSON env var inline
 # (byte-identical to the pre-broker dispatch). AWS ECS RunTask caps the total

--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -370,7 +370,21 @@ def _missing_critical_config() -> list[str]:
     return missing
 
 
-MAX_PARAMS_JSON_BYTES = 6000
+# Hard upper bound on a dispatch's serialized params. Params no longer have to
+# fit the ECS RunTask containerOverrides budget: anything over
+# INLINE_PARAMS_BUDGET is routed off the env var and the runner pulls it from
+# the broker (which already holds it in the run's scope ticket). This cap is now
+# a product/cost sanity bound on agent input, well under the broker ticket's
+# DynamoDB item ceiling (400 KB). Oversize dispatches still get a clean
+# dispatch-time error rather than failing deep in the run.
+MAX_PARAMS_JSON_BYTES = 20000
+
+# At or under this serialized size, params ride the PARAMS_JSON env var inline
+# (byte-identical to the pre-broker dispatch). AWS ECS RunTask caps the total
+# `containerOverrides[]` env payload (~8 KB), shared with INPUT_FILES_JSON and
+# ~15 fixed env vars, so the inline budget stays at the old params cap; larger
+# params are delivered out-of-band via the broker instead (PARAMS_VIA_BROKER).
+INLINE_PARAMS_BUDGET = 6000
 
 # Cap on the serialized INPUT_FILES_JSON env var the dispatch sets on the
 # Fargate task. AWS ECS RunTask limits the total `containerOverrides[]`
@@ -542,6 +556,15 @@ def build_container_overrides(
 ) -> dict:
     if params_json is None:
         params_json = json.dumps(message["params"])
+    # Small params ride PARAMS_JSON inline (byte-identical to the pre-broker
+    # dispatch). Larger params would blow the ECS RunTask containerOverrides
+    # budget, so route them off the env var: set PARAMS_VIA_BROKER and let the
+    # runner fetch them from the broker's /params/read, which serves them from
+    # this run's scope ticket (minted with the full params at launch).
+    if len(params_json.encode("utf-8")) <= INLINE_PARAMS_BUDGET:
+        params_env = {"name": "PARAMS_JSON", "value": params_json}
+    else:
+        params_env = {"name": "PARAMS_VIA_BROKER", "value": "1"}
     env = [
         {"name": "EXPERIMENT_ID", "value": message["experiment_type"]},
         {"name": "RUN_ID", "value": message["run_id"]},
@@ -559,7 +582,7 @@ def build_container_overrides(
         {"name": "BRAINTRUST_API_KEY", "value": broker_token},
         {"name": "BRAINTRUST_APP_URL", "value": f"{broker_url}/braintrust/app"},
         {"name": "BRAINTRUST_API_URL", "value": f"{broker_url}/braintrust/api"},
-        {"name": "PARAMS_JSON", "value": params_json},
+        params_env,
         {"name": "TIMEOUT_SECONDS", "value": str(experiment.get("timeout_seconds", 600))},
         # QA_JUDGES configures the runbooks qa-spine pluggable LLM judge registry
         # (format: name:provider:model,...). Routes through the same broker proxy

--- a/pmf_engine/runner/config.py
+++ b/pmf_engine/runner/config.py
@@ -217,6 +217,25 @@ class RunnerConfig:
         # RunnerConfig directly (tests, future CLI, etc.).
         validate_broker_url_scheme(broker_url, environment_raw)
 
+        # Large params don't fit the ECS RunTask containerOverrides budget, so
+        # dispatch ships them off the env var (PARAMS_VIA_BROKER) and the runner
+        # pulls them from the broker, which holds them in this run's scope ticket
+        # from launch. Done AFTER scheme validation (like the manifest fetch
+        # below) so the broker token never crosses a plaintext connection.
+        if os.environ.get("PARAMS_VIA_BROKER", "").strip() == "1":
+            broker_token_for_params = os.environ.get("BROKER_TOKEN", "").strip()
+            if not (broker_url and broker_token_for_params):
+                raise RuntimeError(
+                    "Cannot fetch params via broker: "
+                    "BROKER_URL and BROKER_TOKEN must both be set."
+                )
+            from pmf_engine.runner.params import fetch_params_from_broker
+
+            params = fetch_params_from_broker(
+                broker_url=broker_url,
+                broker_token=broker_token_for_params,
+            )
+
         contract_schema = None
         attachments: dict[str, str] = {}
         system_prompt: str | None = None

--- a/pmf_engine/runner/params.py
+++ b/pmf_engine/runner/params.py
@@ -1,0 +1,54 @@
+"""Fetch large experiment params from the broker.
+
+Small params ride the PARAMS_JSON env var inline. When they exceed the ECS
+RunTask containerOverrides budget, the dispatch omits PARAMS_JSON and sets
+PARAMS_VIA_BROKER=1; the runner then pulls params from the broker's
+``/params/read`` endpoint, which returns them from this run's scope ticket
+(minted with the full params at launch). Mirrors input_files.py's broker-client
+usage — the broker's long-lived task role is the egress gate, so no AWS
+credentials live on the runner.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_params_from_broker(
+    *,
+    broker_url: str,
+    broker_token: str,
+    client: httpx.Client | None = None,
+) -> dict:
+    """Fetch this run's params from the broker. Returns the params dict.
+
+    Failures bubble up: params are required to run the agent, so a fetch failure
+    means the run is doomed — fail fast so main()'s config-load handler reports
+    FAILED to gp-api cleanly. A `client` arg is accepted for tests
+    (httpx.MockTransport); when omitted, the helper owns the httpx.Client.
+    """
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(
+            base_url=broker_url,
+            headers={"X-Broker-Token": broker_token},
+            timeout=30.0,
+        )
+    try:
+        response = client.get("/params/read")
+        response.raise_for_status()
+        params = response.json()
+    finally:
+        if owns_client:
+            client.close()
+
+    if not isinstance(params, dict):
+        raise ValueError(
+            f"/params/read must return an object, got {type(params).__name__}"
+        )
+    logger.info("fetched params from broker keys=%d", len(params))
+    return params

--- a/pmf_engine/tests/test_dispatch_handler.py
+++ b/pmf_engine/tests/test_dispatch_handler.py
@@ -1345,12 +1345,59 @@ class TestMissingCriticalEnvVars:
         assert result["batchItemFailures"] == [{"itemIdentifier": "msg-001"}]
 
 
+class TestParamsInlineVsBroker:
+    """Small params ride PARAMS_JSON inline; params over INLINE_PARAMS_BUDGET are
+    routed off the env var (PARAMS_VIA_BROKER) so the override stays within the
+    ECS RunTask budget and the runner fetches them from the broker."""
+
+    def _overrides_for(self, params: dict) -> dict:
+        return build_container_overrides(
+            experiment={
+                "harness": "claude_sdk",
+                "model": "sonnet",
+                "contract": {"type": "json", "s3_key_template": "t"},
+            },
+            message={
+                "experiment_type": "opponent_research",
+                "organization_slug": "org-123",
+                "run_id": "run-abc",
+                "clerk_user_id": "user_test_dispatch",
+                "params": params,
+            },
+            broker_token="tok",
+            broker_url="https://broker.example.com",
+            container_name="pmf-engine",
+        )
+
+    def test_small_params_ride_inline(self):
+        env_map = {
+            e["name"]: e["value"]
+            for e in self._overrides_for({"district": "CA-12"})[
+                "containerOverrides"
+            ][0]["environment"]
+        }
+        assert json.loads(env_map["PARAMS_JSON"]) == {"district": "CA-12"}
+        assert "PARAMS_VIA_BROKER" not in env_map
+
+    def test_large_params_routed_to_broker(self):
+        # ~18 KB: over the 6000-byte inline budget, under the 20000 hard cap.
+        env_map = {
+            e["name"]: e["value"]
+            for e in self._overrides_for({"issues": "x" * 18000})[
+                "containerOverrides"
+            ][0]["environment"]
+        }
+        assert env_map["PARAMS_VIA_BROKER"] == "1"
+        assert "PARAMS_JSON" not in env_map
+
+
 class TestParamsSizeLimit:
     @patch("pmf_engine.control_plane.dispatch_handler.send_error_callback")
     @patch("pmf_engine.control_plane.dispatch_handler.emit_dispatch_metric")
     @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
     def test_oversized_params_rejected_before_ecs(self, mock_get_ecs, mock_emit_metric, mock_send_error_callback):
-        oversized = {f"key_{i}": "x" * 900 for i in range(12)}
+        # Over the 20000-byte hard cap (~25 KB serialized).
+        oversized = {f"key_{i}": "x" * 1000 for i in range(25)}
 
         event = _make_sqs_event(
             {

--- a/pmf_engine/tests/test_dispatch_handler.py
+++ b/pmf_engine/tests/test_dispatch_handler.py
@@ -1396,8 +1396,8 @@ class TestParamsSizeLimit:
     @patch("pmf_engine.control_plane.dispatch_handler.emit_dispatch_metric")
     @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
     def test_oversized_params_rejected_before_ecs(self, mock_get_ecs, mock_emit_metric, mock_send_error_callback):
-        # Over the 20000-byte hard cap (~25 KB serialized).
-        oversized = {f"key_{i}": "x" * 1000 for i in range(25)}
+        # Over the 260000-byte hard cap (~280 KB serialized).
+        oversized = {f"key_{i}": "x" * 1000 for i in range(280)}
 
         event = _make_sqs_event(
             {

--- a/pmf_engine/tests/test_params.py
+++ b/pmf_engine/tests/test_params.py
@@ -1,0 +1,116 @@
+"""Tests for runner/params.py and the PARAMS_VIA_BROKER branch of from_env.
+
+Uses httpx.MockTransport to exercise the real client + response parsing path
+without hitting any network, mirroring test_input_files.py.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from pmf_engine.runner.config import RunnerConfig
+from pmf_engine.runner.params import fetch_params_from_broker
+
+BROKER_URL = "https://broker-dev.test"
+BROKER_TOKEN = "broker-token-test-123"
+
+
+def _client_returning(handler) -> httpx.Client:
+    return httpx.Client(
+        base_url=BROKER_URL,
+        headers={"X-Broker-Token": BROKER_TOKEN},
+        transport=httpx.MockTransport(handler),
+    )
+
+
+class TestFetchParamsFromBroker:
+    def test_returns_params_dict(self):
+        params = {"opponent": {"full_name": "Jane Doe"}, "issues": "x" * 18000}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/params/read"
+            assert request.headers["X-Broker-Token"] == BROKER_TOKEN
+            return httpx.Response(200, json=params)
+
+        out = fetch_params_from_broker(
+            broker_url=BROKER_URL,
+            broker_token=BROKER_TOKEN,
+            client=_client_returning(handler),
+        )
+
+        assert out == params
+
+    def test_non_object_response_raises(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=["not", "an", "object"])
+
+        with pytest.raises(ValueError, match="must return an object"):
+            fetch_params_from_broker(
+                broker_url=BROKER_URL,
+                broker_token=BROKER_TOKEN,
+                client=_client_returning(handler),
+            )
+
+    def test_http_error_bubbles_up(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(401, text="bad token")
+
+        with pytest.raises(httpx.HTTPStatusError):
+            fetch_params_from_broker(
+                broker_url=BROKER_URL,
+                broker_token=BROKER_TOKEN,
+                client=_client_returning(handler),
+            )
+
+
+class TestFromEnvParamsViaBroker:
+    def _base_env(self, monkeypatch):
+        # No EXPERIMENT_ID → from_env skips the manifest broker fetch, isolating
+        # the params path.
+        monkeypatch.delenv("EXPERIMENT_ID", raising=False)
+        monkeypatch.setenv("ENVIRONMENT", "dev")
+        monkeypatch.setenv("BROKER_URL", BROKER_URL)
+        monkeypatch.setenv("BROKER_TOKEN", BROKER_TOKEN)
+
+    def test_fetches_from_broker_and_ignores_inline_params(self, monkeypatch):
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("PARAMS_VIA_BROKER", "1")
+        # An inline value must NOT win when the broker path is active.
+        monkeypatch.setenv("PARAMS_JSON", json.dumps({"stale": "inline"}))
+        fetched = {"candidate_platform": {"issues": "y" * 18000}}
+
+        with patch(
+            "pmf_engine.runner.params.fetch_params_from_broker",
+            return_value=fetched,
+        ) as mock_fetch:
+            config = RunnerConfig.from_env()
+
+        assert config.params == fetched
+        mock_fetch.assert_called_once_with(
+            broker_url=BROKER_URL, broker_token=BROKER_TOKEN
+        )
+
+    def test_missing_broker_token_raises(self, monkeypatch):
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("PARAMS_VIA_BROKER", "1")
+        monkeypatch.delenv("BROKER_TOKEN", raising=False)
+
+        with pytest.raises(RuntimeError, match="BROKER_URL and BROKER_TOKEN"):
+            RunnerConfig.from_env()
+
+    def test_inline_params_used_when_flag_absent(self, monkeypatch):
+        self._base_env(monkeypatch)
+        monkeypatch.delenv("PARAMS_VIA_BROKER", raising=False)
+        monkeypatch.setenv("PARAMS_JSON", json.dumps({"district": "CA-12"}))
+
+        with patch(
+            "pmf_engine.runner.params.fetch_params_from_broker"
+        ) as mock_fetch:
+            config = RunnerConfig.from_env()
+
+        assert config.params == {"district": "CA-12"}
+        mock_fetch.assert_not_called()


### PR DESCRIPTION
## Included PRs (qa → prod)

- 8d25a26 Raise dispatch params cap 6k -> 20k via broker delivery

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dispatch→runner startup and a new broker read path for run configuration; auth is per-run token only, but mis-routing or fetch failures would fail runs at config load.
> 
> **Overview**
> Raises the **dispatch params hard cap from 6 KB to 20 KB** while keeping **≤6 KB payloads on `PARAMS_JSON`** unchanged for ECS `containerOverrides` limits.
> 
> When serialized params exceed **`INLINE_PARAMS_BUDGET` (6000 bytes)**, dispatch sets **`PARAMS_VIA_BROKER=1`** instead of embedding JSON in the task env; the runner loads params from the broker **after HTTPS `BROKER_URL` validation** via **`GET /params/read`**, which returns the run’s params from its **scope ticket** (same token auth as other broker routes).
> 
> Adds broker **`params_read`** endpoint wiring in **`main.py`**, runner **`fetch_params_from_broker`**, architecture notes, and tests for inline vs broker routing, oversize rejection, and the broker read path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 375e2d64809b7a818d2070dd45dbfe21f0beb965. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->