### PR TITLE
feat(broker): add opt-in render modes (text/html/links) to /http/fetch

### DIFF
--- a/broker/browser_fetcher.py
+++ b/broker/browser_fetcher.py
@@ -24,6 +24,7 @@ Memory model:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import tempfile
@@ -33,6 +34,18 @@ from typing import Protocol
 from fastapi import HTTPException
 
 from broker.ssrf_guard import validate_url
+
+# Render modes for text/html responses (selected by the /http/fetch `render`
+# param). Non-HTML content types ignore these entirely.
+RENDER_TEXT = "text"  # rendered visible text via inner_text('body') — the default
+RENDER_HTML = "html"  # full serialized rendered DOM via page.content()
+RENDER_LINKS = "links"  # JSON {"links": [{href, text}]} from a[href], hrefs absolute
+
+# a.href is the DOM IDL property, which resolves relative hrefs against the
+# document base URL — so extracted hrefs are absolute WITHOUT any extra network
+# fetch (unlike getAttribute('href'), which returns the raw, possibly-relative
+# attribute). textContent.trim() gives the trimmed anchor text.
+_LINKS_EXTRACTION_JS = "els => els.map(a => ({ href: a.href, text: (a.textContent || '').trim() }))"
 
 
 class _ViolationTracker:
@@ -61,6 +74,7 @@ class _ViolationTracker:
 
     def fatal(self) -> str | None:
         return self._fatal
+
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +118,7 @@ class BrowserFetchResult:
 
 
 class BrowserFetcher(Protocol):
-    async def fetch(self, url: str) -> BrowserFetchResult: ...
+    async def fetch(self, url: str, *, render: str = RENDER_TEXT) -> BrowserFetchResult: ...
 
 
 def _is_binary_content_type(ct: str) -> bool:
@@ -186,14 +200,10 @@ class PlaywrightBrowserFetcher:
         acquired = 0
         try:
             for _ in range(self._max_concurrent):
-                await asyncio.wait_for(
-                    self._semaphore.acquire(), timeout=_ACLOSE_DRAIN_TIMEOUT_S
-                )
+                await asyncio.wait_for(self._semaphore.acquire(), timeout=_ACLOSE_DRAIN_TIMEOUT_S)
                 acquired += 1
         except TimeoutError:
-            logger.warning(
-                "browser_fetcher.aclose timed out waiting for in-flight fetches"
-            )
+            logger.warning("browser_fetcher.aclose timed out waiting for in-flight fetches")
         try:
             if self._browser is not None:
                 await self._browser.close()
@@ -207,25 +217,21 @@ class PlaywrightBrowserFetcher:
                 for _ in range(acquired):
                     self._semaphore.release()
 
-    async def fetch(self, url: str) -> BrowserFetchResult:
+    async def fetch(self, url: str, *, render: str = RENDER_TEXT) -> BrowserFetchResult:
         if self._closing:
             raise HTTPException(status_code=503, detail="browser fetcher shutting down")
         async with self._semaphore:
             if self._closing:
-                raise HTTPException(
-                    status_code=503, detail="browser fetcher shutting down"
-                )
-            return await self._fetch_impl(url)
+                raise HTTPException(status_code=503, detail="browser fetcher shutting down")
+            return await self._fetch_impl(url, render)
 
-    async def _fetch_impl(self, url: str) -> BrowserFetchResult:
+    async def _fetch_impl(self, url: str, render: str = RENDER_TEXT) -> BrowserFetchResult:
         from playwright.async_api import Download, Route
         from playwright.async_api import Error as PlaywrightError
         from playwright_stealth import stealth_async  # type: ignore[import-untyped]
 
         if self._browser is None:
-            raise RuntimeError(
-                "PlaywrightBrowserFetcher.start() must be awaited before fetch()"
-            )
+            raise RuntimeError("PlaywrightBrowserFetcher.start() must be awaited before fetch()")
 
         tracker = _ViolationTracker()
 
@@ -291,27 +297,18 @@ class PlaywrightBrowserFetcher:
             # 1) Initial grace window — Cloudflare and other JS challenges
             # frequently trigger downloads 200-500 ms after page.goto settles.
             # Always wait this regardless of response state.
-            await self._wait_for_download(
-                page, downloads, INITIAL_DOWNLOAD_GRACE_MS, _raise_if_violation
-            )
+            await self._wait_for_download(page, downloads, INITIAL_DOWNLOAD_GRACE_MS, _raise_if_violation)
 
             if not downloads:
                 # 2) If goto raised (download path with no response), keep waiting
                 # the full DOWNLOAD_WAIT_MS for the download event.
                 if response is None or nav_error is not None:
                     remaining = max(DOWNLOAD_WAIT_MS - INITIAL_DOWNLOAD_GRACE_MS, 0)
-                    await self._wait_for_download(
-                        page, downloads, remaining, _raise_if_violation
-                    )
+                    await self._wait_for_download(page, downloads, remaining, _raise_if_violation)
                 else:
                     # 3) Successful navigation with a response: only pay the
                     # secondary download window for binary content-types.
-                    ct_initial = (
-                        (response.headers.get("content-type") or "")
-                        .split(";")[0]
-                        .strip()
-                        .lower()
-                    )
+                    ct_initial = (response.headers.get("content-type") or "").split(";")[0].strip().lower()
                     if _is_binary_content_type(ct_initial):
                         await self._wait_for_download(
                             page,
@@ -342,11 +339,7 @@ class PlaywrightBrowserFetcher:
                         )
                     _raise_if_violation()
                 captured = captured_responses.get(final_url)
-                content_type = (
-                    captured[0]
-                    if captured and captured[0]
-                    else "application/octet-stream"
-                )
+                content_type = captured[0] if captured and captured[0] else "application/octet-stream"
                 return BrowserFetchResult(
                     status=200,
                     content_type=content_type,
@@ -357,9 +350,7 @@ class PlaywrightBrowserFetcher:
                 )
 
             if nav_error is not None:
-                logger.warning(
-                    "playwright navigation error url=%s error=%s", url, nav_error
-                )
+                logger.warning("playwright navigation error url=%s error=%s", url, nav_error)
                 raise HTTPException(
                     status_code=502,
                     detail="upstream navigation failed",
@@ -380,13 +371,9 @@ class PlaywrightBrowserFetcher:
             # late sub-resources / late download triggers. JSON/XML/text get
             # zero settle. networkidle timeout is acceptable — we've already
             # waited the budgeted window.
-            if _is_binary_content_type(content_type) or content_type.startswith(
-                "text/html"
-            ):
+            if _is_binary_content_type(content_type) or content_type.startswith("text/html"):
                 try:
-                    await page.wait_for_load_state(
-                        "networkidle", timeout=POST_NAV_SETTLE_MS
-                    )
+                    await page.wait_for_load_state("networkidle", timeout=POST_NAV_SETTLE_MS)
                 except PlaywrightError:
                     pass
                 _raise_if_violation()
@@ -411,11 +398,7 @@ class PlaywrightBrowserFetcher:
                             )
                         _raise_if_violation()
                     captured = captured_responses.get(final_url)
-                    ct = (
-                        captured[0]
-                        if captured and captured[0]
-                        else "application/octet-stream"
-                    )
+                    ct = captured[0] if captured and captured[0] else "application/octet-stream"
                     return BrowserFetchResult(
                         status=200,
                         content_type=ct,
@@ -426,22 +409,57 @@ class PlaywrightBrowserFetcher:
                     )
 
             if content_type.startswith("text/html"):
