### PR TITLE
chore(infra): pin prod failure-alerting emails, fix stale tfvars examples

### DIFF
--- a/infrastructure/environments/dev/engineer-agent-fargate/terraform.tfvars.example
+++ b/infrastructure/environments/dev/engineer-agent-fargate/terraform.tfvars.example
@@ -1,0 +1,18 @@
+# Dev Environment Configuration
+# Copy this file to terraform.tfvars and update with actual values
+
+# VPC Configuration (us-west-2)
+# Use the prod/master VPC shared across all environments
+vpc_id = "vpc-XXXXXXXXXXXXXXXXX"
+
+# Private subnets for ECS Fargate tasks (minimum 2 for multi-AZ)
+# These subnets should have NAT gateway access for outbound internet
+private_subnet_ids = [
+  "subnet-XXXXXXXXXXXXXXXXX",  # us-west-2a private
+  "subnet-XXXXXXXXXXXXXXXXX"   # us-west-2b private
+]
+
+# Email for ECS task failure notifications (optional)
+# Leave empty "" to disable email notifications
+# Slack notifications will still work via shared Slack notifier Lambda
+failure_notification_email = "your-email@example.com"

--- a/infrastructure/environments/prod/ddhq-matcher-fargate/main.tf
+++ b/infrastructure/environments/prod/ddhq-matcher-fargate/main.tf
@@ -37,10 +37,11 @@ variable "private_subnet_ids" {
   type        = list(string)
 }
 
