### PR TITLE
Release: qa → prod (2026-07-02)

### DIFF
--- a/infrastructure/modules/broker/main.tf
+++ b/infrastructure/modules/broker/main.tf
@@ -729,6 +729,12 @@ resource "aws_ecs_service" "broker" {
   enable_execute_command            = true
   health_check_grace_period_seconds = 60
 
+  # Propagate the task-definition's Project tag (set via provider default_tags)
+  # onto the running tasks so Fargate compute is attributed in Cost Explorer;
+  # tasks don't inherit task-def tags otherwise.
+  propagate_tags          = "TASK_DEFINITION"
+  enable_ecs_managed_tags = true
+
   network_configuration {
     subnets          = var.private_subnet_ids
     security_groups  = [aws_security_group.broker.id]


### PR DESCRIPTION
## Included PRs (qa → prod)

- 06a4f62 Propagate Project tag to broker ECS tasks for cost allocation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform-only ECS service tagging with no changes to networking, IAM, or application behavior; apply may cause a brief service update as ECS reconciles tag settings.
> 
> **Overview**
> **Enables Cost Explorer attribution** for broker Fargate spend by tagging running ECS tasks with the same **Project** label that provider `default_tags` already apply to the task definition.
> 
> The broker `aws_ecs_service` now sets `propagate_tags = "TASK_DEFINITION"` and `enable_ecs_managed_tags = true`, because Fargate tasks do not inherit task-definition tags unless the service propagates them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dee31c9886ffe6f7e07dc1783ee804d2138e650. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->