-                # Return the rendered VISIBLE TEXT, not raw HTML: the publish
-                # gate rejects raw HTML, and every consumer reads the body as
-                # text. Reading the DOM also sidesteps the getResponseBody
-                # eviction that response.body() hits after the networkidle settle.
-                try:
-                    body = (await page.inner_text("body")).encode("utf-8")
-                except PlaywrightError as e:
-                    logger.warning(
-                        "page.inner_text('body') unavailable url=%s error=%s",
-                        url,
-                        e,
-                    )
-                    raise HTTPException(
-                        status_code=502,
-                        detail="upstream response body unavailable",
-                    ) from e
+                if render == RENDER_HTML:
+                    # Full serialized rendered DOM. Explicit opt-in: the publish
+                    # gate rejects raw HTML, so consumers asking for this know
+                    # they're bypassing the text-only default.
+                    try:
+                        body = (await page.content()).encode("utf-8")
+                    except PlaywrightError as e:
+                        logger.warning("page.content() unavailable url=%s error=%s", url, e)
+                        raise HTTPException(
+                            status_code=502,
+                            detail="upstream response body unavailable",
+                        ) from e
+                elif render == RENDER_LINKS:
+                    # Extract a[href] from the rendered DOM as JSON. Recovers doc
+                    # URLs (e.g. CivicPlus /DocumentCenter/View/...) that the
+                    # text-only render hides. Reads the DOM only — no extra
+                    # network fetch, and hrefs are NOT SSRF-validated here (that
+                    # would trigger a DNS lookup); the final page URL is still
+                    # validated below, exactly as the other render modes.
+                    try:
+                        raw_links = await page.eval_on_selector_all("a[href]", _LINKS_EXTRACTION_JS)
+                    except PlaywrightError as e:
+                        logger.warning(
+                            "page.eval_on_selector_all('a[href]') unavailable url=%s error=%s",
+                            url,
+                            e,
+                        )
+                        raise HTTPException(
+                            status_code=502,
+                            detail="upstream response body unavailable",
+                        ) from e
+                    body = json.dumps({"links": raw_links}, ensure_ascii=False).encode("utf-8")
+                    content_type = "application/json"
+                else:
+                    # RENDER_TEXT (default): rendered VISIBLE TEXT, not raw HTML.
+                    # The publish gate rejects raw HTML, and every consumer reads
+                    # the body as text. Reading the DOM also sidesteps the
+                    # getResponseBody eviction that response.body() hits after the
+                    # networkidle settle.
+                    try:
+                        body = (await page.inner_text("body")).encode("utf-8")
+                    except PlaywrightError as e:
+                        logger.warning(
+                            "page.inner_text('body') unavailable url=%s error=%s",
+                            url,
+                            e,
+                        )
+                        raise HTTPException(
+                            status_code=502,
+                            detail="upstream response body unavailable",
+                        ) from e
             else:
                 try:
                     body = await response.body()
@@ -520,9 +538,7 @@ async def _save_download_to_disk(download: object) -> tuple[str, int]:
             try:
                 await asyncio.to_thread(os.unlink, tmp_path)
             except OSError:
-                logger.warning(
-                    "failed to unlink oversized download tmp_path=%s", tmp_path
-                )
+                logger.warning("failed to unlink oversized download tmp_path=%s", tmp_path)
             raise HTTPException(
                 status_code=413,
                 detail=f"download exceeded {MAX_BYTES} bytes",

--- a/broker/endpoints/http_fetch.py
+++ b/broker/endpoints/http_fetch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from typing import Literal
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
@@ -26,6 +27,16 @@ __all__ = ["router", "get_scope_ticket", "get_browser_fetcher", "MAX_BYTES"]
 class HttpFetchRequest(BaseModel):
     url: str
     purpose: str = ""
+
+
+class HttpFetchRenderRequest(HttpFetchRequest):
+    # How to return a text/html page. "text" (default) is the publish-gate-safe
+    # rendered visible text — unchanged legacy behavior. "html" returns the full
+    # serialized DOM; "links" returns JSON {"links": [{href, text}]} from a[href]
+    # (absolute hrefs) — explicit opt-ins for consumers that can handle raw
+    # markup. Non-HTML content types ignore this. Pydantic rejects other values
+    # with 422 before the fetcher runs. Scoped to /fetch — /head is unaffected.
+    render: Literal["text", "html", "links"] = "text"
 
 
 def get_scope_ticket() -> ScopeTicket:  # pragma: no cover
@@ -74,6 +85,7 @@ async def _status_check(client: httpx.AsyncClient, url: str) -> tuple[int, str]:
     missing-Location -> 502, hop bound) is delegated to the canonical
     `resolve_redirects` loop in `ssrf_guard` — never re-implemented here.
     """
+
     async def _run() -> tuple[int, str]:
         head_client = _HeaderInjectingClient(client, {"user-agent": USER_AGENT})
         try:
@@ -81,9 +93,7 @@ async def _status_check(client: httpx.AsyncClient, url: str) -> tuple[int, str]:
                 head_client, "HEAD", url, timeout=_HEAD_TIMEOUT_S, max_redirects=_HEAD_MAX_REDIRECTS
             )
             if resp.status_code in (403, 405, 501):
-                get_client = _HeaderInjectingClient(
-                    client, {"user-agent": USER_AGENT, "range": "bytes=0-0"}
-                )
+                get_client = _HeaderInjectingClient(client, {"user-agent": USER_AGENT, "range": "bytes=0-0"})
                 resp, final_url = await resolve_redirects(
                     get_client,
                     "GET",
@@ -95,17 +105,13 @@ async def _status_check(client: httpx.AsyncClient, url: str) -> tuple[int, str]:
         except HTTPException:
             raise
         except httpx.TimeoutException as e:
-            raise HTTPException(
-                status_code=504, detail=f"timeout after {_HEAD_TIMEOUT_S}s: {url}"
-            ) from e
+            raise HTTPException(status_code=504, detail=f"timeout after {_HEAD_TIMEOUT_S}s: {url}") from e
         except httpx.HTTPError as e:
-            raise HTTPException(
-                status_code=502, detail=f"connection failed: {type(e).__name__}: {e}"
-            ) from e
+            raise HTTPException(status_code=502, detail=f"connection failed: {type(e).__name__}: {e}") from e
 
     try:
         return await asyncio.wait_for(_run(), timeout=_HEAD_TOTAL_TIMEOUT_S)
-    except asyncio.TimeoutError as e:
+    except TimeoutError as e:
         raise HTTPException(
             status_code=504,
             detail=f"head check exceeded {_HEAD_TOTAL_TIMEOUT_S}s total: {url}",
@@ -133,14 +139,14 @@ async def _stream_file(path: str):
 
 @router.post("/fetch")
 async def http_fetch(
-    req: HttpFetchRequest,
+    req: HttpFetchRenderRequest,
     ticket: ScopeTicket = Depends(get_scope_ticket),
     fetcher: BrowserFetcher = Depends(get_browser_fetcher),
 ):
     try:
         await validate_url(req.url)
 
-        result = await fetcher.fetch(req.url)
+        result = await fetcher.fetch(req.url, render=req.render)
 
         try:
             await validate_url(result.final_url)
@@ -221,12 +227,19 @@ async def http_head(
     except HTTPException as e:
         logger.warning(
             "http_head failed run_id=%s status=%d purpose=%s url=%s detail=%s",
-            ticket.run_id, e.status_code, req.purpose or "", req.url, e.detail,
+            ticket.run_id,
+            e.status_code,
+            req.purpose or "",
+            req.url,
+            e.detail,
         )
         raise
     logger.info(
         "http_head ok run_id=%s status=%d purpose=%s url=%s",
-        ticket.run_id, status, req.purpose or "", req.url,
+        ticket.run_id,
+        status,
+        req.purpose or "",
+        req.url,
     )
     return {"status": status, "final_url": final_url}
 

--- a/broker/tests/test_broker_sdk_bridge.py
+++ b/broker/tests/test_broker_sdk_bridge.py
@@ -70,9 +70,11 @@ class _FakeFetcher:
     result: BrowserFetchResult | None = None
     raise_exc: Exception | None = None
     calls: list[str] = field(default_factory=list)
+    render_calls: list[str] = field(default_factory=list)
 
-    async def fetch(self, url: str) -> BrowserFetchResult:
+    async def fetch(self, url: str, *, render: str = "text") -> BrowserFetchResult:
         self.calls.append(url)
+        self.render_calls.append(render)
         if self.raise_exc is not None:
             raise self.raise_exc
         assert self.result is not None, "test must configure result or raise_exc"

--- a/broker/tests/test_browser_fetcher.py
+++ b/broker/tests/test_browser_fetcher.py
@@ -17,6 +17,7 @@ Fakes substitute for playwright runtime types — no real Chromium required.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from typing import Any
 
@@ -90,6 +91,8 @@ class _FakePage:
         on_settle: Any = None,
         responses_to_emit: list[_FakeResponse] | None = None,
         inner_text_value: str | None = None,
+        content_value: str | None = None,
+        links_value: list[dict[str, str]] | None = None,
     ) -> None:
         self._response = response
         self.url = url
@@ -99,6 +102,12 @@ class _FakePage:
         self._responses_to_emit = responses_to_emit or []
         self._wait_calls = 0
         self._load_state_calls = 0
+        # render="html" reads page.content(); render="links" reads
+        # page.eval_on_selector_all('a[href]', ...). Tests that exercise those
+        # render modes configure these; other tests leave them None.
+        self._content_value = content_value
+        self._links_value = links_value
+        self.eval_calls: list[tuple[str, str]] = []
         # text/html now reads rendered visible text via inner_text("body"),
         # not raw response.body(). Default to the response body decoded as text
         # so existing HTML tests (which pass HTML-as-text bodies) round-trip.
@@ -133,6 +142,17 @@ class _FakePage:
 
     async def inner_text(self, selector: str) -> str:
         return self._inner_text_value
+
+    async def content(self) -> str:
+        if self._content_value is None:
+            raise AssertionError("test must configure content_value for html render")
+        return self._content_value
+
+    async def eval_on_selector_all(self, selector: str, expression: str) -> list[dict[str, str]]:
+        self.eval_calls.append((selector, expression))
+        if self._links_value is None:
+            raise AssertionError("test must configure links_value for links render")
+        return self._links_value
 
     def emit_download(self, download: _FakeDownload) -> None:
         for handler in self._download_listeners:
@@ -275,7 +295,7 @@ class TestConcurrencyCap:
 
 class TestUnifiedFetchSignature:
     @pytest.mark.asyncio
-    async def test_fetch_accepts_only_url_arg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_fetch_accepts_url_and_render_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_playwright_types(monkeypatch)
         page = _FakePage(response=_FakeResponse(body=b"ok"), url="https://example.com/")
         fetcher = PlaywrightBrowserFetcher()
@@ -284,6 +304,10 @@ class TestUnifiedFetchSignature:
         monkeypatch.setattr("broker.browser_fetcher.validate_url", _allow_all)
 
         result = await fetcher.fetch("https://example.com/")
+        assert isinstance(result, BrowserFetchResult)
+
+        # render is the only accepted keyword; anything else is a TypeError.
+        result = await fetcher.fetch("https://example.com/", render="text")
         assert isinstance(result, BrowserFetchResult)
 
         with pytest.raises(TypeError):
@@ -468,9 +492,7 @@ class TestDownloadPath:
                 os.unlink(result.body_path)
 
     @pytest.mark.asyncio
-    async def test_download_exceeding_max_bytes_raises_413_and_unlinks(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_download_exceeding_max_bytes_raises_413_and_unlinks(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The fetcher enforces MAX_BYTES on download; oversized files must
         be unlinked immediately and a 413 raised."""
         _patch_playwright_types(monkeypatch)
