### PR TITLE
Release prep: develop → qa (2026-07-02)

### DIFF
--- a/infrastructure/modules/broker/main.tf
+++ b/infrastructure/modules/broker/main.tf
@@ -729,6 +729,12 @@ resource "aws_ecs_service" "broker" {
   enable_execute_command            = true
   health_check_grace_period_seconds = 60
 
+  # Propagate the task-definition's Project tag (set via provider default_tags)
+  # onto the running tasks so Fargate compute is attributed in Cost Explorer;
+  # tasks don't inherit task-def tags otherwise.
+  propagate_tags          = "TASK_DEFINITION"
+  enable_ecs_managed_tags = true
+
   network_configuration {
     subnets          = var.private_subnet_ids
     security_groups  = [aws_security_group.broker.id]


### PR DESCRIPTION
## Included PRs

- 06a4f62 Propagate Project tag to broker ECS tasks for cost allocation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tagging-only ECS service update with no changes to networking, scaling, or application behavior.
> 
> **Overview**
> **Broker ECS service** now copies tags from the task definition onto **running Fargate tasks** so Cost Explorer can attribute compute spend.
> 
> The change sets `propagate_tags = "TASK_DEFINITION"` and `enable_ecs_managed_tags = true` on `aws_ecs_service.broker`. Provider `default_tags` (including `Project`) already land on the task definition; without propagation, those tags do not appear on tasks and Fargate costs stay harder to allocate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8c09bd44f2839331824e5b5c4c898bbacc7727. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->