### PR TITLE
Release prep: develop → qa (2026-06-30)

### DIFF
--- a/pmf_engine/runner/main.py
+++ b/pmf_engine/runner/main.py
@@ -417,6 +417,14 @@ def _collect_log_files(workspace_dir: str) -> dict[str, bytes]:
         else:
             logger.warning("Skipping session JSONL upload — redaction failed")
 
+    # Promote the agent-written milestones log from its nested walk key to a
+    # bare sibling of session.jsonl (<exp>/<runId>/logs/milestones.jsonl), which
+    # is where cost analysis reads it. Rename the already-collected bytes rather
+    # than re-reading from disk. Markers are timestamps + phase names — no PII.
+    nested = files.pop("workspace/logs/milestones.jsonl", None)
+    if nested is not None:
+        files["milestones.jsonl"] = nested
+
     return files
 
 

--- a/pmf_engine/runner/pmf_runtime/__init__.py
+++ b/pmf_engine/runner/pmf_runtime/__init__.py
@@ -1,1 +1,4 @@
 from . import config, databricks, http, priors, publish
+from .milestone import milestone
+
+__all__ = ["config", "databricks", "http", "priors", "publish", "milestone"]

--- a/pmf_engine/runner/pmf_runtime/milestone.py
+++ b/pmf_engine/runner/pmf_runtime/milestone.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import UTC, datetime
+
+logger = logging.getLogger(__name__)
+
+# Sibling of session.jsonl after upload. The runner's _collect_log_files
+# special-cases this basename so it lands at <exp>/<runId>/logs/milestones.jsonl
+# (a bare sibling of session.jsonl) rather than nested under workspace/logs/.
+_LOG_BASENAME = "milestones.jsonl"
+
+
+def milestone(name: str) -> None:
+    """Mark the start of a named phase of the run.
+
+    Appends one JSON line ({"ts": <UTC ISO8601>, "name": <name>}) to
+    <workspace>/logs/milestones.jsonl. The runner uploads that file to S3
+    alongside session.jsonl, and cost analysis joins each turn to the most
+    recent milestone marker at/before the turn's timestamp.
+
+    There is NO broker call and NO network egress — this is a local append the
+    runner already ships. A milestone() call must never break a run, so every
+    failure (bad name, unwritable workspace, full disk) is swallowed and logged.
+    """
+    try:
+        workspace = os.environ.get("WORKSPACE_DIR") or os.environ.get("PMF_WORKSPACE", "/workspace")
+        logs_dir = os.path.join(workspace, "logs")
+        os.makedirs(logs_dir, exist_ok=True)
+        record = {
+            "ts": datetime.now(UTC).isoformat(),
+            "name": str(name),
+        }
+        with open(os.path.join(logs_dir, _LOG_BASENAME), "a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except Exception as exc:
+        logger.warning("milestone(%r) failed: %s: %s", name, type(exc).__name__, exc)

--- a/pmf_engine/runner/pmf_runtime/tests/test_milestone.py
+++ b/pmf_engine/runner/pmf_runtime/tests/test_milestone.py
@@ -1,0 +1,54 @@
+import json
+
+from pmf_engine.runner.pmf_runtime import milestone
+
+
+def _read_markers(tmp_path):
+    log = tmp_path / "logs" / "milestones.jsonl"
+    if not log.exists():
+        return []
+    return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+
+
+class TestMilestone:
+    def test_appends_record_with_name_and_ts(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PMF_WORKSPACE", str(tmp_path))
+        milestone("gather_inputs")
+        markers = _read_markers(tmp_path)
+        assert len(markers) == 1
+        assert markers[0]["name"] == "gather_inputs"
+        assert markers[0]["ts"].endswith("+00:00")
+
+    def test_appends_in_order(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PMF_WORKSPACE", str(tmp_path))
+        milestone("step_one")
+        milestone("step_two")
+        markers = _read_markers(tmp_path)
+        assert [m["name"] for m in markers] == ["step_one", "step_two"]
+
+    def test_prefers_workspace_dir_over_pmf_workspace(self, tmp_path, monkeypatch):
+        workspace_dir = tmp_path / "wsdir"
+        monkeypatch.setenv("WORKSPACE_DIR", str(workspace_dir))
+        monkeypatch.delenv("PMF_WORKSPACE", raising=False)
+        milestone("from_workspace_dir")
+        markers = _read_markers(workspace_dir)
+        assert len(markers) == 1
+        assert markers[0]["name"] == "from_workspace_dir"
+
+    def test_creates_logs_dir_if_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PMF_WORKSPACE", str(tmp_path))
+        assert not (tmp_path / "logs").exists()
+        milestone("first")
+        assert (tmp_path / "logs" / "milestones.jsonl").exists()
+
+    def test_never_raises_on_unwritable_workspace(self, tmp_path, monkeypatch):
+        # workspace points at a path whose parent is a file, so makedirs fails.
+        bad = tmp_path / "afile"
+        bad.write_text("x")
+        monkeypatch.setenv("PMF_WORKSPACE", str(bad / "nested"))
+        milestone("should_not_crash")
+
+    def test_exported_from_package_root(self):
+        import pmf_engine.runner.pmf_runtime as rt
+
+        assert hasattr(rt, "milestone")

--- a/pmf_engine/tests/test_runner_main.py
+++ b/pmf_engine/tests/test_runner_main.py
@@ -1936,6 +1936,59 @@ class TestCollectWorkspaceFilesSkipsUserInputs:
         )
 
 
+class TestCollectLogFilesMilestonesPromotion:
+    """The agent writes its milestone markers to
+    <workspace>/logs/milestones.jsonl. The generic workspace walk collects that
+    under the nested key "workspace/logs/milestones.jsonl", but cost analysis
+    reads the marker log as a bare sibling of session.jsonl
+    (<exp>/<runId>/logs/milestones.jsonl). _collect_log_files promotes the
+    already-collected bytes to the bare "milestones.jsonl" key and drops the
+    nested one — no second disk read, no double-upload.
+    """
+
+    def test_milestones_promoted_to_bare_key(self, tmp_path):
+        from pmf_engine.runner.main import _collect_log_files
+
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        (logs_dir / "milestones.jsonl").write_text(
+            '{"ts":"2026-01-01T00:00:00+00:00","name":"gather"}\n'
+        )
+
+        files = _collect_log_files(str(tmp_path))
+
+        assert "milestones.jsonl" in files, (
+            f"milestones must be promoted to the bare key, got: {sorted(files)}"
+        )
+        assert files["milestones.jsonl"] == (
+            b'{"ts":"2026-01-01T00:00:00+00:00","name":"gather"}\n'
+        )
+
+    def test_nested_milestones_key_removed_after_promotion(self, tmp_path):
+        from pmf_engine.runner.main import _collect_log_files
+
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        (logs_dir / "milestones.jsonl").write_text('{"name":"x"}\n')
+
+        files = _collect_log_files(str(tmp_path))
+
+        assert "workspace/logs/milestones.jsonl" not in files, (
+            f"nested walk key must be dropped after promotion, got: {sorted(files)}"
+        )
+
+    def test_no_milestones_file_leaves_neither_key(self, tmp_path):
+        from pmf_engine.runner.main import _collect_log_files
+
+        (tmp_path / "output").mkdir()
+        (tmp_path / "output" / "result.json").write_text('{"ok": true}')
+
+        files = _collect_log_files(str(tmp_path))
+
+        assert "milestones.jsonl" not in files
+        assert "workspace/logs/milestones.jsonl" not in files
+
+
 class TestBrokerInitLastResortSqsFallback:
     """C2: When BOTH init_config AND the subsequent RunnerConfig.from_env
     broker fetch fail, the runner has no broker channel to send a failed


### PR DESCRIPTION
## Included PRs

- d1f750d feat(pmf-runtime): add milestone() primitive for per-phase cost attribution (#159)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive logging and upload rekeying only; `milestone()` is fail-safe and does not touch auth or run lifecycle.
> 
> **Overview**
> Adds **`pmf_runtime.milestone(name)`** so agents can record run phases locally: each call appends a UTC-timestamped JSON line to `<workspace>/logs/milestones.jsonl` with no broker or network I/O, and failures are swallowed so runs never fail on logging.
> 
> **`_collect_log_files`** now rekeys the walked file from `workspace/logs/milestones.jsonl` to **`milestones.jsonl`** in the upload bundle so it sits next to `session.jsonl` where cost analysis expects it, without a second disk read.
> 
> Unit tests cover the primitive and the promotion behavior in log collection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1f750d7d22dd22594dd5810d6ce70495fd825ac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->