### PR TITLE
Raise dispatch params cap 20k → 260k

### DIFF
--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -370,14 +370,16 @@ def _missing_critical_config() -> list[str]:
     return missing
 
 
-# Hard upper bound on a dispatch's serialized params. Params no longer have to
-# fit the ECS RunTask containerOverrides budget: anything over
-# INLINE_PARAMS_BUDGET is routed off the env var and the runner pulls it from
-# the broker (which already holds it in the run's scope ticket). This cap is now
-# a product/cost sanity bound on agent input, well under the broker ticket's
-# DynamoDB item ceiling (400 KB). Oversize dispatches still get a clean
-# dispatch-time error rather than failing deep in the run.
-MAX_PARAMS_JSON_BYTES = 20000
+# Hard upper bound on a dispatch's serialized params. Params no longer ride the
+# ECS RunTask containerOverrides budget (anything over INLINE_PARAMS_BUDGET is
+# pulled from the broker ticket instead), so the binding limit is now the SQS
+# message that carries the dispatch gp-api -> this Lambda: SQS caps a message at
+# 262144 bytes (params + the small run_id/slugs/type envelope). This cap is
+# measured on Python's spaced json.dumps, which is always >= gp-api's compact
+# JSON.stringify, so a payload that passes here is guaranteed to fit the compact
+# SQS body (+ ~300-byte envelope) under 262144. 260000 leaves that headroom;
+# going higher needs an SQS extended client / S3 offload on the gp-api side.
+MAX_PARAMS_JSON_BYTES = 260000
 
 # At or under this serialized size, params ride the PARAMS_JSON env var inline
 # (byte-identical to the pre-broker dispatch). AWS ECS RunTask caps the total

--- a/pmf_engine/tests/test_dispatch_handler.py
+++ b/pmf_engine/tests/test_dispatch_handler.py
@@ -1396,8 +1396,8 @@ class TestParamsSizeLimit:
     @patch("pmf_engine.control_plane.dispatch_handler.emit_dispatch_metric")
     @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
     def test_oversized_params_rejected_before_ecs(self, mock_get_ecs, mock_emit_metric, mock_send_error_callback):
-        # Over the 20000-byte hard cap (~25 KB serialized).
-        oversized = {f"key_{i}": "x" * 1000 for i in range(25)}
+        # Over the 260000-byte hard cap (~280 KB serialized).
+        oversized = {f"key_{i}": "x" * 1000 for i in range(280)}
 
         event = _make_sqs_event(
             {


### PR DESCRIPTION
Follow-up to #153. The 20000 cap was a conservative placeholder; a non-self-trimming experiment is hitting ~116 KB and failing `Experiment parameters exceed size limit (115927 > 20000 bytes)`.

Since #153, params travel out-of-band via the broker scope ticket, so the ECS overrides budget no longer binds. The real ceiling is now the **SQS dispatch message** (gp-api → this Lambda), hard-capped by AWS at **262144 bytes**. The cap here is measured on Python's spaced `json.dumps`, which is always ≥ gp-api's compact `JSON.stringify`, so a payload that passes the cap is guaranteed to fit the compact SQS body (+ ~300-byte envelope) under 262144. **260000** is the largest round value that preserves that guarantee (~2 KB headroom).

Going beyond ~260 KB would require an SQS extended client / S3 offload on the gp-api producer side — out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant and comment change plus test fixture scaling; no auth or launch-path logic changes beyond allowing larger params that already flow via broker.
> 
> **Overview**
> Raises **`MAX_PARAMS_JSON_BYTES`** from **20,000** to **260,000** so large experiment payloads (e.g. ~116 KB) are accepted instead of failing dispatch with a size-limit error.
> 
> The limit rationale in **`dispatch_handler.py`** is updated: after broker offloading, the binding constraint is the **gp-api → dispatch Lambda SQS message** (AWS **262144** byte max), not the old ECS overrides / DynamoDB ticket ceiling. The cap stays measured on Python’s spaced `json.dumps` so passing here still guarantees the compact producer body fits with envelope headroom.
> 
> **`TestParamsSizeLimit`** now builds an oversized params object above **260k** (~280 × 1k strings) instead of above 20k.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d2bc1ac5050a8e707aa941af67dcf130c8ed31a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->