### PR TITLE
Propagate Project tag to broker ECS tasks

### DIFF
--- a/infrastructure/modules/broker/main.tf
+++ b/infrastructure/modules/broker/main.tf
@@ -729,6 +729,12 @@ resource "aws_ecs_service" "broker" {
   enable_execute_command            = true
   health_check_grace_period_seconds = 60
 
+  # Propagate the task-definition's Project tag (set via provider default_tags)
+  # onto the running tasks so Fargate compute is attributed in Cost Explorer;
+  # tasks don't inherit task-def tags otherwise.
+  propagate_tags          = "TASK_DEFINITION"
+  enable_ecs_managed_tags = true
+
   network_configuration {
     subnets          = var.private_subnet_ids
     security_groups  = [aws_security_group.broker.id]


### PR DESCRIPTION
## Why

PR #144 added provider `default_tags` so the broker task definition is tagged with `Project`, but the broker `aws_ecs_service` still had `propagate_tags` at its default (`NONE`). AWS allocates Fargate cost by the tags on the running task, and tasks only inherit the task-definition's tags when the service propagates them — so broker compute continued to show up untagged in Cost Explorer.

Setting `propagate_tags = "TASK_DEFINITION"` (plus `enable_ecs_managed_tags`) makes the running tasks carry `Project`. This is the broker counterpart to the omni ECS-service fix; it applies prospectively as the service redeploys.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform-only ECS service tagging change with no application or security impact; effect is prospective on redeploy.
> 
> **Overview**
> Updates the broker **`aws_ecs_service`** so Fargate tasks inherit the task definition’s **`Project`** tag (from provider `default_tags`) instead of leaving compute untagged in Cost Explorer.
> 
> Adds **`propagate_tags = "TASK_DEFINITION"`** and **`enable_ecs_managed_tags = true`** on `broker-${var.environment}`; tags apply on the next service redeploy, with no runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6dec26e1d745b110f09bc88a39918c3e780411e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->