+# pinned in git because the gitignored tfvars pattern silently dropped alerting on clean-checkout applies
 variable "failure_notification_email" {
   description = "Email for failure notifications (optional)"
   type        = string
-  default     = ""
+  default     = "collin@goodparty.org"
 }
 
 data "terraform_remote_state" "shared_ecr" {
@@ -66,13 +67,13 @@ data "terraform_remote_state" "shared_slack_notifier" {
 module "ddhq_matcher_fargate" {
   source = "../../../modules/ddhq-matcher-fargate"
 
-  environment                        = "prod"
-  vpc_id                             = var.vpc_id
-  private_subnet_ids                 = var.private_subnet_ids
-  ecr_repository_url                 = data.terraform_remote_state.shared_ecr.outputs.repository_url
-  docker_image_tag                   = "ddhq-matcher-prod"
-  shared_slack_notifier_lambda_arn   = data.terraform_remote_state.shared_slack_notifier.outputs.lambda_function_arn
-  failure_notification_email         = var.failure_notification_email
+  environment                      = "prod"
+  vpc_id                           = var.vpc_id
+  private_subnet_ids               = var.private_subnet_ids
+  ecr_repository_url               = data.terraform_remote_state.shared_ecr.outputs.repository_url
+  docker_image_tag                 = "ddhq-matcher-prod"
+  shared_slack_notifier_lambda_arn = data.terraform_remote_state.shared_slack_notifier.outputs.lambda_function_arn
+  failure_notification_email       = var.failure_notification_email
 }
 
 output "cluster_name" {

--- a/infrastructure/environments/prod/engineer-agent-fargate/main.tf
+++ b/infrastructure/environments/prod/engineer-agent-fargate/main.tf
@@ -37,10 +37,11 @@ variable "private_subnet_ids" {
   type        = list(string)
 }
 
+# pinned in git because the gitignored tfvars pattern silently dropped alerting on clean-checkout applies
 variable "failure_notification_email" {
   description = "Email for failure notifications (optional)"
   type        = string
-  default     = ""
+  default     = "collin@goodparty.org"
 }
 
 data "terraform_remote_state" "shared_ecr" {

--- a/infrastructure/environments/prod/engineer-agent-fargate/terraform.tfvars.example
+++ b/infrastructure/environments/prod/engineer-agent-fargate/terraform.tfvars.example
@@ -1,0 +1,17 @@
+# Prod Environment Configuration
+# Copy this file to terraform.tfvars and update with actual values
+
+# VPC Configuration (us-west-2)
+# Use the prod/master VPC shared across all environments
+vpc_id = "vpc-XXXXXXXXXXXXXXXXX"
+
+# Private subnets for ECS Fargate tasks (minimum 2 for multi-AZ)
+# These subnets should have NAT gateway access for outbound internet
+private_subnet_ids = [
+  "subnet-XXXXXXXXXXXXXXXXX",  # us-west-2a private
+  "subnet-XXXXXXXXXXXXXXXXX"   # us-west-2b private
+]
+
+# Email for ECS task failure notifications (optional)
+# Defaults to collin@goodparty.org (pinned in main.tf); override here if needed
+failure_notification_email = "collin@goodparty.org"

--- a/infrastructure/environments/prod/serve-analyze-fargate/main.tf
+++ b/infrastructure/environments/prod/serve-analyze-fargate/main.tf
@@ -38,10 +38,11 @@ variable "private_subnet_ids" {
   type        = list(string)
 }
 
+# pinned in git because the gitignored tfvars pattern silently dropped alerting on clean-checkout applies
 variable "failure_notification_email" {
   description = "Email for failure notifications (optional)"
   type        = string
-  default     = ""
+  default     = "collin@goodparty.org"
 }
 
 data "terraform_remote_state" "shared_ecr" {
@@ -67,15 +68,15 @@ data "terraform_remote_state" "shared_slack_notifier" {
 module "serve_analyze_fargate" {
   source = "../../../modules/serve-analyze-fargate"
 
-  environment                        = "prod"
-  vpc_id                             = var.vpc_id
-  private_subnet_ids                 = var.private_subnet_ids
-  ecr_repository_url                 = data.terraform_remote_state.shared_ecr.outputs.repository_url
-  docker_image_tag                   = "serve-analyze-prod"
-  sqs_queue_arn                      = "arn:aws:sqs:us-west-2:333022194791:master-Queue.fifo"
-  sqs_queue_url                      = "https://sqs.us-west-2.amazonaws.com/333022194791/master-Queue.fifo"
-  shared_slack_notifier_lambda_arn   = data.terraform_remote_state.shared_slack_notifier.outputs.lambda_function_arn
-  failure_notification_email         = var.failure_notification_email
+  environment                      = "prod"
+  vpc_id                           = var.vpc_id
+  private_subnet_ids               = var.private_subnet_ids
+  ecr_repository_url               = data.terraform_remote_state.shared_ecr.outputs.repository_url
+  docker_image_tag                 = "serve-analyze-prod"
+  sqs_queue_arn                    = "arn:aws:sqs:us-west-2:333022194791:master-Queue.fifo"
+  sqs_queue_url                    = "https://sqs.us-west-2.amazonaws.com/333022194791/master-Queue.fifo"
+  shared_slack_notifier_lambda_arn = data.terraform_remote_state.shared_slack_notifier.outputs.lambda_function_arn
+  failure_notification_email       = var.failure_notification_email
 }
 
 output "cluster_name" {

--- a/infrastructure/environments/qa/engineer-agent-fargate/terraform.tfvars.example
+++ b/infrastructure/environments/qa/engineer-agent-fargate/terraform.tfvars.example
@@ -1,0 +1,18 @@
+# QA Environment Configuration
+# Copy this file to terraform.tfvars and update with actual values
+
+# VPC Configuration (us-west-2)
+# Use the prod/master VPC shared across all environments
+vpc_id = "vpc-XXXXXXXXXXXXXXXXX"
+
+# Private subnets for ECS Fargate tasks (minimum 2 for multi-AZ)
+# These subnets should have NAT gateway access for outbound internet
+private_subnet_ids = [
+  "subnet-XXXXXXXXXXXXXXXXX",  # us-west-2a private
+  "subnet-XXXXXXXXXXXXXXXXX"   # us-west-2b private
+]
+
+# Email for ECS task failure notifications (optional)
+# Leave empty "" to disable email notifications
+# Slack notifications will still work via shared Slack notifier Lambda
+failure_notification_email = "your-email@example.com"

--- a/infrastructure/shared/slack-notifier/main.tf
+++ b/infrastructure/shared/slack-notifier/main.tf
@@ -7,12 +7,6 @@ variable "environment" {
   }
 }
 
-variable "allowed_sns_topic_arns" {
-  description = "List of SNS topic ARNs allowed to invoke this Lambda"
-  type        = list(string)
-  default     = []
-}
-
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
@@ -34,8 +28,8 @@ resource "aws_iam_role" "slack_notifier" {
   })
 
   tags = {
-    Name        = "Shared Slack Notifier"
-    ManagedBy   = "Terraform"
+    Name      = "Shared Slack Notifier"
+    ManagedBy = "Terraform"
   }
 }
 
@@ -64,24 +58,24 @@ resource "aws_iam_role_policy" "slack_notifier_secrets_access" {
 
 # Lambda Function
 resource "aws_lambda_function" "slack_notifier" {
-  filename      = "${path.module}/slack-notifier.zip"
-  function_name = "shared-slack-notifier"
-  role          = aws_iam_role.slack_notifier.arn
-  handler       = "index.handler"
-  runtime       = "nodejs22.x"
-  timeout       = 30
+  filename         = "${path.module}/slack-notifier.zip"
+  function_name    = "shared-slack-notifier"
+  role             = aws_iam_role.slack_notifier.arn
+  handler          = "index.handler"
+  runtime          = "nodejs22.x"
+  timeout          = 30
   source_code_hash = filebase64sha256("${path.module}/slack-notifier.zip")
 
   environment {
     variables = {
-      SECRET_NAME    = "AI_SECRETS_${upper(var.environment)}"
-      SECRET_REGION  = data.aws_region.current.name
+      SECRET_NAME   = "AI_SECRETS_${upper(var.environment)}"
+      SECRET_REGION = data.aws_region.current.name
     }
   }
 
   tags = {
-    Name        = "Shared Slack Notifier"
-    ManagedBy   = "Terraform"
+    Name      = "Shared Slack Notifier"
+    ManagedBy = "Terraform"
   }
 }
 
@@ -91,8 +85,8 @@ resource "aws_cloudwatch_log_group" "slack_notifier" {
   retention_in_days = 7
 
   tags = {
-    Name        = "Shared Slack Notifier Logs"
-    ManagedBy   = "Terraform"
+    Name      = "Shared Slack Notifier Logs"
+    ManagedBy = "Terraform"
   }
 }
 
@@ -103,7 +97,7 @@ resource "aws_lambda_permission" "allow_sns" {
   function_name = aws_lambda_function.slack_notifier.function_name
   principal     = "sns.amazonaws.com"
   # Allow any SNS topic in this account to invoke
-  source_arn    = "arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+  source_arn = "arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
 }
 
 # Outputs

--- a/infrastructure/shared/slack-notifier/terraform.tfvars.example
+++ b/infrastructure/shared/slack-notifier/terraform.tfvars.example
@@ -1,1 +1,6 @@
-slack_webhook_url = "YOUR_SLACK_WEBHOOK_URL_HERE"
+# Shared Slack Notifier Configuration
+# Copy this file to terraform.tfvars and update with actual values
+
+# Environment this deployment targets (dev/qa/prod)
+# Selects the AI_SECRETS_<ENV> secret the Lambda reads the Slack webhook from
+environment = "prod"


### PR DESCRIPTION
## Why

All `*.tfvars` under `infrastructure/**/environments/` are gitignored, so **terraform variable defaults are what a clean-checkout apply actually uses**. This is the same failure class that silently disabled the clickup-bot Lambda on June 26 (fix in a separate PR).

Audit of all 31 env dirs found one more silent-disable instance: `failure_notification_email` defaults to `""` and count-gates the SNS email subscription inside the fargate modules. A clean-checkout apply silently drops failure alerting. Prod `engineer-agent-failures` is **already missing its email subscription today** — either never set or previously dropped by exactly this mechanism.

## What

- Pin `failure_notification_email = "collin@goodparty.org"` in the three **prod** env dirs (engineer-agent, serve-analyze, ddhq-matcher). dev/qa keep the empty default intentionally.
- Add missing `terraform.tfvars.example` for engineer-agent-fargate (dev/qa/prod), mirroring the ddhq/serve style.
- slack-notifier: the example documented a variable that does not exist (`slack_webhook_url`) and omitted the required `environment`; rewritten. Removed the dead `allowed_sns_topic_arns` variable (zero references; the wildcard SNS permission is untouched).
- `terraform fmt` realigned pre-existing whitespace in the touched files (most of the diff line count; review with whitespace hidden).

## Validation

`terraform init -backend=false && terraform validate`: PASS on prod/dev/qa engineer-agent-fargate and prod/ddhq-matcher-fargate. serve-analyze-fargate and slack-notifier FAIL on a **pre-existing** issue unrelated to this change: `source_code_hash` reads gitignored pre-built lambda zips that never exist on a clean checkout (ddhq avoids this via `archive_file`). Worth a follow-up.

## Note for the reviewer

After this merges and prod applies, the new email subscription on `engineer-agent-failures-prod` sends a confirmation email to collin@goodparty.org that must be clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135ZUkgaGNfLhUJoBztCJ1M

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b5f87a16d3ec950086b570711c499f37341b1859. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->