@@ -517,9 +539,7 @@ class TestDownloadPath:
 
 class TestPageResponsePath:
     @pytest.mark.asyncio
-    async def test_returns_real_content_type_from_response_headers(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_returns_real_content_type_from_response_headers(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_playwright_types(monkeypatch)
 
         body = b"<html><body>ok</body></html>"
@@ -569,9 +589,7 @@ class TestPageResponsePath:
         assert exc.value.status_code == 400
 
     @pytest.mark.asyncio
-    async def test_missing_content_type_defaults_to_octet_stream(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_missing_content_type_defaults_to_octet_stream(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_playwright_types(monkeypatch)
 
         page = _FakePage(
@@ -593,9 +611,7 @@ class TestPageResponsePath:
         assert result.content_type == "application/octet-stream"
 
     @pytest.mark.asyncio
-    async def test_page_response_exceeding_page_max_raises_413(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_page_response_exceeding_page_max_raises_413(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Page-response path enforces the tighter PAGE_RESPONSE_MAX_BYTES cap
         before buffering response.body() into RAM."""
         _patch_playwright_types(monkeypatch)
@@ -730,9 +746,7 @@ class TestHtmlBodyIsRenderedVisibleText:
 
 class TestNavigationFailure:
     @pytest.mark.asyncio
-    async def test_nav_error_with_no_download_raises_generic_502(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_nav_error_with_no_download_raises_generic_502(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_playwright_types(monkeypatch)
 
         from playwright.async_api import Error as PlaywrightError
@@ -762,9 +776,7 @@ class TestDownloadGraceWindow:
     HTML back to the caller instead of the file."""
 
     @pytest.mark.asyncio
-    async def test_late_fired_download_after_successful_goto_is_captured(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_late_fired_download_after_successful_goto_is_captured(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_playwright_types(monkeypatch)
 
         download_url = "https://example.com/agenda.pdf"
@@ -808,9 +820,7 @@ class TestDownloadGraceWindow:
                 os.unlink(result.body_path)
 
     @pytest.mark.asyncio
-    async def test_textual_response_skips_binary_grace_and_settle(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_textual_response_skips_binary_grace_and_settle(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """For JSON/text responses (NOT HTML), the fetcher must skip both the
         secondary binary download grace AND the post-nav networkidle settle.
         That's the whole point of the content-type-conditional waits — JSON
@@ -835,9 +845,7 @@ class TestDownloadGraceWindow:
         result = await fetcher.fetch("https://example.com/api")
         assert result.body == body
         # JSON must never trigger the networkidle settle wait.
-        assert page._load_state_calls == 0, (
-            "JSON responses must not wait_for_load_state(networkidle)"
-        )
+        assert page._load_state_calls == 0, "JSON responses must not wait_for_load_state(networkidle)"
         # Only the initial download grace should fire (≤ 1 budget worth of slices).
         # Binary grace would add 3× more slices; that's the regression we guard against.
         from broker.browser_fetcher import (
@@ -855,9 +863,7 @@ class TestDownloadGraceWindow:
         )
 
     @pytest.mark.asyncio
-    async def test_nav_error_path_waits_full_download_window(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_nav_error_path_waits_full_download_window(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """When goto raises (download path with no response), the loop should
         be willing to wait the full DOWNLOAD_WAIT_MS for the download event."""
         _patch_playwright_types(monkeypatch)
@@ -900,9 +906,7 @@ class TestPostNavSettleConditional:
     download triggers and pay up to POST_NAV_SETTLE_MS via networkidle wait."""
 
     @pytest.mark.asyncio
-    async def test_json_response_does_not_wait_for_networkidle(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_json_response_does_not_wait_for_networkidle(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_playwright_types(monkeypatch)
 
         body = b'{"ok":true}'
@@ -922,15 +926,12 @@ class TestPostNavSettleConditional:
 
         result = await fetcher.fetch("https://example.com/api")
         assert result.body == body
-        assert page._load_state_calls == 0, (
-            "JSON response must not wait_for_load_state(networkidle) — "
-            "POST_NAV_SETTLE_MS should be conditional"
-        )
+        assert (
+            page._load_state_calls == 0
+        ), "JSON response must not wait_for_load_state(networkidle) — POST_NAV_SETTLE_MS should be conditional"
 
     @pytest.mark.asyncio
-    async def test_html_response_waits_for_networkidle(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_html_response_waits_for_networkidle(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_playwright_types(monkeypatch)
 
         body = b"<html></html>"
@@ -950,9 +951,9 @@ class TestPostNavSettleConditional:
 
         result = await fetcher.fetch("https://example.com/")
         assert result.body == body
-        assert page._load_state_calls == 1, (
-            "HTML responses must wait_for_load_state(networkidle, timeout=POST_NAV_SETTLE_MS)"
-        )
+        assert (
+            page._load_state_calls == 1
+        ), "HTML responses must wait_for_load_state(networkidle, timeout=POST_NAV_SETTLE_MS)"
 
     @pytest.mark.asyncio
     async def test_networkidle_timeout_is_tolerated(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1022,6 +1023,7 @@ class TestSSRFRecheckAfterAwaits:
         # Earlier wait_for_timeout grace windows must remain no-ops so the
         # violation is specifically attributed to post-settle.
         page._on_settle = None
+
         async def wait_for_load_state(state: str, *, timeout: int) -> None:
             page._load_state_calls += 1
             await on_settle()
@@ -1094,9 +1096,7 @@ class TestContextLeakProtection:
             await fetcher.fetch("https://example.com/")
 
         assert len(browser.contexts) == 1
-        assert browser.contexts[0].closed, (
-            "context.close() must run even when new_page() raises"
-        )
+        assert browser.contexts[0].closed, "context.close() must run even when new_page() raises"
 
     @pytest.mark.asyncio
     async def test_context_closed_when_stealth_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1111,9 +1111,7 @@ class TestContextLeakProtection:
         with pytest.raises(RuntimeError):
             await fetcher.fetch("https://example.com/")
 
-        assert browser.contexts[0].closed, (
-            "context.close() must run even when stealth_async raises"
-        )
+        assert browser.contexts[0].closed, "context.close() must run even when stealth_async raises"
 
 
 class TestAcloseGate:
@@ -1134,9 +1132,7 @@ class TestAcloseGate:
         assert exc.value.status_code == 503
 
     @pytest.mark.asyncio
-    async def test_aclose_drains_in_flight_fetches_before_closing(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_aclose_drains_in_flight_fetches_before_closing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_playwright_types(monkeypatch)
 
         gate = asyncio.Event()
@@ -1215,6 +1211,7 @@ class TestDownloadTempFileLeakOnSSRFViolation:
         # Capture the path that gets written so we can assert it's unlinked.
         captured_paths: list[str] = []
         from broker import browser_fetcher as bf_module
+
         orig_save = bf_module._save_download_to_disk
 
         async def save_then_violate(download):
@@ -1227,9 +1224,7 @@ class TestDownloadTempFileLeakOnSSRFViolation:
             await handler(_FakeRoute("https://10.0.0.5/internal-subresource"))
             return path, size
 
-        monkeypatch.setattr(
-            "broker.browser_fetcher._save_download_to_disk", save_then_violate
-        )
+        monkeypatch.setattr("broker.browser_fetcher._save_download_to_disk", save_then_violate)
 
         browser = _FakeBrowser(lambda: page)
         browser_holder.append(browser)
@@ -1242,9 +1237,7 @@ class TestDownloadTempFileLeakOnSSRFViolation:
         assert "SSRF blocked mid-fetch" in exc.value.detail
         assert len(captured_paths) == 1, "save was called exactly once"
         leaked = captured_paths[0]
-        assert not os.path.exists(leaked), (
-            f"download temp file leaked after post-save SSRF violation: {leaked}"
-        )
+        assert not os.path.exists(leaked), f"download temp file leaked after post-save SSRF violation: {leaked}"
 
     @pytest.mark.asyncio
     async def test_late_download_path_unlinks_on_post_save_ssrf_violation(
@@ -1267,28 +1260,34 @@ class TestDownloadTempFileLeakOnSSRFViolation:
         browser_holder: list[_FakeBrowser] = []
         page = _FakePage(
             response=_FakeResponse(
-                url="https://example.com/", status=200,
-                headers={"content-type": "text/html"}, body=b"<html></html>",
+                url="https://example.com/",
+                status=200,
+                headers={"content-type": "text/html"},
+                body=b"<html></html>",
             ),
             url="https://example.com/",
         )
+
         # Suppress download fires in the grace window so we end up on the
         # post-settle late-download path. Return the FakeResponse so we take
         # the page-response → settle branch (download will fire inside
         # wait_for_load_state below).
         async def goto(_url: str, *, timeout: int):
             return page._response
+
         page.goto = goto  # type: ignore[method-assign]
 
         # Fire the download from inside wait_for_load_state (the post-settle path).
         async def wait_for_load_state(state: str, *, timeout: int) -> None:
             page._load_state_calls += 1
             page.emit_download(_FakeDownload(download_url, payload))
+
         page.wait_for_load_state = wait_for_load_state  # type: ignore[method-assign]
         page._on_settle = None
 
         captured_paths: list[str] = []
         from broker import browser_fetcher as bf_module
+
         orig_save = bf_module._save_download_to_disk
 
         async def save_then_violate(download):
@@ -1298,9 +1297,7 @@ class TestDownloadTempFileLeakOnSSRFViolation:
             await handler(_FakeRoute("https://10.0.0.5/late-subresource"))
             return path, size
 
-        monkeypatch.setattr(
-            "broker.browser_fetcher._save_download_to_disk", save_then_violate
-        )
+        monkeypatch.setattr("broker.browser_fetcher._save_download_to_disk", save_then_violate)
 
         browser = _FakeBrowser(lambda: page)
         browser_holder.append(browser)
@@ -1312,9 +1309,7 @@ class TestDownloadTempFileLeakOnSSRFViolation:
         assert exc.value.status_code == 400
         assert len(captured_paths) == 1
         leaked = captured_paths[0]
-        assert not os.path.exists(leaked), (
-            f"late-download temp file leaked after post-save SSRF violation: {leaked}"
-        )
+        assert not os.path.exists(leaked), f"late-download temp file leaked after post-save SSRF violation: {leaked}"
 
 
 def _patch_playwright_async_api(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1351,9 +1346,7 @@ class TestSubResourceSSRFNonFatalDuringSettle:
     `tracker.record(...)`), which the _ViolationTracker-only tests bypass."""
 
     @pytest.mark.asyncio
-    async def test_subresource_ssrf_during_settle_resolves_page(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_subresource_ssrf_during_settle_resolves_page(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _patch_playwright_types(monkeypatch)
         _patch_playwright_async_api(monkeypatch)
 
@@ -1471,8 +1464,8 @@ class TestSubResourceSSRFTolerance:
     @pytest.mark.parametrize(
         "subresource_url",
         [
-            "https://d31qbv1cthcecs.cloudfront.net/atrk.js",       # comScore/Alexa tracker
-            "https://launch.newsinc.com/js/embed.js",               # NewsInc video widget
+            "https://d31qbv1cthcecs.cloudfront.net/atrk.js",  # comScore/Alexa tracker
+            "https://launch.newsinc.com/js/embed.js",  # NewsInc video widget
         ],
     )
     def test_real_world_embedded_trackers_are_not_fatal(self, subresource_url):
@@ -1484,3 +1477,233 @@ class TestSubResourceSSRFTolerance:
             f"{subresource_url} is an embedded third-party resource; blocking it must "
             f"not fail the host news article it was cited from"
         )
+
+
+class TestRenderMode:
+    """The `render` param on fetch() selects how a text/html page is returned:
+      - "text"  (default): rendered VISIBLE TEXT via inner_text('body') — the
+        publish-gate-safe legacy behavior, byte-for-byte unchanged.
+      - "html": the full serialized rendered DOM via page.content().
+      - "links": a JSON body {"links": [{"href","text"}, ...]} extracted from
+        a[href] via eval_on_selector_all — hrefs absolute, anchor text trimmed.
+    Non-HTML content types (downloads, JSON, XML) ignore render entirely.
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_render_is_visible_text(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_playwright_async_api(monkeypatch)
+        _patch_playwright_types(monkeypatch)
+
+        visible = "Heading\nBody text"
+        page = _FakePage(
+            response=_FakeResponse(
+                url="https://town.gov/page",
+                status=200,
+                headers={"content-type": "text/html; charset=utf-8"},
+                body=b"<html><body><h1>Heading</h1><p>Body text</p><a href='/doc'>Doc</a></body></html>",
+            ),
+            url="https://town.gov/page",
+            inner_text_value=visible,
+        )
+        fetcher = PlaywrightBrowserFetcher()
+        fetcher._browser = _FakeBrowser(lambda: page)  # type: ignore[assignment]
+        monkeypatch.setattr("broker.browser_fetcher.validate_url", _allow_all)
+
+        # No render arg -> default "text": unchanged legacy behavior.
+        result = await fetcher.fetch("https://town.gov/page")
+        assert result.content_type == "text/html"
+        assert result.body == visible.encode("utf-8")
+        assert result.byte_size == len(visible.encode("utf-8"))
+
+    @pytest.mark.asyncio
+    async def test_render_html_returns_full_serialized_dom(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_playwright_async_api(monkeypatch)
+        _patch_playwright_types(monkeypatch)
+
+        raw_html = (
+            "<html><body><h1>By-Laws</h1>"
+            '<a href="https://town.gov/DocumentCenter/View/431">General Town By-Laws</a>'
+            "</body></html>"
+        )
+        page = _FakePage(
+            response=_FakeResponse(
+                url="https://town.gov/page/1449",
+                status=200,
+                headers={"content-type": "text/html; charset=utf-8"},
+                body=b"<html><body>raw response body ignored for html render</body></html>",
+            ),
+            url="https://town.gov/page/1449",
+            inner_text_value="visible text only, href stripped",
+            content_value=raw_html,
+        )
+        fetcher = PlaywrightBrowserFetcher()
+        fetcher._browser = _FakeBrowser(lambda: page)  # type: ignore[assignment]
+        monkeypatch.setattr("broker.browser_fetcher.validate_url", _allow_all)
+
+        result = await fetcher.fetch("https://town.gov/page/1449", render="html")
+        assert result.content_type == "text/html"
+        assert result.body == raw_html.encode("utf-8")
+        # the href that text mode hides is present in the markup
+        assert b'<a href="https://town.gov/DocumentCenter/View/431">' in result.body
+        # NOT the inner-text rendering
+        assert result.body != b"visible text only, href stripped"
+
+    @pytest.mark.asyncio
+    async def test_render_links_returns_json_of_absolute_links(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_playwright_async_api(monkeypatch)
+        _patch_playwright_types(monkeypatch)
+
+        # What a real browser's `a.href` (absolute) + textContent.trim() yields.
+        browser_links = [
+            {"href": "https://town.gov/DocumentCenter/View/431", "text": "General Town By-Laws"},
+            {"href": "https://town.gov/agendas", "text": "Agendas"},
+        ]
+        page = _FakePage(
+            response=_FakeResponse(
+                url="https://town.gov/page/1449",
+                status=200,
+                headers={"content-type": "text/html; charset=utf-8"},
+                body=b"<html><body>...</body></html>",
+            ),
+            url="https://town.gov/page/1449",
+            links_value=browser_links,
+        )
+        fetcher = PlaywrightBrowserFetcher()
+        fetcher._browser = _FakeBrowser(lambda: page)  # type: ignore[assignment]
+        monkeypatch.setattr("broker.browser_fetcher.validate_url", _allow_all)
+
+        result = await fetcher.fetch("https://town.gov/page/1449", render="links")
+        assert result.content_type == "application/json"
+        payload = json.loads(result.body.decode("utf-8"))
+        assert payload == {"links": browser_links}
+        # the CivicPlus DocumentCenter href hidden from text mode is recovered
+        hrefs = [link["href"] for link in payload["links"]]
+        assert "https://town.gov/DocumentCenter/View/431" in hrefs
+
+    @pytest.mark.asyncio
+    async def test_render_links_reads_dom_href_property_and_trims(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Guard the extraction MECHANISM: absolute-href + trimmed-text is
+        delivered by reading the DOM `.href` IDL property (which resolves
+        relative hrefs against the document base) and `.trim()` — never
+        getAttribute('href') (raw, possibly-relative)."""
+        _patch_playwright_async_api(monkeypatch)
+        _patch_playwright_types(monkeypatch)
+
+        page = _FakePage(
+            response=_FakeResponse(
+                url="https://town.gov/page",
+                status=200,
+                headers={"content-type": "text/html"},
+                body=b"<html></html>",
+            ),
+            url="https://town.gov/page",
+            links_value=[],
+        )
+        fetcher = PlaywrightBrowserFetcher()
+        fetcher._browser = _FakeBrowser(lambda: page)  # type: ignore[assignment]
+        monkeypatch.setattr("broker.browser_fetcher.validate_url", _allow_all)
+
+        await fetcher.fetch("https://town.gov/page", render="links")
+        assert len(page.eval_calls) == 1, "links render must call eval_on_selector_all exactly once"
+        selector, expression = page.eval_calls[0]
+        assert selector == "a[href]"
+        assert ".href" in expression
+        assert "getAttribute" not in expression
+        assert "trim" in expression
+
+    @pytest.mark.asyncio
+    async def test_render_links_does_not_validate_or_fetch_hrefs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Link extraction must not trigger additional network activity: the
+        extracted hrefs are never passed to validate_url (a DNS lookup) nor
+        re-fetched. Only the landed page URL is validated, exactly as before."""
+        _patch_playwright_async_api(monkeypatch)
+        _patch_playwright_types(monkeypatch)
+
+        link_href = "https://other-domain.example/DocumentCenter/View/999"
+        page = _FakePage(
+            response=_FakeResponse(
+                url="https://town.gov/page",
+                status=200,
+                headers={"content-type": "text/html"},
+                body=b"<html></html>",
+            ),
+            url="https://town.gov/page",
+            links_value=[{"href": link_href, "text": "Doc"}],
+        )
+        fetcher = PlaywrightBrowserFetcher()
+        fetcher._browser = _FakeBrowser(lambda: page)  # type: ignore[assignment]
+
+        validated: list[str] = []
+
+        async def _record_validate(url: str) -> None:
+            validated.append(url)
+
+        monkeypatch.setattr("broker.browser_fetcher.validate_url", _record_validate)
+
+        result = await fetcher.fetch("https://town.gov/page", render="links")
+        assert result.content_type == "application/json"
+        assert (
+            link_href not in validated
+        ), "link hrefs must never reach validate_url — that DNS lookup would defeat the no-extra-network guarantee"
+        assert "https://town.gov/page" in validated, "the landed page URL is still validated"
+
+    @pytest.mark.asyncio
+    async def test_render_html_failure_raises_502(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """page.content() torn down under memory pressure -> clean 502."""
+        _patch_playwright_async_api(monkeypatch)
+        _patch_playwright_types(monkeypatch)
+
+        from playwright.async_api import Error as PlaywrightError
+
+        page = _FakePage(
+            response=_FakeResponse(
+                url="https://town.gov/page",
+                status=200,
+                headers={"content-type": "text/html"},
+                body=b"<html></html>",
+            ),
+            url="https://town.gov/page",
+        )
+
+        async def content_torn_down() -> str:
+            raise PlaywrightError("Page.content: Target page, context or browser has been closed")
+
+        page.content = content_torn_down  # type: ignore[method-assign]
+        fetcher = PlaywrightBrowserFetcher()
+        fetcher._browser = _FakeBrowser(lambda: page)  # type: ignore[assignment]
+        monkeypatch.setattr("broker.browser_fetcher.validate_url", _allow_all)
+
+        with pytest.raises(HTTPException) as exc:
+            await fetcher.fetch("https://town.gov/page", render="html")
+        assert exc.value.status_code == 502
+        assert exc.value.detail == "upstream response body unavailable"
+
+    @pytest.mark.asyncio
+    async def test_download_path_ignores_render(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A PDF (download path) is unaffected by render: the file bytes come
+        back on disk regardless, never re-shaped into JSON."""
+        _patch_playwright_types(monkeypatch)
+
+        payload = b"%PDF-1.7 fake pdf bytes"
+        download_url = "https://town.gov/DocumentCenter/View/431.pdf"
+        page = _FakePage(response=None, url="https://town.gov/")
+
+        async def goto(_url: str, *, timeout: int) -> None:
+            page.emit_download(_FakeDownload(download_url, payload))
+            return None
+
+        page.goto = goto  # type: ignore[method-assign]
+        fetcher = PlaywrightBrowserFetcher()
+        fetcher._browser = _FakeBrowser(lambda: page)  # type: ignore[assignment]
+        monkeypatch.setattr("broker.browser_fetcher.validate_url", _allow_all)
+
+        result = await fetcher.fetch(download_url, render="links")
+        try:
+            assert result.body_path is not None
+            assert result.body is None
+            with open(result.body_path, "rb") as f:
+                assert f.read() == payload
+            assert result.content_type != "application/json"
+        finally:
+            if result.body_path and os.path.exists(result.body_path):
+                os.unlink(result.body_path)

--- a/broker/tests/test_http_fetch.py
+++ b/broker/tests/test_http_fetch.py
@@ -84,9 +84,11 @@ class _FakeFetcher:
     result: BrowserFetchResult | None = None
     raise_exc: Exception | None = None
     calls: list[str] = field(default_factory=list)
+    render_calls: list[str] = field(default_factory=list)
 
-    async def fetch(self, url: str) -> BrowserFetchResult:
+    async def fetch(self, url: str, *, render: str = "text") -> BrowserFetchResult:
         self.calls.append(url)
+        self.render_calls.append(render)
         if self.raise_exc is not None:
             raise self.raise_exc
         assert self.result is not None, "test must configure result or raise_exc"
@@ -241,9 +243,9 @@ class TestResponseShape:
             assert resp.headers["x-source-url"] == "https://legistar.granicus.com/x.pdf"
             assert resp.headers["x-byte-size"] == str(len(pdf_bytes))
             # BackgroundTask should have unlinked the temp file after response.
-            assert not os.path.exists(tmp_path), (
-                "download temp file must be unlinked via BackgroundTask after the response is sent"
-            )
+            assert not os.path.exists(
+                tmp_path
+            ), "download temp file must be unlinked via BackgroundTask after the response is sent"
         finally:
             if os.path.exists(tmp_path):
                 os.unlink(tmp_path)
@@ -346,10 +348,7 @@ class TestFailureLogging:
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
         assert resp.status_code == 400
-        warnings = [
-            r for r in caplog.records
-            if r.levelno == logging.WARNING and "http_fetch failed" in r.getMessage()
-        ]
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "http_fetch failed" in r.getMessage()]
         assert len(warnings) == 1, f"expected one warning, got {[r.getMessage() for r in caplog.records]}"
         msg = warnings[0].getMessage()
         assert "run_id=run-http-001" in msg
@@ -368,10 +367,7 @@ class TestFailureLogging:
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
         assert resp.status_code == 502
-        warnings = [
-            r for r in caplog.records
-            if r.levelno == logging.WARNING and "http_fetch failed" in r.getMessage()
-        ]
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "http_fetch failed" in r.getMessage()]
         assert len(warnings) == 1
         msg = warnings[0].getMessage()
         assert "status=502" in msg
@@ -388,10 +384,7 @@ class TestFailureLogging:
             headers={"X-Broker-Token": BROKER_TOKEN},
         )
         assert resp.status_code == 413
-        warnings = [
-            r for r in caplog.records
-            if r.levelno == logging.WARNING and "http_fetch failed" in r.getMessage()
-        ]
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "http_fetch failed" in r.getMessage()]
         assert len(warnings) == 1
         assert "status=413" in warnings[0].getMessage()
 
@@ -415,6 +408,98 @@ class TestFetcherCallShape:
         assert fetcher.calls == ["https://example.com/"]
 
 
+class TestRenderParam:
+    """The optional `render` body param is threaded to the fetcher. Default is
+    "text" (publish-gate-safe legacy behavior — the publish gate rejects raw
+    HTML). "html"/"links" are explicit opt-ins. Invalid values are rejected by
+    the route's Pydantic validation (422) before the fetcher is called."""
+
+    def test_default_render_is_text_and_body_unchanged(self):
+        body = b"visible rendered text"
+        fetcher = _FakeFetcher(
+            result=_page_result(body, content_type="text/html", final_url="https://example.com/p"),
+        )
+        client = TestClient(_create_app(fetcher))
+        resp = client.post(
+            "/http/fetch",
+            json={"url": "https://example.com/p"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+        assert resp.status_code == 200
+        assert resp.content == body
+        # Starlette appends "; charset=utf-8" to text/* media types.
+        assert resp.headers["content-type"].startswith("text/html")
+        assert fetcher.render_calls == ["text"]
+
+    def test_render_html_threaded_to_fetcher(self):
+        markup = b'<html><body><a href="https://town.gov/DocumentCenter/View/431">Doc</a></body></html>'
+        fetcher = _FakeFetcher(
+            result=_page_result(markup, content_type="text/html", final_url="https://example.com/p"),
+        )
+        client = TestClient(_create_app(fetcher))
+        resp = client.post(
+            "/http/fetch",
+            json={"url": "https://example.com/p", "render": "html"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+        assert resp.status_code == 200
+        assert fetcher.render_calls == ["html"]
+        assert resp.content == markup
+        assert resp.headers["content-type"].startswith("text/html")
+
+    def test_render_links_threaded_and_json_returned(self):
+        links_json = b'{"links": [{"href": "https://town.gov/DocumentCenter/View/431", "text": "By-Laws"}]}'
+        fetcher = _FakeFetcher(
+            result=_page_result(links_json, content_type="application/json", final_url="https://example.com/p"),
+        )
+        client = TestClient(_create_app(fetcher))
+        resp = client.post(
+            "/http/fetch",
+            json={"url": "https://example.com/p", "render": "links"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+        assert resp.status_code == 200
+        assert fetcher.render_calls == ["links"]
+        assert resp.content == links_json
+        assert resp.headers["content-type"] == "application/json"
+
+    def test_invalid_render_value_returns_422_and_skips_fetch(self):
+        fetcher = _FakeFetcher(
+            result=_page_result(b"unused", content_type="text/html"),
+        )
+        client = TestClient(_create_app(fetcher))
+        resp = client.post(
+            "/http/fetch",
+            json={"url": "https://example.com/p", "render": "raw"},
+            headers={"X-Broker-Token": BROKER_TOKEN},
+        )
+        assert resp.status_code == 422
+        assert fetcher.calls == [], "fetcher must not be invoked when render is invalid"
+
+    def test_render_links_on_pdf_download_is_unaffected(self):
+        """Render param is threaded, but a PDF (download path) is returned
+        unchanged — the fetcher ignores render for non-HTML content."""
+        pdf_bytes = b"%PDF-1.7 fake"
+        result, tmp_path = _download_result(
+            pdf_bytes, content_type="application/pdf", final_url="https://example.com/doc.pdf"
+        )
+        try:
+            fetcher = _FakeFetcher(result=result)
+            client = TestClient(_create_app(fetcher))
+            resp = client.post(
+                "/http/fetch",
+                json={"url": "https://example.com/doc.pdf", "render": "links"},
+                headers={"X-Broker-Token": BROKER_TOKEN},
+            )
+            assert resp.status_code == 200
+            assert resp.content == pdf_bytes
+            assert resp.headers["content-type"] == "application/pdf"
+            assert fetcher.render_calls == ["links"]
+        finally:
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+
 class TestDownloadStreaming:
     """Download path streams from disk and cleans up the temp file."""
 
@@ -431,9 +516,9 @@ class TestDownloadStreaming:
             )
             assert resp.status_code == 200
             assert resp.content == payload
-            assert not os.path.exists(tmp_path), (
-                "BackgroundTask must unlink the temp file after the response is fully sent"
-            )
+            assert not os.path.exists(
+                tmp_path
+            ), "BackgroundTask must unlink the temp file after the response is fully sent"
         finally:
             if os.path.exists(tmp_path):
                 os.unlink(tmp_path)
@@ -463,6 +548,7 @@ def _head_app(handler, monkeypatch, *, allow=lambda u: True):
     async def _validate(url: str) -> None:
         if not allow(url):
             raise HTTPException(status_code=400, detail="SSRF blocked")
+
     monkeypatch.setattr("broker.endpoints.http_fetch.validate_url", _validate)
     monkeypatch.setattr("broker.ssrf_guard.validate_url", _validate)
     app = FastAPI()
@@ -478,6 +564,7 @@ class TestHttpHead:
         def handler(req: httpx.Request) -> httpx.Response:
             assert req.method == "HEAD"  # no browser, no GET body
             return httpx.Response(200)
+
         app = _head_app(handler, monkeypatch)
         r = TestClient(app).post("/http/head", json={"url": "https://example.gov/page"})
         assert r.status_code == 200
@@ -490,6 +577,7 @@ class TestHttpHead:
         def handler(req: httpx.Request) -> httpx.Response:
             seen[req.method] = req.headers
             return httpx.Response(405) if req.method == "HEAD" else httpx.Response(200)
+
         app = _head_app(handler, monkeypatch)
         r = TestClient(app).post("/http/head", json={"url": "https://example.gov/p"})
         assert r.json()["status"] == 200
@@ -501,6 +589,7 @@ class TestHttpHead:
             if req.url.path == "/old":
                 return httpx.Response(301, headers={"location": "https://example.gov/new"})
             return httpx.Response(200)
+
         app = _head_app(handler, monkeypatch)
         r = TestClient(app).post("/http/head", json={"url": "https://example.gov/old"})
         assert r.json()["status"] == 200
@@ -511,6 +600,7 @@ class TestHttpHead:
             if "10.0.0.5" in str(req.url):
                 return httpx.Response(200)
             return httpx.Response(302, headers={"location": "http://10.0.0.5/internal"})
+
         # allow the public origin, block the private redirect target. If per-hop
         # validation were dropped, the 10.0.0.5 hop would return a clean 200
         # instead of a 400 — so a passing 400 here proves the guard fired on the
@@ -523,6 +613,7 @@ class TestHttpHead:
     def test_blocks_ssrf_on_initial_url(self, monkeypatch):
         def handler(req: httpx.Request) -> httpx.Response:
             return httpx.Response(200)
+
         app = _head_app(handler, monkeypatch, allow=lambda u: False)
         r = TestClient(app).post("/http/head", json={"url": "http://169.254.169.254/"})
         assert r.status_code == 400
@@ -531,6 +622,7 @@ class TestHttpHead:
     def test_transport_connect_error_maps_to_502(self, monkeypatch):
         def handler(req: httpx.Request) -> httpx.Response:
             raise httpx.ConnectError("boom")
+
         app = _head_app(handler, monkeypatch)
         r = TestClient(app).post("/http/head", json={"url": "https://example.gov/down"})
         assert r.status_code == 502
@@ -540,6 +632,7 @@ class TestHttpHead:
     def test_transport_timeout_maps_to_504(self, monkeypatch):
         def handler(req: httpx.Request) -> httpx.Response:
             raise httpx.ConnectTimeout("slow")
+
         app = _head_app(handler, monkeypatch)
         r = TestClient(app).post("/http/head", json={"url": "https://example.gov/slow"})
         assert r.status_code == 504

--- a/broker/tests/test_mint_to_fetch_e2e.py
+++ b/broker/tests/test_mint_to_fetch_e2e.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
+
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
@@ -82,9 +83,11 @@ class _FakeFetcher:
 
     result: BrowserFetchResult
     calls: list[str] = field(default_factory=list)
+    render_calls: list[str] = field(default_factory=list)
 
-    async def fetch(self, url: str) -> BrowserFetchResult:
+    async def fetch(self, url: str, *, render: str = "text") -> BrowserFetchResult:
         self.calls.append(url)
+        self.render_calls.append(render)
         return self.result
 
 

--- a/pmf_engine/runner/pmf_runtime/http.py
+++ b/pmf_engine/runner/pmf_runtime/http.py
@@ -89,11 +89,22 @@ def _raise_from_error(resp, operation: str) -> None:
     raise ValueError(f"{operation} failed: {detail}")
 
 
-def get(url: str, purpose: str = "") -> dict:
+def get(url: str, purpose: str = "", render: str | None = None) -> dict:
+    """Fetch a URL through the broker and return its body as text.
+
+    render: optional broker render mode for text/html pages — "text" (default,
+    rendered visible text), "html" (full DOM markup), or "links" (JSON list of
+    {href, text} from the page's anchors, hrefs absolute). None omits the param
+    so the broker default ("text") applies. Ignored by the broker for non-HTML
+    content. "links" returns an application/json body you can json.loads.
+    """
     from .config import get_config
 
     client = get_config().client
-    with client.stream("POST", "/http/fetch", json={"url": url, "purpose": purpose}) as resp:
+    payload: dict = {"url": url, "purpose": purpose}
+    if render is not None:
+        payload["render"] = render
+    with client.stream("POST", "/http/fetch", json=payload) as resp:
         if resp.status_code >= 400:
             _raise_from_error(resp, "http.get")
 
@@ -106,10 +117,7 @@ def get(url: str, purpose: str = "") -> dict:
             upstream_status = resp.status_code
 
         if not _is_textual(content_type):
-            raise ValueError(
-                f"http.get cannot decode binary content-type {content_type!r}; "
-                "use http.download instead"
-            )
+            raise ValueError(f"http.get cannot decode binary content-type {content_type!r}; use http.download instead")
 
         chunks: list[bytes] = []
         byte_size = 0
@@ -151,11 +159,21 @@ def head(url: str, purpose: str = "") -> dict:
     return {"status": int(data["status"]), "final_url": data.get("final_url", url)}
 
 
-def download(url: str, dest: str | None = None, purpose: str = "") -> dict:
+def download(url: str, dest: str | None = None, purpose: str = "", render: str | None = None) -> dict:
+    """Download a URL through the broker to disk and return metadata.
+
+    render: optional broker render mode, passed through in the POST body; None
+    omits it (broker default). Downloads are binary, so the broker ignores
+    render for the download path — this kwarg exists for call-site symmetry
+    with get().
+    """
     from .config import get_config
 
     client = get_config().client
-    with client.stream("POST", "/http/fetch", json={"url": url, "purpose": purpose}) as resp:
+    payload: dict = {"url": url, "purpose": purpose}
+    if render is not None:
+        payload["render"] = render
+    with client.stream("POST", "/http/fetch", json=payload) as resp:
         if resp.status_code >= 400:
             _raise_from_error(resp, "http.download")
 

--- a/pmf_engine/runner/pmf_runtime/tests/test_http.py
+++ b/pmf_engine/runner/pmf_runtime/tests/test_http.py
@@ -18,6 +18,7 @@ def _inject_client(handler):
 
 def _reset_config():
     import pmf_engine.runner.pmf_runtime.config as config_mod
+
     config_mod._config = None
 
 
@@ -580,6 +581,136 @@ class TestDownload:
         _inject_client(handler)
         result = download("https://city.gov/x.pdf", dest=str(tmp_path / "x.pdf"))
         assert result["byte_size"] == 9999
+
+
+class TestGetRender:
+    def setup_method(self):
+        _reset_config()
+
+    def test_omits_render_from_payload_by_default(self):
+        captured = {}
+
+        def handler(request):
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(
+                200,
+                content=b"ok",
+                headers={
+                    "content-type": "text/html",
+                    "x-upstream-status": "200",
+                    "x-source-url": "https://town.gov/p",
+                    "x-byte-size": "2",
+                },
+            )
+
+        _inject_client(handler)
+        get("https://town.gov/p")
+        assert "render" not in captured["body"], "render must be omitted so the broker default (text) applies"
+
+    def test_passes_render_when_provided(self):
+        captured = {}
+
+        def handler(request):
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(
+                200,
+                content=b'{"links": []}',
+                headers={
+                    "content-type": "application/json",
+                    "x-upstream-status": "200",
+                    "x-source-url": "https://town.gov/p",
+                    "x-byte-size": "13",
+                },
+            )
+
+        _inject_client(handler)
+        get("https://town.gov/p", render="links")
+        assert captured["body"]["render"] == "links"
+
+    def test_returns_links_json_body_for_links_render(self):
+        links_json = b'{"links": [{"href": "https://town.gov/DocumentCenter/View/431", "text": "By-Laws"}]}'
+
+        def handler(request):
+            return httpx.Response(
+                200,
+                content=links_json,
+                headers={
+                    "content-type": "application/json",
+                    "x-upstream-status": "200",
+                    "x-source-url": "https://town.gov/p/1449",
+                    "x-byte-size": str(len(links_json)),
+                },
+            )
+
+        _inject_client(handler)
+        result = get("https://town.gov/p/1449", render="links")
+        assert result["content_type"] == "application/json"
+        parsed = json.loads(result["body"])
+        assert parsed["links"][0]["href"] == "https://town.gov/DocumentCenter/View/431"
+
+    def test_returns_full_markup_for_html_render(self):
+        markup = b'<html><body><a href="https://town.gov/DocumentCenter/View/431">Doc</a></body></html>'
+
+        def handler(request):
+            return httpx.Response(
+                200,
+                content=markup,
+                headers={
+                    "content-type": "text/html; charset=utf-8",
+                    "x-upstream-status": "200",
+                    "x-source-url": "https://town.gov/p",
+                    "x-byte-size": str(len(markup)),
+                },
+            )
+
+        _inject_client(handler)
+        result = get("https://town.gov/p", render="html")
+        assert '<a href="https://town.gov/DocumentCenter/View/431">' in result["body"]
+
+
+class TestDownloadRender:
+    def setup_method(self):
+        _reset_config()
+
+    def test_omits_render_from_payload_by_default(self, tmp_path):
+        captured = {}
+
+        def handler(request):
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(
+                200,
+                content=b"%PDF",
+                headers={
+                    "content-type": "application/pdf",
+                    "x-upstream-status": "200",
+                    "x-source-url": "https://town.gov/x.pdf",
+                    "x-byte-size": "4",
+                },
+            )
+
+        _inject_client(handler)
+        download("https://town.gov/x.pdf", dest=str(tmp_path / "x.pdf"))
+        assert "render" not in captured["body"]
+
+    def test_passes_render_when_provided(self, tmp_path):
+        captured = {}
+
+        def handler(request):
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(
+                200,
+                content=b"%PDF",
+                headers={
+                    "content-type": "application/pdf",
+                    "x-upstream-status": "200",
+                    "x-source-url": "https://town.gov/x.pdf",
+                    "x-byte-size": "4",
+                },
+            )
+
+        _inject_client(handler)
+        download("https://town.gov/x.pdf", dest=str(tmp_path / "x.pdf"), render="html")
+        assert captured["body"]["render"] == "html"
 
 
 class TestHead:


### PR DESCRIPTION
## What

Adds an opt-in `render` param to the broker's unified `POST /http/fetch` route, with three modes for `text/html` responses:

- `text` (default): unchanged behavior. Rendered visible text via `page.inner_text("body")`.
- `html`: the full serialized rendered DOM via `page.content()` (content-type `text/html`).
- `links`: a JSON body `{"links": [{"href": "<absolute url>", "text": "<trimmed anchor text>"}, ...]}` extracted from `a[href]` via `page.eval_on_selector_all(...)` (content-type `application/json`).

The pmf_engine consumer (`pmf_runtime/http.py`) gains an optional `render` kwarg on `get()` and `download()`, passed through in the POST body and omitted by default so the broker default applies.

## Why

Today the browser fetcher deliberately strips `text/html` down to visible text: the artifact publish gate rejects raw HTML, and every consumer reads the body as text. That default is correct and stays the default.

But it makes anchor hrefs unrecoverable. Agents researching municipal code on CivicPlus town sites see a page that NAMES a document while the text-only render hides the link. Verified real case: `northbrookfield.net` page 1449 names "General Town By-Laws" whose PDF at `DocumentCenter/View/431` is invisible in text mode, so the agent cannot fetch it. `render:"links"` recovers `/DocumentCenter/View/...` URLs in one call.

This also unlocks a future server-side code-text fetcher that can recover DocumentCenter URLs in a single call.

## Constraints honored

- Default stays `text` so the publish gate is never handed raw HTML by surprise. `html`/`links` are explicit opt-ins for consumers that can handle markup.
- SSRF policy in the fetch path is fully intact for all modes. `links` extraction reads the DOM only: hrefs are NOT SSRF-validated per-link (that would trigger a DNS lookup) and no additional network fetch is made. The landed page URL is still validated exactly as before.
- Non-HTML content types (PDFs etc.) ignore `render` and behave exactly as today (download path unchanged).
- Invalid `render` values are rejected with 422 by the route's Pydantic model before the fetcher runs. The `render` field is scoped to a `/fetch`-only request model, so `/http/head` is unaffected.

## Tests (red/green TDD)

- Broker fetcher (`test_browser_fetcher.py`): default returns inner-text (regression lock), `html` returns full DOM containing `<a href=...>`, `links` returns absolute hrefs + trimmed text as JSON, a mechanism guard that link extraction reads the DOM `.href` property (not `getAttribute`), a guard that link hrefs are never passed to `validate_url`, `page.content()` failure maps to 502, and PDF download ignores `render`.
- Broker endpoint (`test_http_fetch.py`): each render value is threaded to the fetcher and its body/content-type returned faithfully, invalid value returns 422 without invoking the fetcher, and a PDF download with `render` set is unaffected.
- pmf_engine consumer (`test_http.py`): `render` omitted from the payload by default, passed through when provided, and `get()` handles the `links` JSON and `html` markup bodies.

## Notes

- Editing `broker/endpoints/http_fetch.py` and `broker/browser_fetcher.py` caused the repo's pinned `ruff-format` (v0.6.9) to normalize a handful of pre-existing lines in those files that were not previously format-clean. This is expected pre-commit behavior for any staged edit to those files.
- One pre-existing, unrelated test failure exists on `develop` and is left untouched (out of scope): `broker/tests/test_mint_run_token.py::TestMintRunTokenInputFiles::test_input_files_roundtrips_to_ticket` fails on a local input-file bucket-name assertion (`gp-agent-run-inputs-local-collin` vs expected `-dev`), which has nothing to do with this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the SSRF-adjacent browser fetch path and adds modes that return raw HTML or unvalidated link URLs, though defaults and main-URL validation stay the same.
> 
> **Overview**
> Adds an optional **`render`** parameter end-to-end for browser-backed **`POST /http/fetch`**, while keeping **`text`** as the default so publish-gate-safe visible text behavior is unchanged.
> 
> For **`text/html`** pages, callers can opt into **`html`** (full DOM via `page.content()`) or **`links`** (JSON `{"links": [{href, text}]}` from rendered anchors with absolute `a.href`). The route validates **`render`** with Pydantic (`422` before fetch); **`/http/head`** is unchanged. **`pmf_runtime`** **`get()`** and **`download()`** accept an optional **`render`** and include it in the POST body only when set.
> 
> **`links`** reads the DOM only—extracted hrefs are not SSRF-validated or fetched; only the landed page URL is still checked. Downloads and non-HTML responses ignore **`render`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d6c8c164135cf5d8a26c462b9ea4184bbbb53b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->