### PR TITLE
dev -> qa

### DIFF
--- a/.claude/skills/terraform-deploy.md
+++ b/.claude/skills/terraform-deploy.md
@@ -1,0 +1,72 @@
+---
+name: terraform-deploy
+description: Use when deploying a gp-ai-projects code or infra change to an environment (dev/qa/prod) via Terraform — especially control-plane Lambda changes (dispatch_handler.py, scheduler_handler.py, task_reaper.py) that a branch merge does NOT auto-deploy. Covers the build_lambda_package + AWS-credential bridge + init/plan/apply procedure and what deploys automatically vs. manually.
+---
+
+You are deploying a change in `gp-ai-projects`. Read this before assuming a merge deployed your code — for some components it did, for others it did not.
+
+## What deploys automatically vs. needs Terraform
+
+A push/merge to a deployment branch (`develop`→dev, `qa`→qa, `prod`→prod) triggers `build-*.yml` workflows that build+push images. That is the WHOLE deploy for some components and only HALF for others:
+
+| Component | How its code goes live | Action on a code change |
+| --- | --- | --- |
+| **Broker** (`broker/**`) | `build-broker.yml` builds the image and runs `aws ecs update-service --force-new-deployment` | **Automatic** on branch push. None. |
+| **Runner** (`pmf_engine/runner/**`) | `build-pmf-engine.yml` pushes the `:pmf-engine-<env>` image; the Fargate task def points at that moving tag, so the next `RunTask` pulls it | **Automatic** (next run). None. |
+| **Control-plane Lambdas** — dispatch, scheduler, task_reaper (`pmf_engine/control_plane/**`) | **Zip-packaged by Terraform** (`data.archive_file` over `pmf_engine/.lambda_build`). The image build does NOT touch them. | **Manual `terraform apply`.** A merge alone never updates them. |
+| **Any `*.tf` change** (IAM, SG, task def cpu/mem/env, new resources) | Terraform state | **Manual `terraform apply`** for that module. |
+
+**The trap:** you change `dispatch_handler.py` or `scheduler_handler.py`, merge to `develop`, see the green CI builds, and assume dev is deployed. It is not — those run in the zip Lambdas, which only update via `terraform apply`. (Runner-side files like `config.py`/`params.py` DO ride the image, so a change spanning both needs the image build AND the apply.)
+
+## Deploy procedure (control-plane Lambdas / any terraform module)
+
+Run from a checkout of the **target branch** — `archive_file` zips your local source, so a stale checkout ships stale Lambda code. Branch→env: `develop`→`dev`, `qa`→`qa`, `prod`→`prod`.
+
+```bash
+# 1. Be on the deployed branch's code
+git fetch origin && git reset --hard origin/<branch>   # develop | qa | prod
+
+# 2. Build the Lambda package (only needed for control-plane Lambda changes).
+#    Re-zips dispatch_handler/scheduler_handler/task_reaper + vendored deps into
+#    pmf_engine/.lambda_build, which the terraform archive_file points at.
+bash pmf_engine/scripts/build_lambda_package.sh
+
+# 3. Bridge AWS creds into Terraform (see "Credentials" below), then apply.
+cd infrastructure/environments/<env>/<module>   # e.g. dev/pmf-engine-control-plane
+eval "$(aws configure export-credentials --format env)"
+terraform init -input=false
+terraform plan -input=false -out=tfplan          # REVIEW before applying
+terraform apply -input=false tfplan
+```
+
+**Always review the plan.** A clean control-plane code deploy is exactly
+`0 to add, 3 to change, 0 to destroy` — the dispatch/scheduler/task_reaper
+Lambdas with only `source_code_hash` (and `last_modified`) changing. If the plan
+shows IAM/SG/S3/networking changes you did not intend, STOP — your checkout has
+drift or other unapplied changes; surface it before applying.
+
+Each environment is independent state (S3 backend key `<module>/<env>/terraform.tfstate`). Applying dev does not touch qa/prod. Promote through `develop`→`qa`→`prod`, applying each env from its own branch.
+
+## Credentials
+
+The README says `AWS_PROFILE=work`, but a typical local setup authenticates the
+**`default`** profile via a login helper (`~/.aws/login/`). The `aws` CLI resolves
+those creds, but Terraform's AWS provider does **not** read them and fails with
+`No valid credential sources found` (then tries EC2 IMDS and times out).
+
+Fix: bridge the CLI's live creds into the provider's env, in the **same shell** as
+the terraform command (each invocation is a fresh shell):
+
+```bash
+eval "$(aws configure export-credentials --format env)"
+```
+
+No persistent env var is needed — do not hardcode keys in `.env`. Confirm the
+target account first: `aws sts get-caller-identity` should show account `333022194791`.
+
+## Quick reference
+
+- Build script: `pmf_engine/scripts/build_lambda_package.sh` (writes `pmf_engine/.lambda_build`).
+- Module dirs: `infrastructure/environments/<env>/<module>/`; modules in `infrastructure/modules/`.
+- Verify image builds landed: `gh run list --workflow build-broker.yml --branch <branch>` (and `build-pmf-engine.yml`).
+- Provider is region-only (no hardcoded `profile`), so default creds via the bridge above work.

--- a/pmf_engine/control_plane/dispatch_handler.py
+++ b/pmf_engine/control_plane/dispatch_handler.py
@@ -370,14 +370,16 @@ def _missing_critical_config() -> list[str]:
     return missing
 
 
-# Hard upper bound on a dispatch's serialized params. Params no longer have to
-# fit the ECS RunTask containerOverrides budget: anything over
-# INLINE_PARAMS_BUDGET is routed off the env var and the runner pulls it from
-# the broker (which already holds it in the run's scope ticket). This cap is now
-# a product/cost sanity bound on agent input, well under the broker ticket's
-# DynamoDB item ceiling (400 KB). Oversize dispatches still get a clean
-# dispatch-time error rather than failing deep in the run.
-MAX_PARAMS_JSON_BYTES = 20000
+# Hard upper bound on a dispatch's serialized params. Params no longer ride the
+# ECS RunTask containerOverrides budget (anything over INLINE_PARAMS_BUDGET is
+# pulled from the broker ticket instead), so the binding limit is now the SQS
+# message that carries the dispatch gp-api -> this Lambda: SQS caps a message at
+# 262144 bytes (params + the small run_id/slugs/type envelope). This cap is
+# measured on Python's spaced json.dumps, which is always >= gp-api's compact
+# JSON.stringify, so a payload that passes here is guaranteed to fit the compact
+# SQS body (+ ~300-byte envelope) under 262144. 260000 leaves that headroom;
+# going higher needs an SQS extended client / S3 offload on the gp-api side.
+MAX_PARAMS_JSON_BYTES = 260000
 
 # At or under this serialized size, params ride the PARAMS_JSON env var inline
 # (byte-identical to the pre-broker dispatch). AWS ECS RunTask caps the total

--- a/pmf_engine/tests/test_dispatch_handler.py
+++ b/pmf_engine/tests/test_dispatch_handler.py
@@ -1396,8 +1396,8 @@ class TestParamsSizeLimit:
     @patch("pmf_engine.control_plane.dispatch_handler.emit_dispatch_metric")
     @patch("pmf_engine.control_plane.dispatch_handler.get_ecs_client")
     def test_oversized_params_rejected_before_ecs(self, mock_get_ecs, mock_emit_metric, mock_send_error_callback):
-        # Over the 20000-byte hard cap (~25 KB serialized).
-        oversized = {f"key_{i}": "x" * 1000 for i in range(25)}
+        # Over the 260000-byte hard cap (~280 KB serialized).
+        oversized = {f"key_{i}": "x" * 1000 for i in range(280)}
 
         event = _make_sqs_event(
             {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes dispatch acceptance limits for experiment params on a critical path; effect is allowing much larger payloads (still bounded under SQS), and Lambda code only takes effect after manual Terraform apply per the new doc.
> 
> **Overview**
> Raises the dispatch Lambda’s **`MAX_PARAMS_JSON_BYTES`** from **20 000** to **260 000**, aligning the hard cap with the **SQS 262 KB message limit** (gp-api → dispatch) now that large params are broker-backed instead of ECS env vars. Comments document the sizing guarantee vs compact JSON from gp-api.
> 
> Adds a **`terraform-deploy`** Claude skill that explains **what CI deploys automatically** (broker/runner images) vs **control-plane Lambdas** (`dispatch_handler`, etc.), which require **`build_lambda_package.sh`** plus **`terraform apply`**, including AWS credential bridging for Terraform.
> 
> Updates **`TestParamsSizeLimit`** to reject payloads over the new cap (~280 KB serialized).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b35b807d2d3451f56f542afd40dc3c70157f0b73. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->